### PR TITLE
Persist thread sources and improve stream diagnostics

### DIFF
--- a/apps/agents/src/astra/server.py
+++ b/apps/agents/src/astra/server.py
@@ -1,14 +1,14 @@
 import logging
 import secrets
-from collections.abc import Awaitable, Callable
-from typing import cast
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any, cast
 from uuid import uuid4
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
-from starlette.responses import Response
+from starlette.responses import Response, StreamingResponse
 
 from astra.agents import build_astra_agent
 from astra.cli import configure_observability
@@ -92,6 +92,39 @@ async def log_unhandled_errors(
         )
 
 
+def wrap_streaming_response_errors(
+    response: Response,
+    *,
+    context: dict[str, Any],
+) -> Response:
+    body_iterator = getattr(response, "body_iterator", None)
+
+    if body_iterator is None:
+        return response
+
+    async def guarded_stream() -> AsyncIterator[bytes | str]:
+        try:
+            async for chunk in body_iterator:
+                yield chunk
+        except Exception:
+            logger.exception("Astra streaming response error", extra=context)
+            raise
+
+    wrapped = StreamingResponse(
+        guarded_stream(),
+        status_code=response.status_code,
+        media_type=response.media_type,
+        background=response.background,
+    )
+
+    for key, value in response.headers.items():
+        if key.lower() == "content-length":
+            continue
+        wrapped.headers[key] = value
+
+    return wrapped
+
+
 @app.post("/internal/chat")
 async def internal_chat(
     request: Request,
@@ -99,10 +132,14 @@ async def internal_chat(
     x_astra_user_id: str | None = Header(default=None),
     x_astra_workspace: str | None = Header(default=None),
     x_astra_model: str | None = Header(default=None),
+    x_aqsha_gateway_request_id: str | None = Header(default=None),
 ):
     require_internal_auth(authorization)
     conversation_id = await extract_conversation_id(request)
+    request_id = getattr(request.state, "astra_request_id", uuid4().hex)
     request.state.astra_context = {
+        "request_id": request_id,
+        "gateway_request_id": x_aqsha_gateway_request_id or "none",
         "conversation_id": conversation_id or "none",
         "user_id": x_astra_user_id or settings.user_id,
         "workspace": x_astra_workspace or settings.workspace,
@@ -116,13 +153,21 @@ async def internal_chat(
         research_artifact_dir=settings.resolved_research_artifact_dir(),
     )
 
-    return await VercelAIAdapter.dispatch_request(
+    logger.info("Astra internal chat request accepted", extra=request.state.astra_context)
+
+    response = await VercelAIAdapter.dispatch_request(
         request,
         agent=astra_agent,
         sdk_version=6,
         deps=deps,
         model=x_astra_model or settings.model,
         manage_system_prompt="server",
+    )
+    response.headers["x-astra-request-id"] = request_id
+
+    return wrap_streaming_response_errors(
+        response,
+        context=request.state.astra_context,
     )
 
 

--- a/apps/agents/tests/test_astra.py
+++ b/apps/agents/tests/test_astra.py
@@ -4,6 +4,7 @@ import json
 import logging
 import subprocess
 import sys
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ from pydantic_ai import Agent
 from pydantic_ai.capabilities import MCP, WebSearch
 from pydantic_ai.models.test import TestModel
 from pydantic_ai_skills import SkillsDirectory
+from starlette.responses import StreamingResponse
 
 from astra.agents import build_astra_agent, build_astra_capabilities
 from astra.artifacts import (
@@ -200,6 +202,33 @@ def test_internal_chat_logs_unhandled_dispatch_errors(
     assert body["error"]["requestId"]
     assert any(
         record.getMessage() == "Unhandled agents request error"
+        and getattr(record, "conversation_id", None) == "thread-1"
+        for record in caplog.records
+    )
+
+
+async def test_streaming_response_errors_are_logged(caplog: Any) -> None:
+    from astra import server
+
+    async def broken_stream() -> AsyncIterator[bytes]:
+        yield b'{"type":"start"}\n'
+        raise RuntimeError("forced stream failure")
+
+    caplog.set_level(logging.ERROR, logger="astra.server")
+    response = server.wrap_streaming_response_errors(
+        StreamingResponse(broken_stream()),
+        context={"request_id": "req-1", "conversation_id": "thread-1"},
+    )
+
+    try:
+        async for _chunk in response.body_iterator:  # type: ignore[attr-defined]
+            pass
+    except RuntimeError:
+        pass
+
+    assert any(
+        record.getMessage() == "Astra streaming response error"
+        and getattr(record, "request_id", None) == "req-1"
         and getattr(record, "conversation_id", None) == "thread-1"
         for record in caplog.records
     )

--- a/apps/api/drizzle/0013_mature_chat_sources.sql
+++ b/apps/api/drizzle/0013_mature_chat_sources.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "chat_sources" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"chat_thread_id" uuid NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"run_id" uuid NOT NULL,
+	"source_key" text NOT NULL,
+	"kind" text NOT NULL,
+	"title" text,
+	"url" text,
+	"filename" text,
+	"media_type" text,
+	"provider_source_id" text,
+	"metadata" jsonb,
+	"first_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "chat_sources_thread_source_key_unique" UNIQUE("chat_thread_id","source_key"),
+	CONSTRAINT "chat_sources_kind_check" CHECK ("chat_sources"."kind" in ('url', 'document'))
+);
+--> statement-breakpoint
+ALTER TABLE "chat_sources" ADD CONSTRAINT "chat_sources_chat_thread_id_chat_threads_id_fk" FOREIGN KEY ("chat_thread_id") REFERENCES "public"."chat_threads"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chat_sources" ADD CONSTRAINT "chat_sources_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chat_sources" ADD CONSTRAINT "chat_sources_run_id_agent_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."agent_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "chat_sources_thread_last_seen_idx" ON "chat_sources" USING btree ("chat_thread_id","last_seen_at");--> statement-breakpoint
+CREATE INDEX "chat_sources_workspace_thread_idx" ON "chat_sources" USING btree ("workspace_id","chat_thread_id");--> statement-breakpoint
+CREATE INDEX "chat_sources_run_id_idx" ON "chat_sources" USING btree ("run_id");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777597200000,
       "tag": "0012_agent_chat_timeline",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777600800000,
+      "tag": "0013_mature_chat_sources",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/modules/chat/index.ts
+++ b/apps/api/src/modules/chat/index.ts
@@ -5,7 +5,12 @@ import { authIdentityPlugin } from "../../plugins/auth-identity";
 import { servicesPlugin } from "../../plugins/services";
 import { chatModel } from "./model";
 import { collectFinishedMessages } from "./vercel-stream";
-import type { AgentRun, AppendAgentEventInput, ChatScope } from "./store";
+import type {
+  AgentRun,
+  AppendAgentEventInput,
+  AppendChatSourceInput,
+  ChatScope,
+} from "./store";
 
 const chatThreadNotFoundResponse = {
   error: {
@@ -33,6 +38,33 @@ function copyStreamHeaders(headers: Headers): Headers {
   }
 
   return responseHeaders;
+}
+
+function createChatRequestId() {
+  return crypto.randomUUID();
+}
+
+function logChatError(
+  message: string,
+  context: Record<string, unknown>,
+  error?: unknown,
+) {
+  const payload: Record<string, unknown> = {
+    level: "error",
+    module: "chat",
+    message,
+    ...context,
+  };
+
+  if (error instanceof Error) {
+    payload.errorName = error.name;
+    payload.errorMessage = error.message;
+    payload.stack = error.stack;
+  } else if (error !== undefined) {
+    payload.error = error;
+  }
+
+  console.error(JSON.stringify(payload));
 }
 
 function chunkRecord(chunk: UIMessageChunk): Record<string, unknown> {
@@ -182,6 +214,51 @@ function eventForChunk(chunk: UIMessageChunk): Omit<AppendAgentEventInput, "sequ
   }
 }
 
+function sourceForChunk(chunk: UIMessageChunk): AppendChatSourceInput | null {
+  const record = chunkRecord(chunk);
+
+  if (chunk.type === "source-url") {
+    const url = typeof record.url === "string" ? record.url : null;
+
+    if (!url) {
+      return null;
+    }
+
+    return {
+      kind: "url",
+      title: typeof record.title === "string" ? record.title : null,
+      url,
+      providerSourceId:
+        typeof record.sourceId === "string" ? record.sourceId : null,
+      metadata: { chunkType: chunk.type },
+    };
+  }
+
+  if (chunk.type === "source-document") {
+    const filename =
+      typeof record.filename === "string" ? record.filename : null;
+    const mediaType =
+      typeof record.mediaType === "string" ? record.mediaType : null;
+    const providerSourceId =
+      typeof record.sourceId === "string" ? record.sourceId : null;
+
+    if (!providerSourceId && !filename && !mediaType) {
+      return null;
+    }
+
+    return {
+      kind: "document",
+      title: typeof record.title === "string" ? record.title : filename,
+      filename,
+      mediaType,
+      providerSourceId,
+      metadata: { chunkType: chunk.type },
+    };
+  }
+
+  return null;
+}
+
 function createRunEventWriter(
   chatService: {
     appendRunEvent: (
@@ -316,6 +393,7 @@ export const chatModule = new Elysia({
   .post(
     "/threads/:id/messages",
     async ({ body, chatService, identity, params, status }) => {
+      const requestId = createChatRequestId();
       const messagesResult = await chatService.appendUserMessage(
         identity,
         params.id,
@@ -355,6 +433,7 @@ export const chatModule = new Elysia({
       const headers = new Headers({
         Authorization: `Bearer ${env.ASTRA_INTERNAL_TOKEN}`,
         "Content-Type": "application/json",
+        "x-aqsha-gateway-request-id": requestId,
         "x-astra-user-id": identity.authUserId,
       });
 
@@ -362,37 +441,107 @@ export const chatModule = new Elysia({
         headers.set("x-astra-model", model);
       }
 
-      const upstream = await fetch(`${env.AGENTS_BASE_URL}/internal/chat`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          trigger: "submit-message",
-          id: params.id,
-          runId: runResult.data.run.id,
-          messages: messagesResult.data.messages,
-        }),
-      });
+      let upstream: Response;
+
+      try {
+        upstream = await fetch(`${env.AGENTS_BASE_URL}/internal/chat`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            trigger: "submit-message",
+            id: params.id,
+            runId: runResult.data.run.id,
+            messages: messagesResult.data.messages,
+          }),
+        });
+      } catch (error) {
+        logChatError(
+          "Failed to connect to agents service",
+          {
+            requestId,
+            threadId: params.id,
+            runId: runResult.data.run.id,
+            agentsBaseUrl: env.AGENTS_BASE_URL,
+          },
+          error,
+        );
+        await eventWriter({
+          type: "run_failed",
+          scope: "error",
+          status: "failed",
+          title: "Astra connection failed",
+          summary:
+            error instanceof Error
+              ? error.message
+              : "Unable to connect to the agents service.",
+          agentName: "Astra",
+          payload: { requestId },
+        });
+        await chatService.finishRun(runResult.data.scope, runResult.data.run.id, {
+          status: "failed",
+          errorMessage:
+            error instanceof Error
+              ? error.message
+              : "Unable to connect to the agents service.",
+        });
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "agents_network_error",
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "Unable to connect to the agents service.",
+              requestId,
+            },
+          }),
+          {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
 
       if (!upstream.ok || !upstream.body) {
+        const upstreamBody = await upstream.text().catch(() => "");
+        const astraRequestId = upstream.headers.get("x-astra-request-id");
+
+        logChatError("Agents service returned an error response", {
+          requestId,
+          astraRequestId,
+          threadId: params.id,
+          runId: runResult.data.run.id,
+          upstreamStatus: upstream.status,
+          upstreamBody,
+        });
         await eventWriter({
           type: "run_failed",
           scope: "error",
           status: "failed",
           title: "Astra failed to start",
-          summary: "The agents service failed to stream a response.",
+          summary:
+            upstreamBody ||
+            `The agents service failed with HTTP ${upstream.status}.`,
           agentName: "Astra",
-          payload: { status: upstream.status },
+          payload: { requestId, astraRequestId, status: upstream.status, upstreamBody },
         });
         await chatService.finishRun(runResult.data.scope, runResult.data.run.id, {
           status: "failed",
-          errorMessage: "Agents service failed to stream a response",
+          errorMessage:
+            upstreamBody ||
+            `Agents service failed with HTTP ${upstream.status}.`,
         });
 
         return new Response(
           JSON.stringify({
             error: {
               code: "agents_service_error",
-              message: "Agents service failed to stream a response",
+              message:
+                upstreamBody ||
+                `Agents service failed with HTTP ${upstream.status}.`,
+              requestId,
+              astraRequestId,
             },
           }),
           {
@@ -403,15 +552,25 @@ export const chatModule = new Elysia({
       }
 
       const [clientStream, persistenceStream] = upstream.body.tee();
+      const astraRequestId = upstream.headers.get("x-astra-request-id");
 
       void collectFinishedMessages(
         persistenceStream,
         messagesResult.data.messages,
         async (chunk) => {
           const event = eventForChunk(chunk);
+          const source = sourceForChunk(chunk);
 
           if (event) {
             await eventWriter(event);
+          }
+
+          if (source) {
+            await chatService.appendRunSource(
+              runResult.data.scope,
+              runResult.data.run,
+              source,
+            );
           }
         },
       )
@@ -430,14 +589,27 @@ export const chatModule = new Elysia({
           });
         })
         .catch((error: unknown) => {
-          console.error("Failed to persist streamed chat response", error);
+          logChatError(
+            "Failed to persist streamed chat response",
+            {
+              requestId,
+              astraRequestId,
+              threadId: params.id,
+              runId: runResult.data.run.id,
+            },
+            error,
+          );
           void eventWriter({
             type: "run_failed",
             scope: "error",
             status: "failed",
             title: "Astra failed",
-            summary: error instanceof Error ? error.message : "Unable to persist the streamed response.",
+            summary:
+              error instanceof Error
+                ? error.message
+                : "Unable to persist the streamed response.",
             agentName: "Astra",
+            payload: { requestId, astraRequestId },
           }).then(() =>
             chatService.finishRun(runResult.data.scope, runResult.data.run.id, {
               status: "failed",
@@ -449,9 +621,15 @@ export const chatModule = new Elysia({
           );
         });
 
+      const responseHeaders = copyStreamHeaders(upstream.headers);
+      responseHeaders.set("x-aqsha-request-id", requestId);
+      if (astraRequestId) {
+        responseHeaders.set("x-astra-request-id", astraRequestId);
+      }
+
       return new Response(clientStream, {
         status: upstream.status,
-        headers: copyStreamHeaders(upstream.headers),
+        headers: responseHeaders,
       });
     },
     {

--- a/apps/api/src/modules/chat/model.ts
+++ b/apps/api/src/modules/chat/model.ts
@@ -69,11 +69,29 @@ const agentEvent = t.Object({
   createdAt: t.String(),
 });
 
+const chatSource = t.Object({
+  id: t.String(),
+  chatThreadId: t.String(),
+  runId: t.String(),
+  kind: t.Union([t.Literal("url"), t.Literal("document")]),
+  title: t.Union([t.String(), t.Null()]),
+  url: t.Union([t.String(), t.Null()]),
+  filename: t.Union([t.String(), t.Null()]),
+  mediaType: t.Union([t.String(), t.Null()]),
+  providerSourceId: t.Union([t.String(), t.Null()]),
+  metadata: t.Any(),
+  firstSeenAt: t.String(),
+  lastSeenAt: t.String(),
+  createdAt: t.String(),
+  updatedAt: t.String(),
+});
+
 const chatThreadDetail = t.Object({
   thread: chatThread,
   messages: t.Array(chatMessage),
   latestRun: t.Union([agentRun, t.Null()]),
   events: t.Array(agentEvent),
+  sources: t.Array(chatSource),
 });
 
 const unauthorizedError = t.Object({
@@ -105,6 +123,7 @@ export const chatModel = {
   chatMessage,
   agentRun,
   agentEvent,
+  chatSource,
   chatThreadDetail,
   unauthorizedError,
   chatThreadNotFoundError,

--- a/apps/api/src/modules/chat/repository.ts
+++ b/apps/api/src/modules/chat/repository.ts
@@ -1,5 +1,12 @@
 import { and, desc, eq, sql } from "drizzle-orm";
-import { agentEvents, agentRuns, chatMessages, chatThreads, type JsonValue } from "@aqsha/db";
+import {
+  agentEvents,
+  agentRuns,
+  chatMessages,
+  chatSources,
+  chatThreads,
+  type JsonValue,
+} from "@aqsha/db";
 import { generateId, type UIMessage } from "ai";
 import type { DatabaseClient } from "../../database/client";
 import type {
@@ -8,11 +15,13 @@ import type {
   AppendAgentEventInput,
   ChatMessage,
   ChatScope,
+  ChatSource,
   ChatStore,
   ChatThread,
   CreateAgentRunInput,
   CreateChatThreadInput,
   FinishAgentRunInput,
+  UpsertChatSourceInput,
 } from "./store";
 
 type ChatMessageRole = ChatMessage["role"];
@@ -118,6 +127,21 @@ export class DrizzleChatStore implements ChatStore {
     return rows.map((row) => this.toEvent(row));
   }
 
+  async getSources(scope: ChatScope, threadId: string): Promise<ChatSource[]> {
+    const rows = await this.db
+      .select()
+      .from(chatSources)
+      .where(
+        and(
+          eq(chatSources.chatThreadId, threadId),
+          eq(chatSources.workspaceId, scope.workspaceId),
+        ),
+      )
+      .orderBy(chatSources.firstSeenAt, chatSources.createdAt);
+
+    return rows.map((row) => this.toSource(row));
+  }
+
   async createRun(input: CreateAgentRunInput): Promise<AgentRun> {
     const now = new Date();
     const [run] = await this.db
@@ -163,6 +187,50 @@ export class DrizzleChatStore implements ChatStore {
       .returning();
 
     return this.toEvent(storedEvent);
+  }
+
+  async upsertSource(
+    scope: ChatScope,
+    source: UpsertChatSourceInput,
+  ): Promise<ChatSource> {
+    const seenAt = source.seenAt ? new Date(source.seenAt) : new Date();
+    const now = new Date();
+    const [storedSource] = await this.db
+      .insert(chatSources)
+      .values({
+        chatThreadId: source.chatThreadId,
+        workspaceId: scope.workspaceId,
+        runId: source.runId,
+        sourceKey: source.sourceKey,
+        kind: source.kind,
+        title: source.title ?? null,
+        url: source.url ?? null,
+        filename: source.filename ?? null,
+        mediaType: source.mediaType ?? null,
+        providerSourceId: source.providerSourceId ?? null,
+        metadata: this.toJsonValue(source.metadata ?? null),
+        firstSeenAt: seenAt,
+        lastSeenAt: seenAt,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [chatSources.chatThreadId, chatSources.sourceKey],
+        set: {
+          runId: source.runId,
+          kind: source.kind,
+          title: source.title ?? null,
+          url: source.url ?? null,
+          filename: source.filename ?? null,
+          mediaType: source.mediaType ?? null,
+          providerSourceId: source.providerSourceId ?? null,
+          metadata: this.toJsonValue(source.metadata ?? null),
+          lastSeenAt: seenAt,
+          updatedAt: now,
+        },
+      })
+      .returning();
+
+    return this.toSource(storedSource);
   }
 
   async finishRun(
@@ -389,6 +457,25 @@ export class DrizzleChatStore implements ChatStore {
       payload: event.payload ?? null,
       occurredAt: event.occurredAt.toISOString(),
       createdAt: event.createdAt.toISOString(),
+    };
+  }
+
+  private toSource(source: typeof chatSources.$inferSelect): ChatSource {
+    return {
+      id: source.id,
+      chatThreadId: source.chatThreadId,
+      runId: source.runId,
+      kind: source.kind,
+      title: source.title,
+      url: source.url,
+      filename: source.filename,
+      mediaType: source.mediaType,
+      providerSourceId: source.providerSourceId,
+      metadata: source.metadata ?? null,
+      firstSeenAt: source.firstSeenAt.toISOString(),
+      lastSeenAt: source.lastSeenAt.toISOString(),
+      createdAt: source.createdAt.toISOString(),
+      updatedAt: source.updatedAt.toISOString(),
     };
   }
 

--- a/apps/api/src/modules/chat/service.ts
+++ b/apps/api/src/modules/chat/service.ts
@@ -3,6 +3,7 @@ import type { AuthIdentity } from "../../plugins/auth-identity";
 import type { ChatModel } from "./model";
 import type {
   AgentRun,
+  AppendChatSourceInput,
   AppendAgentEventInput,
   ChatMessage,
   ChatScope,
@@ -80,6 +81,7 @@ export class ChatService {
         messages: await this.store.getMessages(scope, threadId),
         latestRun: await this.store.getLatestRun(scope, threadId),
         events: await this.store.getEvents(scope, threadId),
+        sources: await this.store.getSources(scope, threadId),
       },
     };
   }
@@ -218,6 +220,26 @@ export class ChatService {
     await this.store.appendEvent(scope, run, event);
   }
 
+  async appendRunSource(
+    scope: ChatScope,
+    run: Pick<AgentRun, "id" | "chatThreadId">,
+    source: AppendChatSourceInput,
+  ): Promise<void> {
+    const sourceKey = this.sourceKeyForSource(source);
+
+    if (!sourceKey) {
+      return;
+    }
+
+    await this.store.upsertSource(scope, {
+      ...source,
+      chatThreadId: run.chatThreadId,
+      workspaceId: scope.workspaceId,
+      runId: run.id,
+      sourceKey,
+    });
+  }
+
   async finishRun(
     scope: ChatScope,
     runId: string,
@@ -251,6 +273,39 @@ export class ChatService {
       role: message.role,
       parts: message.parts as UIMessage["parts"],
     };
+  }
+
+  private sourceKeyForSource(source: AppendChatSourceInput): string | null {
+    if (source.kind === "url") {
+      const normalizedUrl = this.normalizeUrl(source.url);
+
+      return normalizedUrl ? `url:${normalizedUrl}` : null;
+    }
+
+    const documentKey =
+      source.providerSourceId?.trim() ||
+      [source.filename?.trim(), source.mediaType?.trim()]
+        .filter(Boolean)
+        .join(":");
+
+    return documentKey ? `document:${documentKey}` : null;
+  }
+
+  private normalizeUrl(value: string | null | undefined): string | null {
+    const trimmed = value?.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const url = new URL(trimmed);
+      url.hash = "";
+
+      return url.toString();
+    } catch {
+      return trimmed;
+    }
   }
 
   private titleForThread(currentTitle: string, messages: Pick<ChatMessage, "role" | "parts">[]): string {

--- a/apps/api/src/modules/chat/store.ts
+++ b/apps/api/src/modules/chat/store.ts
@@ -5,6 +5,7 @@ export type ChatThread = ChatModel["chatThread"];
 export type ChatMessage = ChatModel["chatMessage"];
 export type AgentRun = ChatModel["agentRun"];
 export type AgentEvent = ChatModel["agentEvent"];
+export type ChatSource = ChatModel["chatSource"];
 
 export interface ChatScope {
   userId: string;
@@ -34,6 +35,24 @@ export interface AppendAgentEventInput {
   occurredAt?: string;
 }
 
+export interface AppendChatSourceInput {
+  kind: ChatSource["kind"];
+  title?: string | null;
+  url?: string | null;
+  filename?: string | null;
+  mediaType?: string | null;
+  providerSourceId?: string | null;
+  metadata?: unknown;
+  seenAt?: string;
+}
+
+export interface UpsertChatSourceInput extends AppendChatSourceInput {
+  chatThreadId: string;
+  workspaceId: string;
+  runId: string;
+  sourceKey: string;
+}
+
 export interface FinishAgentRunInput {
   status: Extract<AgentRun["status"], "completed" | "failed" | "cancel_requested">;
   errorMessage?: string | null;
@@ -47,12 +66,17 @@ export interface ChatStore {
   getMessages(scope: ChatScope, threadId: string): Promise<ChatMessage[]>;
   getLatestRun(scope: ChatScope, threadId: string): Promise<AgentRun | null>;
   getEvents(scope: ChatScope, threadId: string): Promise<AgentEvent[]>;
+  getSources(scope: ChatScope, threadId: string): Promise<ChatSource[]>;
   createRun(input: CreateAgentRunInput): Promise<AgentRun>;
   appendEvent(
     scope: ChatScope,
     run: Pick<AgentRun, "id" | "chatThreadId">,
     event: AppendAgentEventInput,
   ): Promise<AgentEvent>;
+  upsertSource(
+    scope: ChatScope,
+    source: UpsertChatSourceInput,
+  ): Promise<ChatSource>;
   finishRun(
     scope: ChatScope,
     runId: string,

--- a/apps/web/app/(app)/app/threads/[id]/page.tsx
+++ b/apps/web/app/(app)/app/threads/[id]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation";
 
-import { AppPageHeader } from "@/components/app-page-header";
-import { ChatThread } from "@/features/chat/components/chat-thread";
+import { ThreadPageShell } from "@/features/chat/components/thread-page-shell";
 import { getChatThread } from "@/features/chat/lib/server-api";
 
 export default async function ThreadPage({
@@ -17,14 +16,13 @@ export default async function ThreadPage({
   }
 
   return (
-    <div className="flex h-full flex-col bg-background text-foreground">
-      <AppPageHeader title={detail.thread.title} sticky />
-      <ChatThread
-        id={id}
-        initialEvents={detail.events}
-        initialLatestRun={detail.latestRun}
-        initialMessages={detail.messages}
-      />
-    </div>
+    <ThreadPageShell
+      id={id}
+      initialEvents={detail.events}
+      initialLatestRun={detail.latestRun}
+      initialMessages={detail.messages}
+      initialSources={detail.sources}
+      title={detail.thread.title}
+    />
   );
 }

--- a/apps/web/features/chat/components/chat-thread.tsx
+++ b/apps/web/features/chat/components/chat-thread.tsx
@@ -15,19 +15,38 @@ import { getApiBaseUrl } from "@/lib/api-url";
 import { queryKeys } from "@/lib/react-query/keys";
 import { toast } from "@/lib/toast";
 
+function describeChatError(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return "Something went wrong. Please try again.";
+}
+
+const CHAT_UPDATE_THROTTLE_MS = 50;
+
+function messagesSignature(messages: UIMessage[]) {
+  return messages
+    .map((message) => `${message.id}:${message.role}:${message.parts.length}`)
+    .join("|");
+}
+
 export function ChatThread({
   id,
   initialEvents,
   initialLatestRun,
   initialMessages,
+  onMessagesChange,
 }: {
   id: string;
   initialEvents: AgentEvent[];
   initialLatestRun: AgentRun | null;
   initialMessages: UIMessage[];
+  onMessagesChange?: (messages: UIMessage[]) => void;
 }) {
   const queryClient = useQueryClient();
   const sentPendingPromptRef = useRef(false);
+  const emittedMessagesSignatureRef = useRef("");
   const toastedErrorRef = useRef<unknown>(null);
   const { containerRef, isAtBottom, scrollToBottom } = useChatScroll(id);
   const transport = useMemo(
@@ -47,6 +66,7 @@ export function ChatThread({
     id,
     messages: initialMessages,
     transport,
+    experimental_throttle: CHAT_UPDATE_THROTTLE_MS,
     onFinish: () => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.chat.threads(),
@@ -62,7 +82,7 @@ export function ChatThread({
     toastedErrorRef.current = error;
     toast.error({
       title: "Could not send message",
-      description: "Something went wrong. Please try again.",
+      description: describeChatError(error),
     });
   }, [error]);
 
@@ -84,6 +104,17 @@ export function ChatThread({
   }, [id, sendMessage, status]);
 
   const isStreaming = status === "submitted" || status === "streaming";
+
+  useEffect(() => {
+    const signature = messagesSignature(messages);
+
+    if (emittedMessagesSignatureRef.current === signature) {
+      return;
+    }
+
+    emittedMessagesSignatureRef.current = signature;
+    onMessagesChange?.(messages);
+  }, [messages, onMessagesChange]);
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
@@ -116,7 +147,7 @@ export function ChatThread({
       <div className="absolute inset-x-0 bottom-0 z-20 bg-background px-4 pb-6 pt-3 sm:px-6">
         {error ? (
           <div className="mx-auto mb-3 w-full max-w-[820px] rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-2 text-sm text-destructive">
-            Something went wrong. Please try again.
+            {describeChatError(error)}
           </div>
         ) : null}
         <MessageInput

--- a/apps/web/features/chat/components/message-list.tsx
+++ b/apps/web/features/chat/components/message-list.tsx
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import { useState } from "react";
 import {
   CheckCircle2Icon,
   ChevronDownIcon,
@@ -839,6 +840,7 @@ function AgentTimeline({
 function ToolPartView({ part }: { part: ToolPart }) {
   const record = partRecord(part);
   const state = toolState(part) as Parameters<typeof ToolHeader>[0]["state"];
+  const [defaultOpen] = useState(() => state !== "output-available");
   const output =
     "output" in record && record.output !== undefined ? (
       <pre className="max-h-48 overflow-auto rounded-md bg-muted px-3 py-2 text-xs leading-5 text-muted-foreground">
@@ -849,7 +851,7 @@ function ToolPartView({ part }: { part: ToolPart }) {
     ) : null;
 
   return (
-    <Tool defaultOpen={state !== "output-available"}>
+    <Tool defaultOpen={defaultOpen}>
       <ToolHeader
         state={state}
         toolType={part.type === "dynamic-tool" ? `tool-${toolName(part)}` : part.type}

--- a/apps/web/features/chat/components/thread-page-shell.tsx
+++ b/apps/web/features/chat/components/thread-page-shell.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { PanelRightIcon } from "lucide-react";
+import type { UIMessage } from "ai";
+import { useState, useSyncExternalStore } from "react";
+
+import { AppPageHeader } from "@/components/app-page-header";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+import { ChatThread } from "@/features/chat/components/chat-thread";
+import { ThreadSourcesPanel } from "@/features/chat/components/thread-sources-panel";
+import type {
+  AgentEvent,
+  AgentRun,
+  ChatMessage,
+  ChatSource,
+} from "@/features/chat/lib/types";
+import { cn } from "@/lib/utils";
+
+const DESKTOP_QUERY = "(min-width: 1024px)";
+
+function subscribeToDesktopQuery(callback: () => void) {
+  const mediaQuery = window.matchMedia(DESKTOP_QUERY);
+
+  mediaQuery.addEventListener("change", callback);
+
+  return () => mediaQuery.removeEventListener("change", callback);
+}
+
+function getDesktopSnapshot() {
+  return window.matchMedia(DESKTOP_QUERY).matches;
+}
+
+function getServerDesktopSnapshot() {
+  return false;
+}
+
+function useIsDesktop() {
+  return useSyncExternalStore(
+    subscribeToDesktopQuery,
+    getDesktopSnapshot,
+    getServerDesktopSnapshot,
+  );
+}
+
+export function ThreadPageShell({
+  id,
+  initialEvents,
+  initialLatestRun,
+  initialMessages,
+  initialSources,
+  title,
+}: {
+  id: string;
+  initialEvents: AgentEvent[];
+  initialLatestRun: AgentRun | null;
+  initialMessages: ChatMessage[];
+  initialSources: ChatSource[];
+  title: string;
+}) {
+  const isDesktop = useIsDesktop();
+  const [displayMessages, setDisplayMessages] =
+    useState<UIMessage[]>(initialMessages);
+  const [desktopSourcesOpen, setDesktopSourcesOpen] = useState(true);
+  const [mobileSourcesOpen, setMobileSourcesOpen] = useState(false);
+
+  const trigger = (
+    <>
+      <Button
+        aria-controls="thread-sources-sidebar"
+        aria-expanded={desktopSourcesOpen}
+        className="hidden lg:inline-flex"
+        onClick={() => setDesktopSourcesOpen((open) => !open)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <PanelRightIcon data-icon="inline-start" />
+        <span>sources</span>
+      </Button>
+      <Button
+        aria-expanded={mobileSourcesOpen}
+        className="lg:hidden"
+        onClick={() => setMobileSourcesOpen(true)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <PanelRightIcon data-icon="inline-start" />
+        <span>sources</span>
+      </Button>
+    </>
+  );
+
+  return (
+    <div className="flex h-full flex-col bg-background text-foreground">
+      <AppPageHeader actions={trigger} sticky title={title} />
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <main className="flex min-h-0 min-w-0 flex-1">
+          <ChatThread
+            id={id}
+            initialEvents={initialEvents}
+            initialLatestRun={initialLatestRun}
+            initialMessages={initialMessages}
+            onMessagesChange={setDisplayMessages}
+          />
+        </main>
+
+        <aside
+          className={cn(
+            "hidden min-h-0 shrink-0 overflow-hidden border-l border-border transition-[width,opacity] duration-200 lg:flex",
+            desktopSourcesOpen
+              ? "opacity-100"
+              : "border-l-0 opacity-0",
+          )}
+          id="thread-sources-sidebar"
+          style={{ width: desktopSourcesOpen ? 320 : 0 }}
+        >
+          <ThreadSourcesPanel
+            events={initialEvents}
+            messages={displayMessages}
+            sources={initialSources}
+          />
+        </aside>
+      </div>
+
+      <Drawer
+        direction="right"
+        open={mobileSourcesOpen && !isDesktop}
+        onOpenChange={setMobileSourcesOpen}
+      >
+        <DrawerContent className="lg:hidden sm:max-w-md">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>Sources</DrawerTitle>
+            <DrawerDescription>
+              Sources cited in the current thread.
+            </DrawerDescription>
+          </DrawerHeader>
+          <ThreadSourcesPanel
+            events={initialEvents}
+            messages={displayMessages}
+            sources={initialSources}
+          />
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+}

--- a/apps/web/features/chat/components/thread-sources-panel.tsx
+++ b/apps/web/features/chat/components/thread-sources-panel.tsx
@@ -1,0 +1,198 @@
+import type { UIMessage } from "ai";
+import { ExternalLinkIcon, LinkIcon } from "lucide-react";
+
+import type { AgentEvent, ChatSource } from "@/features/chat/lib/types";
+import { cn } from "@/lib/utils";
+
+type SourceItem = {
+  href: string | null;
+  id: string;
+  meta: string;
+  title: string;
+};
+
+type MessagePart = UIMessage["parts"][number];
+
+function partRecord(part: MessagePart): Record<string, unknown> {
+  return part as unknown as Record<string, unknown>;
+}
+
+function collectSources(messages: UIMessage[], events: AgentEvent[]): SourceItem[] {
+  const sources = new Map<string, SourceItem>();
+
+  messages.forEach((message, messageIndex) => {
+    message.parts.forEach((part, partIndex) => {
+      if (part.type !== "source-url") {
+        return;
+      }
+
+      const record = partRecord(part);
+      const href = typeof record.url === "string" ? record.url : "";
+
+      if (!href || sources.has(href)) {
+        return;
+      }
+
+      sources.set(href, {
+        href,
+        id: `${message.id}-source-${partIndex}`,
+        meta: `Message ${messageIndex + 1}`,
+        title: typeof record.title === "string" ? record.title : href,
+      });
+    });
+  });
+
+  events.forEach((event) => {
+    if (event.scope !== "source") {
+      return;
+    }
+
+    const payload =
+      event.payload && typeof event.payload === "object"
+        ? (event.payload as Record<string, unknown>)
+        : {};
+    const href = typeof payload.url === "string" ? payload.url : null;
+    const title =
+      typeof payload.title === "string"
+        ? payload.title
+        : event.summary || event.title || href || "Document source";
+    const key = href ?? event.id;
+
+    if (sources.has(key)) {
+      return;
+    }
+
+    sources.set(key, {
+      href,
+      id: event.id,
+      meta: "Agent event",
+      title,
+    });
+  });
+
+  return Array.from(sources.values());
+}
+
+function collectStoredSources(sources: ChatSource[]): SourceItem[] {
+  return sources.map((source) => ({
+    href: source.kind === "url" ? source.url : null,
+    id: source.id,
+    meta:
+      source.kind === "url"
+        ? "Web source"
+        : source.mediaType || "Document source",
+    title:
+      source.title ||
+      source.filename ||
+      source.url ||
+      (source.kind === "url" ? "Web source" : "Document source"),
+  }));
+}
+
+export function ThreadSourcesPanel({
+  className,
+  messages,
+  events = [],
+  sources = [],
+}: {
+  className?: string;
+  messages: UIMessage[];
+  events?: AgentEvent[];
+  sources?: ChatSource[];
+}) {
+  const sourceItems = mergeSources(
+    collectStoredSources(sources),
+    collectSources(messages, events),
+  );
+
+  return (
+    <section
+      aria-label="Sources"
+      className={cn("flex h-full min-h-0 flex-col bg-background", className)}
+    >
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <LinkIcon className="size-4" />
+          <span>Sources</span>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {sourceItems.length} source{sourceItems.length === 1 ? "" : "s"} in this thread
+        </p>
+      </div>
+
+      {sourceItems.length > 0 ? (
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="flex flex-col gap-2">
+            {sourceItems.map((source) => (
+              <SourceCard
+                href={source.href}
+                key={source.id}
+                meta={source.meta}
+                title={source.title}
+              />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          Sources will appear here after Astra cites web or document references.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function mergeSources(primary: SourceItem[], fallback: SourceItem[]) {
+  const merged = new Map<string, SourceItem>();
+
+  for (const source of [...primary, ...fallback]) {
+    const key = source.href ?? `${source.title}:${source.meta}`;
+
+    if (!merged.has(key)) {
+      merged.set(key, source);
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+function SourceCard({
+  href,
+  meta,
+  title,
+}: {
+  href: string | null;
+  meta: string;
+  title: string;
+}) {
+  const className =
+    "group flex min-w-0 items-start gap-2 rounded-md border border-border bg-card px-3 py-2.5 text-sm transition-colors hover:bg-muted";
+  const content = (
+    <>
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="line-clamp-2 font-medium leading-5 text-foreground">
+          {title}
+        </span>
+        <span className="truncate text-xs text-muted-foreground">{meta}</span>
+      </span>
+      {href ? (
+        <ExternalLinkIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+      ) : null}
+    </>
+  );
+
+  if (!href) {
+    return <div className={className}>{content}</div>;
+  }
+
+  return (
+    <a
+      className={className}
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+    >
+      {content}
+    </a>
+  );
+}

--- a/apps/web/features/chat/lib/types.ts
+++ b/apps/web/features/chat/lib/types.ts
@@ -54,9 +54,27 @@ export type AgentEvent = {
   createdAt: string;
 };
 
+export type ChatSource = {
+  id: string;
+  chatThreadId: string;
+  runId: string;
+  kind: "url" | "document";
+  title: string | null;
+  url: string | null;
+  filename: string | null;
+  mediaType: string | null;
+  providerSourceId: string | null;
+  metadata: unknown;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type ChatThreadDetail = {
   thread: ChatThread;
   messages: ChatMessage[];
   latestRun: AgentRun | null;
   events: AgentEvent[];
+  sources: ChatSource[];
 };

--- a/packages/db/src/model.ts
+++ b/packages/db/src/model.ts
@@ -17,6 +17,7 @@ const _insertJournalVersions = createInsertSchema(table.journalVersions);
 const _insertExports = createInsertSchema(table.exports);
 const _insertChatThreads = createInsertSchema(table.chatThreads);
 const _insertChatMessages = createInsertSchema(table.chatMessages);
+const _insertChatSources = createInsertSchema(table.chatSources);
 const _insertAgentRuns = createInsertSchema(table.agentRuns);
 const _insertAgentEvents = createInsertSchema(table.agentEvents);
 
@@ -35,6 +36,7 @@ const _selectJournalVersions = createSelectSchema(table.journalVersions);
 const _selectExports = createSelectSchema(table.exports);
 const _selectChatThreads = createSelectSchema(table.chatThreads);
 const _selectChatMessages = createSelectSchema(table.chatMessages);
+const _selectChatSources = createSelectSchema(table.chatSources);
 const _selectAgentRuns = createSelectSchema(table.agentRuns);
 const _selectAgentEvents = createSelectSchema(table.agentEvents);
 
@@ -53,6 +55,7 @@ export const dbModel = {
     exports: _insertExports,
     chatThreads: _insertChatThreads,
     chatMessages: _insertChatMessages,
+    chatSources: _insertChatSources,
     agentRuns: _insertAgentRuns,
     agentEvents: _insertAgentEvents,
   }),
@@ -70,6 +73,7 @@ export const dbModel = {
     exports: _selectExports,
     chatThreads: _selectChatThreads,
     chatMessages: _selectChatMessages,
+    chatSources: _selectChatSources,
     agentRuns: _selectAgentRuns,
     agentEvents: _selectAgentEvents,
   }),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -54,6 +54,7 @@ export const exportStatuses = [
 ] as const;
 export const chatThreadStatuses = ["active", "archived"] as const;
 export const chatMessageRoles = ["system", "user", "assistant", "tool"] as const;
+export const chatSourceKinds = ["url", "document"] as const;
 export const agentRunStatuses = [
   "queued",
   "running",
@@ -607,6 +608,54 @@ export const agentRuns = pgTable(
   ],
 );
 
+export const chatSources = pgTable(
+  "chat_sources",
+  {
+    id: idColumn("id"),
+    chatThreadId: uuid("chat_thread_id")
+      .notNull()
+      .references(() => chatThreads.id, { onDelete: "cascade" }),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    runId: uuid("run_id")
+      .notNull()
+      .references(() => agentRuns.id, { onDelete: "cascade" }),
+    sourceKey: text("source_key").notNull(),
+    kind: text("kind", { enum: chatSourceKinds }).notNull(),
+    title: text("title"),
+    url: text("url"),
+    filename: text("filename"),
+    mediaType: text("media_type"),
+    providerSourceId: text("provider_source_id"),
+    metadata: jsonb("metadata").$type<JsonValue>(),
+    firstSeenAt: timestamp("first_seen_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    createdAt: createdAtColumn(),
+    updatedAt: updatedAtColumn(),
+  },
+  (table) => [
+    check("chat_sources_kind_check", sql`${table.kind} in ('url', 'document')`),
+    unique("chat_sources_thread_source_key_unique").on(
+      table.chatThreadId,
+      table.sourceKey,
+    ),
+    index("chat_sources_thread_last_seen_idx").on(
+      table.chatThreadId,
+      table.lastSeenAt,
+    ),
+    index("chat_sources_workspace_thread_idx").on(
+      table.workspaceId,
+      table.chatThreadId,
+    ),
+    index("chat_sources_run_id_idx").on(table.runId),
+  ],
+);
+
 export const agentEvents = pgTable(
   "agent_events",
   {
@@ -671,6 +720,7 @@ export const table = {
   exports,
   chatThreads,
   chatMessages,
+  chatSources,
   agentRuns,
   agentEvents,
 } as const;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -2,6 +2,7 @@ import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import {
   accounts,
   chatMessages,
+  chatSources,
   chatThreads,
   exports,
   journalVersions,
@@ -33,6 +34,7 @@ export type JournalVersionRecord = InferSelectModel<typeof journalVersions>;
 export type ExportRecord = InferSelectModel<typeof exports>;
 export type ChatThreadRecord = InferSelectModel<typeof chatThreads>;
 export type ChatMessageRecord = InferSelectModel<typeof chatMessages>;
+export type ChatSourceRecord = InferSelectModel<typeof chatSources>;
 export type AgentRunRecord = InferSelectModel<typeof agentRuns>;
 export type AgentEventRecord = InferSelectModel<typeof agentEvents>;
 
@@ -51,6 +53,7 @@ export type NewJournalVersion = InferInsertModel<typeof journalVersions>;
 export type NewExport = InferInsertModel<typeof exports>;
 export type NewChatThread = InferInsertModel<typeof chatThreads>;
 export type NewChatMessage = InferInsertModel<typeof chatMessages>;
+export type NewChatSource = InferInsertModel<typeof chatSources>;
 export type NewAgentRun = InferInsertModel<typeof agentRuns>;
 export type NewAgentEvent = InferInsertModel<typeof agentEvents>;
 


### PR DESCRIPTION
## Summary
- add durable chat_sources table and migration for thread-scoped source dedupe
- upsert AI SDK source-url/source-document chunks and return sources from thread detail
- render persisted sources in the thread sidebar/drawer with legacy fallback
- improve streaming diagnostics across API and agents, and stabilize chat UI updates/collapsible state

## Validation
- bun run --filter @aqsha/db typecheck
- bun run --filter @aqsha/api typecheck
- bun run --filter @aqsha/web typecheck
- bun run --filter @aqsha/db lint -- src/schema.ts src/types.ts src/model.ts
- bun run --filter @aqsha/api lint -- src/modules/chat/index.ts src/modules/chat/model.ts src/modules/chat/repository.ts src/modules/chat/service.ts src/modules/chat/store.ts
- bun eslint app/(app)/app/threads/[id]/page.tsx features/chat/components/chat-thread.tsx features/chat/components/message-list.tsx features/chat/components/thread-page-shell.tsx features/chat/components/thread-sources-panel.tsx features/chat/lib/types.ts
- uv run pytest tests/test_astra.py -q
- uv run ruff check src tests
- uv run pyright
- PYTHONPATH=src .venv/bin/python -m compileall src tests