### PR TITLE
fix(convex): make sandbox file write + statcheck parsing work live

### DIFF
--- a/packages/convex/convex/agent/sandbox/sandboxVendor.ts
+++ b/packages/convex/convex/agent/sandbox/sandboxVendor.ts
@@ -49,6 +49,42 @@ const CREATE_TIMEOUT_SECONDS = 120;
 // Idle minutes before Daytona auto-stops (then auto-deletes, since ephemeral
 // forces autoDeleteInterval=0). Backstop if our explicit delete never runs.
 const AUTO_STOP_MINUTES = 5;
+// Base64 chars written per executeCommand append (keeps each command well within
+// shell/API length limits while minimizing round-trips).
+const WRITE_CHUNK_CHARS = 40_000;
+
+// Writes a file into the sandbox via executeCommand + base64 rather than
+// `fs.uploadFile`. The SDK's multipart upload needs the `form-data` module,
+// which is not bundleable in the Convex Node runtime; base64 over the shell is
+// dependency-free and safely round-trips any byte content (R scripts, text).
+async function writeFile(
+  sandbox: Sandbox,
+  path: string,
+  content: string,
+  timeoutSeconds: number,
+): Promise<void> {
+  const b64 = Buffer.from(content, "utf8").toString("base64");
+  const tmp = `${path}.b64`;
+  await sandbox.process.executeCommand(`: > '${tmp}'`, "/workspace", undefined, timeoutSeconds);
+  for (let i = 0; i < b64.length; i += WRITE_CHUNK_CHARS) {
+    const chunk = b64.slice(i, i + WRITE_CHUNK_CHARS);
+    await sandbox.process.executeCommand(
+      `printf '%s' '${chunk}' >> '${tmp}'`,
+      "/workspace",
+      undefined,
+      timeoutSeconds,
+    );
+  }
+  const decoded = await sandbox.process.executeCommand(
+    `base64 -d '${tmp}' > '${path}' && rm -f '${tmp}'`,
+    "/workspace",
+    undefined,
+    timeoutSeconds,
+  );
+  if (decoded.exitCode !== 0) {
+    throw new Error(`failed to write ${path}: ${decoded.result ?? ""}`);
+  }
+}
 
 /**
  * Provision one ephemeral sandbox, upload all files, run every command in it,
@@ -72,7 +108,7 @@ export async function runSandboxSession(
     );
 
     for (const file of req.files) {
-      await sandbox.fs.uploadFile(Buffer.from(file.content, "utf8"), file.path);
+      await writeFile(sandbox, file.path, file.content, req.timeoutSeconds);
     }
 
     const results: SandboxCommandResult[] = [];

--- a/packages/convex/convex/agent/sandbox/scripts/statcheck.ts
+++ b/packages/convex/convex/agent/sandbox/scripts/statcheck.ts
@@ -38,22 +38,29 @@ if (is.null(res) || nrow(res) == 0) {
   quit(save = "no", status = 0)
 }
 
-# statcheck column names drift slightly across versions; pull each defensively.
-col <- function(df, name) if (name %in% names(df)) df[[name]] else rep(NA, nrow(df))
+# statcheck column names changed across versions (newer releases use snake_case
+# like test_type/reported_p/computed_p; older ones use CamelCase like
+# Statistic/Reported.P.Value/Computed). Pull each by trying both.
+col <- function(df, candidates) {
+  for (n in candidates) {
+    if (n %in% names(df)) return(df[[n]])
+  }
+  rep(NA, nrow(df))
+}
 
 out <- data.frame(
-  source = as.character(col(res, "Source")),
-  statistic = as.character(col(res, "Statistic")),
-  df1 = suppressWarnings(as.numeric(col(res, "df1"))),
-  df2 = suppressWarnings(as.numeric(col(res, "df2"))),
-  testValue = suppressWarnings(as.numeric(col(res, "Value"))),
-  reportedComparison = as.character(col(res, "Reported.Comparison")),
-  reportedPValue = suppressWarnings(as.numeric(col(res, "Reported.P.Value"))),
-  computedPValue = suppressWarnings(as.numeric(col(res, "Computed"))),
-  raw = as.character(col(res, "Raw")),
-  statcheckError = as.logical(col(res, "Error")),
-  statcheckDecisionError = as.logical(col(res, "DecisionError")),
-  oneTailedInTxt = as.logical(col(res, "OneTailedInTxt")),
+  source = as.character(col(res, c("source", "Source"))),
+  statistic = as.character(col(res, c("test_type", "Statistic"))),
+  df1 = suppressWarnings(as.numeric(col(res, c("df1", "Df1")))),
+  df2 = suppressWarnings(as.numeric(col(res, c("df2", "Df2")))),
+  testValue = suppressWarnings(as.numeric(col(res, c("test_value", "Value")))),
+  reportedComparison = as.character(col(res, c("p_comp", "Reported.Comparison"))),
+  reportedPValue = suppressWarnings(as.numeric(col(res, c("reported_p", "Reported.P.Value")))),
+  computedPValue = suppressWarnings(as.numeric(col(res, c("computed_p", "Computed")))),
+  raw = as.character(col(res, c("raw", "Raw"))),
+  statcheckError = as.logical(col(res, c("error", "Error"))),
+  statcheckDecisionError = as.logical(col(res, c("decision_error", "DecisionError"))),
+  oneTailedInTxt = as.logical(col(res, c("one_tailed_in_txt", "OneTailedInTxt"))),
   stringsAsFactors = FALSE
 )
 


### PR DESCRIPTION
## Summary

Two fixes for the Phase 1 statistical verification engine, found by validating it **live end-to-end against the real Daytona snapshot** (the Phase 0 spike never caught these — it only ran base R, and never uploaded files or parsed statcheck output).

1. **Sandbox file write** — `sandboxVendor` wrote files with Daytona's `fs.uploadFile`, whose multipart upload needs the `form-data` module, which is **not bundleable in the Convex Node runtime** (`Cannot find module 'form-data'`). Now writes files via `executeCommand` + base64 — dependency-free and safely round-trips any byte content.
2. **statcheck column names** — this statcheck version emits **snake_case** columns (`test_type`, `reported_p`, `computed_p`, `raw`, …); `statcheck.R` only read the older **CamelCase** names, so every recomputed value came back `null`. Now reads both conventions.

## Verified live

Against the `aqsha-statverify-v1` snapshot (built from the GHCR image), the real path (`runSandboxSession` → base64 write → `STATCHECK_R` → `parseStatcheckStdout` + `classifyStatcheckRow`) returns correct, classified results:

| Reported | Recomputed | Outcome |
|---|---|---|
| `t(28)=2.10, p=.04` | 0.0449 | consistent |
| `F(2,45)=3.20, p=.049` | 0.0502 | **decision_error** (significance flips) |
| `t(100)=1.10, p=.27` | 0.274 | consistent |

Gate green: typecheck (3 workspaces), 174 convex tests, lint, `convex dev --once`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
