### PR TITLE
feat(v2-agent): persisted-event resume, B-strip storage, zombie reconciler

### DIFF
--- a/apps/agent-v2/agent/hooks/projection.ts
+++ b/apps/agent-v2/agent/hooks/projection.ts
@@ -8,6 +8,7 @@ import {
   recordAssistantMessage,
   recordUserMessage,
   setThreadStatus,
+  stripSupersededDeltas,
 } from "../lib/store.ts";
 
 /**
@@ -122,6 +123,15 @@ export default defineHook({
           idempotencyKey: `${ctx.session.id}:${event.data.turnId}:${event.data.stepIndex}`,
         });
       });
+      // B-strip (Phase 6): step selesai → kosongkan payload delta tersusul step ini (at-rest KB).
+      // Swallow TERPISAH dari billing — gagal-strip tak boleh ganggu debit (dan sebaliknya).
+      await swallow("strip", () =>
+        stripSupersededDeltas({
+          sessionId: ctx.session.id,
+          turnId: event.data.turnId,
+          stepIndex: event.data.stepIndex,
+        }),
+      );
     },
 
     async "turn.completed"(_event, ctx) {

--- a/apps/agent-v2/agent/instructions.md
+++ b/apps/agent-v2/agent/instructions.md
@@ -19,10 +19,13 @@ Gunakan tool bila relevan, jangan menebak yang bisa diverifikasi:
 - **Verifikasi:** `verify_identifiers`, `verify_citations` untuk memeriksa integritas
   referensi sebelum mengeklaimnya.
 
-Aksi yang mengubah data (buat/ubah/simpan/hapus) dikonfirmasi lewat **percakapan**, bukan
-kartu/tombol: tawarkan atau tanyakan lewat teks lebih dulu, lalu tunggu jawaban user di
-composer sebelum memanggil tool-nya. Untuk aksi DESTRUKTIF (mis. `delete_artifact`) ini
-WAJIB — jangan pernah menghapus tanpa konfirmasi user yang eksplisit.
+Untuk klarifikasi atau pilihan di tengah turn, gunakan **`ask_question`** (prompt + opsi
+opsional) — user menjawab lewat kartu di atas composer atau teks bebas di composer.
+
+Aksi yang mengubah data: tawarkan dulu bila perlu, lalu panggil tool-nya. Tool destruktif
+seperti **`delete_artifact`** sudah memiliki gerbang persetujuan UI (`needsApproval`) — panggil
+langsung; jangan minta konfirmasi ganda lewat teks sebelum memanggil tool tersebut. Untuk tool
+lain yang belum digerbang, tetap tunggu jawaban eksplisit user di composer sebelum mengeksekusi.
 
 ## Skills
 
@@ -32,9 +35,9 @@ atau user menyebutnya — panggil **`load_skill`** lebih dulu, lalu ikuti instru
 dimuat alih-alih berimprovisasi.
 
 - **`/deep` atau permintaan riset mendalam tercitasi → muat skill `deep-research`** dan
-  jalankan metodologinya (gali konteks lewat percakapan dulu, sajikan rencana prosa & minta
-  konfirmasi, panggil `begin_deep_research`, delegasi telaah literatur & bukti tandingan ke
-  subagent, verifikasi sitasi, lalu tulis sintesis tercitasi).
+  jalankan metodologinya (gali konteks lewat **`ask_question`**, sajikan rencana prosa &
+  konfirmasi lewat **`ask_question`**, panggil `begin_deep_research`, delegasi telaah
+  literatur & bukti tandingan ke subagent, verifikasi sitasi, lalu tulis sintesis tercitasi).
 - Sebelum menulis laporan domain tertentu, muat domain-pack yang relevan (mis.
   `research-medicine`/`research-cs-ml`/`research-education`/`research-general`) dan
   `cite-apa7`/`write-academic-id` untuk format & gaya.

--- a/apps/agent-v2/agent/lib/store.ts
+++ b/apps/agent-v2/agent/lib/store.ts
@@ -68,20 +68,64 @@ export async function appendThreadEvent(input: {
   event: { type: string; data?: unknown };
 }): Promise<void> {
   const type = input.event.type;
-  const data = (input.event.data ?? {}) as { turnId?: unknown };
+  const data = (input.event.data ?? {}) as { turnId?: unknown; stepIndex?: unknown };
   const turnId = typeof data.turnId === "string" ? data.turnId : null;
+  // `step_index` di-lift ke kolom (Phase 3, fix C) → compaction baca GROUP BY kolom, bukan
+  // ekspresi JSON yang men-detoast payload. Null untuk event non-step (lifecycle/dll.).
+  const stepIndex = typeof data.stepIndex === "number" ? data.stepIndex : null;
   const sql = getSql();
   await sql`
     insert into chat_thread_events
-      (thread_id, owner_user_id, event_index, type, turn_id, payload, created_at)
+      (thread_id, owner_user_id, event_index, type, turn_id, step_index, payload, created_at)
     values
       (
         ${input.sessionId}, ${input.ownerUserId},
         (select coalesce(max(event_index), -1) + 1 from chat_thread_events where thread_id = ${input.sessionId}),
-        ${type}, ${turnId}, ${sql.json(input.event as never)}, ${Date.now()}
+        ${type}, ${turnId}, ${stepIndex}, ${sql.json(input.event as never)}, ${Date.now()}
       )
     on conflict (thread_id, event_index) do update
-      set payload = excluded.payload, type = excluded.type, turn_id = excluded.turn_id
+      set payload = excluded.payload, type = excluded.type, turn_id = excluded.turn_id,
+          step_index = excluded.step_index
+  `;
+}
+
+/**
+ * B-strip (Phase 6, deploy ATOMIC) — saat sebuah step selesai, kosongkan payload delta
+ * `*.appended` yang SUDAH disusul untuk step itu, sisakan hanya delta TERAKHIR per (type, turn,
+ * step). Hasilnya: teks final + reasoning final tetap UTUH (delta terakhir tak di-strip), tapi
+ * delta kumulatif besar di tengah (sumber O(n²) 32MB) jadi `{"stripped":true}` → at-rest KB.
+ *
+ * Baris TIDAK dihapus (event_index tak berubah) → cursor resume = max(event_index)+1 NOL berubah
+ * (event terakhir thread = lifecycle non-delta, selalu disimpan). Read-path (`listByThread`) sudah
+ * mem-filter delta tersusul, jadi payload-nya tak pernah dibaca → aman dikosongkan. Token-level
+ * realtime tetap dari stream durable eve (bukan tabel ini). 1 UPDATE/step.
+ *
+ * Idempoten (`payload->>'stripped' is null` → skip yang sudah di-strip saat step RE-RUN durable);
+ * EXISTS(later) = "ada delta tipe sama yang lebih baru" = tersusul. Di-`swallow` di hook. JANGAN
+ * pengaruhi idempotency-key billing `step.completed` (operasi terpisah).
+ */
+export async function stripSupersededDeltas(input: {
+  sessionId: string;
+  turnId: string;
+  stepIndex: number;
+}): Promise<void> {
+  const sql = getSql();
+  await sql`
+    update chat_thread_events e
+    set payload = ${sql.json({ stripped: true } as never)}
+    where e.thread_id = ${input.sessionId}
+      and e.turn_id = ${input.turnId}
+      and e.step_index = ${input.stepIndex}
+      and e.type in ('message.appended', 'reasoning.appended')
+      and e.payload ->> 'stripped' is null
+      and exists (
+        select 1 from chat_thread_events l
+        where l.thread_id = ${input.sessionId}
+          and l.turn_id = ${input.turnId}
+          and l.step_index = ${input.stepIndex}
+          and l.type = e.type
+          and l.event_index > e.event_index
+      )
   `;
 }
 

--- a/apps/agent-v2/agent/skills/deep-research/SKILL.md
+++ b/apps/agent-v2/agent/skills/deep-research/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Use when the user runs /deep or asks for a thorough, citation-verified research report. Gather context conversationally first, present a prose plan, confirm, then delegate literature search and counter-evidence to subagents and write a cited synthesis.
+description: Use when the user runs /deep or asks for a thorough, citation-verified research report. Gather context with ask_question first, present a prose plan, confirm via ask_question, then delegate literature search and counter-evidence to subagents and write a cited synthesis.
 ---
 
 # Deep research
@@ -7,33 +7,85 @@ description: Use when the user runs /deep or asks for a thorough, citation-verif
 Metodologi untuk menjawab pertanyaan riset secara mendalam dan jujur. Kamu (root)
 adalah orkestrator DAN penulis akhir. Alur di bawah adalah panduan, bukan loop kaku —
 gunakan penilaianmu, berhenti saat bukti sudah cukup, dan sampaikan ketidakpastian apa
-adanya. **Semua interaksi dengan user lewat PERCAKAPAN biasa** — tak ada kartu/tombol/form.
-Composer user selalu aktif; saat kamu bertanya, turn-mu selesai dan user menjawab di composer.
+adanya.
+
+**Klarifikasi & konfirmasi rencana** memakai tool built-in **`ask_question`** — user
+menjawab lewat kartu di atas composer (opsi) atau teks bebas di composer (`allowFreeform`).
+Setiap panggilan `ask_question` **mengakhiri turn-mu** sampai user menjawab; jangan
+menumpuk banyak pertanyaan dalam teks biasa lalu berharap user menjawab sekaligus.
 
 ## 1. Gali konteks dulu (JANGAN langsung membuat rencana)
 
 Saat `/deep` dimulai, JANGAN langsung menyusun rencana atau meriset. Pertama:
 
-- Beri tanggapan singkat yang menunjukkan kamu memahami topiknya (1-2 kalimat).
-- Ajukan **2-3 pertanyaan lanjutan** untuk mempersempit ruang lingkup: tujuan/penggunaan
-  hasil, batasan (rentang tahun, populasi, domain, geografi), kedalaman yang diinginkan,
-  definisi istilah yang ambigu, atau sudut pandang yang harus/ tak boleh disertakan.
-- Lalu **berhenti** (akhiri turn) dan tunggu jawaban user. Jangan meriset apa pun di tahap ini.
+- Beri tanggapan singkat yang menunjukkan kamu memahami topiknya (1-2 kalimat di teks).
+- Panggil **`ask_question`** untuk menggali konteks yang masih kurang. Satu panggilan per
+  turn — turn parkir sampai user menjawab.
 
-Bila pertanyaan user sudah sangat spesifik, cukup satu pertanyaan konfirmasi singkat —
-jangan memaksakan tiga.
+**Apa yang perlu digali** (pilih yang relevan, jangan memaksakan semuanya):
+
+- Tujuan/penggunaan hasil riset
+- Batasan: rentang tahun, populasi, domain, geografi
+- Kedalaman yang diinginkan (survey cepat vs tinjauan sistematis)
+- Definisi istilah yang ambigu
+- Sudut pandang yang harus / tak boleh disertakan
+
+**Cara memakai `ask_question`:**
+
+- **`prompt`**: satu pertanyaan jelas, spesifik, dalam bahasa user.
+- **`options`**: tawarkan 3-5 pilihan umum bila membantu mempersempit ruang lingkup (mis.
+  rentang tahun, jenis sumber, audiens). Setiap opsi punya `id` singkat + `label` ramah.
+- **`allowFreeform: true`** hampir selalu — user boleh menjawab di luar opsi lewat composer.
+- Bila topik user **sudah sangat spesifik**, satu `ask_question` konfirmasi singkat cukup
+  (mis. "Apakah fokus X sudah tepat, atau ada batasan lain?") — jangan memaksakan tiga
+  putaran.
+
+**Putaran lanjutan:** setelah user menjawab, evaluasi apakah konteks sudah cukup. Bila masih
+ada celah penting, panggil `ask_question` lagi (maks. 2-3 putaran total untuk gali konteks).
+Bila sudah cukup → langsung ke langkah 2. **Jangan meriset apa pun** sebelum rencana
+disetujui.
+
+Contoh opsi untuk pertanyaan ruang lingkup:
+
+```json
+{
+  "prompt": "Rentang tahun mana yang paling relevan untuk tinjauan ini?",
+  "options": [
+    { "id": "5y", "label": "5 tahun terakhir" },
+    { "id": "10y", "label": "10 tahun terakhir" },
+    { "id": "classic", "label": "Termasuk studi klasik/landmark" },
+    { "id": "open", "label": "Tanpa batas tahun khusus" }
+  ],
+  "allowFreeform": true
+}
+```
 
 ## 2. Sajikan rencana sebagai PROSA + minta konfirmasi
 
-Setelah user menjawab, susun rencana riset sebagai **teks deskriptif mengalir** (prosa),
+Setelah konteks cukup, susun rencana riset sebagai **teks deskriptif mengalir** (prosa),
 BUKAN daftar Q1-Q5 dan BUKAN form. Jelaskan dalam beberapa kalimat: apa yang akan kamu
 selidiki, sub-arah/aspek utama yang akan ditelusuri terpisah, jenis sumber yang dicari, dan
-bagaimana kamu akan memverifikasi. Lalu **minta konfirmasi lewat percakapan** ("Boleh saya
-mulai riset dengan rencana ini, atau ada yang ingin disesuaikan?") dan **berhenti**.
+bagaimana kamu akan memverifikasi.
 
-- Bila user minta revisi → perbarui rencana prosa sesuai masukannya, konfirmasi lagi.
-- Bila user membatalkan → hentikan, jangan riset.
-- Hanya setelah user menyetujui (mis. "ya", "lanjut", "boleh") → ke langkah 3.
+Lalu panggil **`ask_question`** untuk konfirmasi rencana — jangan hanya minta "ya/tidak"
+lewat teks tanpa tool:
+
+```json
+{
+  "prompt": "Boleh saya mulai riset dengan rencana di atas, atau ada yang ingin disesuaikan?",
+  "options": [
+    { "id": "proceed", "label": "Ya, lanjutkan riset", "style": "primary" },
+    { "id": "revise", "label": "Revisi rencana dulu" },
+    { "id": "cancel", "label": "Batalkan", "style": "danger" }
+  ],
+  "allowFreeform": true
+}
+```
+
+- Jawaban **proceed** / setara ("ya", "lanjut", "boleh") → langkah 3.
+- Jawaban **revise** atau teks bebas berisi masukan → perbarui rencana prosa, konfirmasi
+  lagi dengan `ask_question` (boleh opsi yang sama).
+- Jawaban **cancel** / batalkan → hentikan, jangan riset.
 
 ## 3. Mulai eksekusi (gerbang kuota) lalu delegasikan riset
 
@@ -92,5 +144,5 @@ demikian. Bila ingin pemeriksaan akhir atas draftmu, panggil `verify_citations` 
 ## Catatan
 
 - Berhenti saat bukti sudah cukup; jangan mencari tanpa henti.
-- Bila user ingin laporan disimpan sebagai dokumen, tawarkan `propose_artifact` (konfirmasi lewat
-  percakapan) setelah jawaban siap.
+- Bila user ingin laporan disimpan sebagai dokumen, tawarkan `propose_artifact` setelah
+  jawaban siap (konfirmasi lewat percakapan atau `ask_question` bila perlu).

--- a/apps/agent-v2/agent/tools/begin_deep_research.ts
+++ b/apps/agent-v2/agent/tools/begin_deep_research.ts
@@ -6,10 +6,10 @@ import { callerEmail, callerId, getServiceDb } from "../lib/tools.ts";
 
 /**
  * begin_deep_research — gerbang billing satu run `/deep` saat EKSEKUSI (bukan approval).
- * Menggantikan `propose_research_plan` (HITL terstruktur dibuang; plan kini prosa percakapan).
+ * Menggantikan `propose_research_plan` (plan kini prosa + konfirmasi via `ask_question`).
  *
  * Skill deep-research memanggil tool ini SEKALI, setelah user mengonfirmasi rencana lewat
- * percakapan dan TEPAT sebelum mulai mendelegasikan ke subagent. Ini titik commit alami satu
+ * `ask_question` dan TEPAT sebelum mulai mendelegasikan ke subagent. Ini titik commit alami satu
  * deep-run:
  * - GATE `requireEntitlement(feature:'deep_research', requiredPlan:'free')` — Free pakai kuota
  *   bulanan `deepResearchRuns` (plan.ts), bukan ditolak `subscription_required`. Blok = stop.
@@ -18,11 +18,11 @@ import { callerEmail, callerId, getServiceDb } from "../lib/tools.ts";
  *
  * Blok = return-union `{ ok:false, reason }` (model relay "kuota deep habis" lalu HENTIKAN —
  * JANGAN riset). Sukses = `{ ok:true }` → model lanjut delegasi subagent. TANPA `needsApproval`
- * (composer selalu aktif; konfirmasi rencana terjadi di percakapan, bukan kartu).
+ * (konfirmasi rencana terjadi via `ask_question`, bukan approval tool).
  */
 export default defineTool({
   description:
-    "Mulai eksekusi riset mendalam (deep research) untuk run ini. Panggil SEKALI setelah user mengonfirmasi rencana riset lewat percakapan, TEPAT sebelum mendelegasikan ke subagent. Mengunci kuota deep research; bila `{ ok:false }`, sampaikan alasannya ke user dan hentikan (jangan riset).",
+    "Mulai eksekusi riset mendalam (deep research) untuk run ini. Panggil SEKALI setelah user mengonfirmasi rencana riset lewat `ask_question`, TEPAT sebelum mendelegasikan ke subagent. Mengunci kuota deep research; bila `{ ok:false }`, sampaikan alasannya ke user dan hentikan (jangan riset).",
   inputSchema: z.object({}),
   async execute(_input, ctx) {
     const ownerUserId = callerId(ctx);

--- a/apps/agent-v2/agent/tools/delete_artifact.ts
+++ b/apps/agent-v2/agent/tools/delete_artifact.ts
@@ -1,20 +1,22 @@
 import { ArtifactService } from "@aqsha/services/artifact";
 import { defineTool } from "eve/tools";
+import { always } from "eve/tools/approval";
 import { z } from "zod";
 import { callerId, getServiceDb } from "../lib/tools.ts";
 
 /**
- * delete_artifact (Slice 6.5 → konfirmasi percakapan) — WRITE DESTRUKTIF. Soft-delete +
- * enqueue cleanup (lihat `ArtifactService.remove`). HANYA artifact workspace-scoped (assert di
- * service). WAJIB: tanya konfirmasi user lewat TEKS + tunggu jawaban sebelum memanggil tool ini —
- * eksekusi langsung menghapus (tak ada gerbang approval lain).
+ * delete_artifact (Slice 6.5) — WRITE DESTRUKTIF. Soft-delete + enqueue cleanup (lihat
+ * `ArtifactService.remove`). HANYA artifact workspace-scoped (assert di service).
+ * Gerbang HITL: `needsApproval: always()` → UI kartu konfirmasi di atas composer sebelum
+ * eksekusi (eve `input.requested` / `session.waiting`).
  */
 export default defineTool({
   description:
-    "Hapus sebuah dokumen/artifact milik user dari workspace-nya. WAJIB tanya konfirmasi user lewat percakapan dan tunggu jawabannya SEBELUM memanggil tool ini — penghapusan langsung berlaku.",
+    "Hapus sebuah dokumen/artifact milik user dari workspace-nya. Memerlukan persetujuan user di UI sebelum dijalankan — penghapusan langsung berlaku setelah disetujui.",
   inputSchema: z.object({
     artifactId: z.string().min(1).describe("Id artifact yang akan dihapus."),
   }),
+  needsApproval: always(),
   async execute(input, ctx) {
     const ownerUserId = callerId(ctx);
     return ArtifactService.remove(getServiceDb(), { ownerUserId, artifactId: input.artifactId });

--- a/apps/api-v2/src/routes/threads.ts
+++ b/apps/api-v2/src/routes/threads.ts
@@ -203,14 +203,15 @@ export const threads = new Elysia({ prefix: "/threads" })
     },
     { auth: true },
   )
-  // Handle-resume eve (continuationToken) dari KLIEN (`useAstraAgent onSessionChange`).
-  // Token KLIEN (ter-namespace sekali) — bukan `channel.continuationToken` server (ganda) →
-  // approval HITL `inputResponses` lintas-reload bisa di-`deliver`. Owner-gated di service.
+  // Handle-resume eve (continuationToken) — di-upsert SERVER-SIDE oleh proxy-tee respons
+  // create/continue eve (`web-v2 app/eve/v1/[...path]/route.ts`), BUKAN klien. Token dari
+  // respons create-POST = ber-namespace TUNGGAL (`eve:<uuid>`); RACE-PROOF (insert-if-absent,
+  // owner-guard di repo) karena respons create (202) bisa mendahului hook `session.started`.
   .post(
-    "/:id/session",
+    "/:id/session-token",
     ({ ownerUserId, params, body }) => {
       const { db } = getDb();
-      return ThreadService.saveContinuation(db, {
+      return ThreadService.upsertContinuationToken(db, {
         ownerUserId,
         threadId: params.id,
         continuationToken: body.continuationToken,

--- a/apps/api-v2/src/routes/threads.ts
+++ b/apps/api-v2/src/routes/threads.ts
@@ -76,6 +76,17 @@ export const threads = new Elysia({ prefix: "/threads" })
       }),
     },
   )
+  // Thread `streaming` termuda milik caller (Layer C2) — klien memakai ini untuk menemukan
+  // sessionId turn PERTAMA segera setelah `send()` (eve baru surface sessionId di akhir turn),
+  // lalu bump URL → refresh saat menyusun plan tak kehilangan thread. Static route → di atas `/:id`.
+  .get(
+    "/recent-active",
+    ({ ownerUserId, query }) => {
+      const { db } = getDb();
+      return ThreadService.recentActive(db, ownerUserId, query.since);
+    },
+    { auth: true, query: t.Object({ since: t.Optional(t.Numeric()) }) },
+  )
   .get(
     "/:id",
     ({ ownerUserId, params }) => {
@@ -100,13 +111,15 @@ export const threads = new Elysia({ prefix: "/threads" })
   // di-assert dulu (thread milik caller), lalu list by thread (urut seq).
   .get(
     "/:id/events",
-    async ({ ownerUserId, params }) => {
+    async ({ ownerUserId, params, query }) => {
       const { db } = getDb();
       await ThreadService.assertOwner(db, ownerUserId, params.id);
-      const items = await EventService.listByThread(db, params.id);
+      // `afterIndex` → fetch INCREMENTAL (hanya delta) untuk reconciliation klien; tanpa
+      // itu → seluruh log (cold-start snapshot saat reload).
+      const items = await EventService.listByThread(db, params.id, query.afterIndex);
       return { items };
     },
-    { auth: true },
+    { auth: true, query: t.Object({ afterIndex: t.Optional(t.Numeric()) }) },
   )
   // Sumber riset yang dipersist tool Astra (Slice 6.4) — panel Sources. Ownership
   // di-assert dulu (thread milik caller), lalu list by thread.

--- a/apps/api-v2/src/workers/index.ts
+++ b/apps/api-v2/src/workers/index.ts
@@ -12,6 +12,7 @@ import { type AccountDeletionJob, processAccountDeletion } from "./account-delet
 import { type ArtifactCleanupJob, processArtifactCleanup } from "./artifact-cleanup.worker";
 import { type FeedHydrationJob, processFeedHydration } from "./feed-hydration.worker";
 import { type PaperEnrichmentJob, processPaperEnrichment } from "./paper-enrichment.worker";
+import { type ReconcileStaleJob, processReconcileStale } from "./reconcile-stale.worker";
 import { type ThreadTitleJob, processThreadTitle } from "./thread-title.worker";
 import { type UrlIngestionJob, processUrlIngestion } from "./url-ingestion.worker";
 
@@ -46,6 +47,11 @@ const workers = [
     connection,
     concurrency: CONCURRENCY,
   }),
+  // Reconciler zombie (Phase 5): concurrency 1 — sweep berkala ringan, tak perlu paralel.
+  new Worker<ReconcileStaleJob>(CHAT_QUEUES.reconcileStale, processReconcileStale, {
+    connection,
+    concurrency: 1,
+  }),
   new Worker<AccountDeletionJob>(ACCOUNT_QUEUES.accountDeletion, processAccountDeletion, {
     connection,
     concurrency: 2,
@@ -66,6 +72,15 @@ registerRepeatable(FEED_QUEUES.feedHydration, { kind: "cycle" }, {
 })
   .then(() => logger.info({ pattern: "0 */3 * * *" }, "cron_feed_hydration_registered"))
   .catch((err) => logger.error({ err }, "cron_feed_hydration_register_failed"));
+
+// Cron reconciler zombie (Phase 5, fix E) — tiap jam tandai thread `streaming` basi → `failed`
+// + event terminal sintetik (composer unlock). Idempotent by jobId.
+registerRepeatable(CHAT_QUEUES.reconcileStale, { kind: "cycle" }, {
+  pattern: "0 * * * *",
+  jobId: "reconcile-stale-threads-cycle",
+})
+  .then(() => logger.info({ pattern: "0 * * * *" }, "cron_reconcile_stale_registered"))
+  .catch((err) => logger.error({ err }, "cron_reconcile_stale_register_failed"));
 
 async function shutdown() {
   logger.info("workers_shutting_down");

--- a/apps/api-v2/src/workers/reconcile-stale.worker.ts
+++ b/apps/api-v2/src/workers/reconcile-stale.worker.ts
@@ -1,0 +1,16 @@
+import { ThreadService } from "@aqsha/services";
+import type { Job } from "bullmq";
+import { getDb } from "../clients/db";
+
+export type ReconcileStaleJob = { kind: "cycle" };
+
+/**
+ * Worker `reconcile-stale-threads` (Phase 5, fix E) — cron berkala menandai thread "zombie"
+ * (`status='streaming'` yang turn-nya mati mid-stream tanpa event terminal, mis. ENOSPC / restart)
+ * → append `turn.failed` sintetik + `status='failed'` supaya `isStreamActive` klien false (composer
+ * unlock). Idempoten (guard event-recency di repo + `onConflictDoNothing`).
+ */
+export async function processReconcileStale(_job: Job<ReconcileStaleJob>): Promise<void> {
+  const { db } = getDb();
+  await ThreadService.reconcileStaleStreaming(db);
+}

--- a/apps/web-v2/app/eve/v1/[...path]/route.ts
+++ b/apps/web-v2/app/eve/v1/[...path]/route.ts
@@ -42,6 +42,38 @@ const DROP_RESPONSE_HEADERS = new Set([
   "keep-alive",
 ]);
 
+// api-v2 origin untuk upsert continuation token (proxy-tee Phase 2). Server-side; reuse
+// NEXT_PUBLIC_API_URL (sama dgn klien) kecuali ada override server-only `API_ORIGIN`.
+const API_ORIGIN =
+  process.env.API_ORIGIN ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+/**
+ * Tee token continuation dari respons create/continue eve (`POST /eve/v1/session*` → JSON kecil
+ * `{sessionId, continuationToken}`; token TUNGGAL `eve:<uuid>` = nilai yang dipakai live). Upsert
+ * RACE-PROOF ke api-v2 (bearer sama) supaya jawab HITL `inputResponses` + follow-up lintas-reload
+ * punya token andal TANPA bergantung klien menangkap boundary `session.waiting` (akar fix B).
+ * Fire-and-forget + idempoten: kegagalan ditolerir (continue-POST berikutnya menulis token sama).
+ */
+function teeContinuationToken(buf: Buffer, authorization: string | null): void {
+  if (!authorization) return;
+  try {
+    const json = JSON.parse(buf.toString("utf8")) as {
+      sessionId?: unknown;
+      continuationToken?: unknown;
+    };
+    const sessionId = typeof json.sessionId === "string" ? json.sessionId : null;
+    const token = typeof json.continuationToken === "string" ? json.continuationToken : null;
+    if (!sessionId || !token) return;
+    void fetch(`${API_ORIGIN}/threads/${encodeURIComponent(sessionId)}/session-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization },
+      body: JSON.stringify({ continuationToken: token }),
+    }).catch(() => {});
+  } catch {
+    // Bukan JSON (mustahil di jalur ini: guard content-type) → abaikan.
+  }
+}
+
 async function proxy(req: NextRequest): Promise<Response> {
   const origin = new URL(AGENT_ORIGIN);
   const transport = origin.protocol === "https:" ? https : http;
@@ -67,6 +99,7 @@ async function proxy(req: NextRequest): Promise<Response> {
         headers,
       },
       (res) => {
+        const status = res.statusCode ?? 502;
         const resHeaders = new Headers();
         for (const [key, value] of Object.entries(res.headers)) {
           if (value === undefined || DROP_RESPONSE_HEADERS.has(key.toLowerCase())) continue;
@@ -74,11 +107,34 @@ async function proxy(req: NextRequest): Promise<Response> {
         }
         resHeaders.set("x-accel-buffering", "no"); // nginx: jangan buffer (eve sudah set; tegaskan)
 
+        // Tee token dari respons create/continue eve (`POST /eve/v1/session*` → JSON kecil).
+        // Stream turn = GET (content-type x-ndjson) → guard `application/json` melewatkannya, jadi
+        // buffering hanya menyentuh respons mungil ini, tak pernah stream long-lived.
+        const isTokenPost =
+          req.method === "POST" &&
+          req.nextUrl.pathname.startsWith("/eve/v1/session") &&
+          status >= 200 &&
+          status < 300 &&
+          String(res.headers["content-type"] ?? "").includes("application/json");
+        if (isTokenPost) {
+          const chunks: Buffer[] = [];
+          res.on("data", (c: Buffer) => chunks.push(c));
+          res.on("end", () => {
+            const out = Buffer.concat(chunks);
+            teeContinuationToken(out, req.headers.get("authorization"));
+            resolve(
+              new Response(out, { status, statusText: res.statusMessage, headers: resHeaders }),
+            );
+          });
+          res.on("error", reject);
+          return;
+        }
+
         // `Readable.toWeb` mengalirkan chunk incremental + menjaga backpressure; abort
         // klien → `cancel` web-stream → `res` di-destroy → koneksi upstream tertutup.
         resolve(
           new Response(Readable.toWeb(res) as ReadableStream<Uint8Array>, {
-            status: res.statusCode ?? 502,
+            status,
             statusText: res.statusMessage,
             headers: resHeaders,
           }),

--- a/apps/web-v2/app/eve/v1/[...path]/route.ts
+++ b/apps/web-v2/app/eve/v1/[...path]/route.ts
@@ -1,0 +1,100 @@
+import type { NextRequest } from "next/server";
+import http from "node:http";
+import https from "node:https";
+import { Readable } from "node:stream";
+
+/**
+ * Proxy streaming eve (`/eve/v1/*`) → app `@aqsha/agent-v2`.
+ *
+ * KENAPA `node:http`/`node:https` LANGSUNG, bukan global `fetch` (undici): `fetch` Node
+ * memberi `headersTimeout`/`bodyTimeout` default **300 dtk** — waktu maksimum antar-chunk
+ * body. Stream eve long-lived bisa DIAM jauh lebih lama dari itu (mis. gap subagent `/deep`
+ * terverifikasi 5,7 mnt > 300 dtk tanpa satu byte pun) → undici meng-abort body upstream →
+ * koneksi mati → progres BEKU sampai user refresh. Soket `node:http` tak punya idle-timeout
+ * default (`setTimeout(0)`) → koneksi long-lived bertahan selama turn berjalan.
+ *
+ * Body upstream dialirkan APA ADANYA & incremental (`Readable.toWeb`, jaga backpressure) →
+ * event tiba real-time. Same-origin tetap terjaga (bearer Clerk diteruskan; channel eve yang
+ * verifikasi; `/eve/v1` di-exclude dari Clerk middleware di `proxy.ts`).
+ *
+ * Menggantikan Next `rewrites()` (yang mem-buffer stream long-lived) DAN proxy berbasis
+ * `fetch` (yang kena idle-timeout undici di atas).
+ */
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const AGENT_ORIGIN = process.env.AGENT_ORIGIN ?? "http://localhost:4317";
+
+// Header hop-by-hop yang JANGAN diteruskan (dihitung ulang oleh transport).
+const DROP_REQUEST_HEADERS = new Set([
+  "host",
+  "connection",
+  "content-length",
+  "transfer-encoding",
+  "keep-alive",
+]);
+const DROP_RESPONSE_HEADERS = new Set([
+  "content-length",
+  "content-encoding",
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+]);
+
+async function proxy(req: NextRequest): Promise<Response> {
+  const origin = new URL(AGENT_ORIGIN);
+  const transport = origin.protocol === "https:" ? https : http;
+
+  const headers: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    if (!DROP_REQUEST_HEADERS.has(key.toLowerCase())) headers[key] = value;
+  });
+
+  // Body eve = JSON kecil (create/continue) → buffer; GET/HEAD (stream) tanpa body.
+  const body =
+    req.method === "GET" || req.method === "HEAD" ? undefined : Buffer.from(await req.arrayBuffer());
+  if (body) headers["content-length"] = String(body.byteLength);
+
+  return await new Promise<Response>((resolve, reject) => {
+    const upstream = transport.request(
+      {
+        protocol: origin.protocol,
+        hostname: origin.hostname,
+        port: origin.port || undefined,
+        method: req.method,
+        path: `${req.nextUrl.pathname}${req.nextUrl.search}`,
+        headers,
+      },
+      (res) => {
+        const resHeaders = new Headers();
+        for (const [key, value] of Object.entries(res.headers)) {
+          if (value === undefined || DROP_RESPONSE_HEADERS.has(key.toLowerCase())) continue;
+          resHeaders.set(key, Array.isArray(value) ? value.join(", ") : value);
+        }
+        resHeaders.set("x-accel-buffering", "no"); // nginx: jangan buffer (eve sudah set; tegaskan)
+
+        // `Readable.toWeb` mengalirkan chunk incremental + menjaga backpressure; abort
+        // klien → `cancel` web-stream → `res` di-destroy → koneksi upstream tertutup.
+        resolve(
+          new Response(Readable.toWeb(res) as ReadableStream<Uint8Array>, {
+            status: res.statusCode ?? 502,
+            statusText: res.statusMessage,
+            headers: resHeaders,
+          }),
+        );
+      },
+    );
+
+    upstream.setTimeout(0); // TANPA idle-timeout: stream long-lived boleh diam bermenit-menit
+    upstream.on("error", reject);
+    // Abort klien (tombol stop / unmount / refresh) → tutup koneksi upstream.
+    req.signal.addEventListener("abort", () => upstream.destroy(), { once: true });
+
+    if (body) upstream.write(body);
+    upstream.end();
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;

--- a/apps/web-v2/features/thread-experience/components/eve-chat-thread-surface.tsx
+++ b/apps/web-v2/features/thread-experience/components/eve-chat-thread-surface.tsx
@@ -13,6 +13,7 @@ import { useThread, useThreadEvents, useThreadMessages } from "@/features/thread
 import { ChatSurface } from "@/features/threads/components/chat-surface";
 import {
   chatMessagesToTimeline,
+  type IndexedEvent,
   isStreamActive,
   recoverPending,
   streamIndexFromEvents,
@@ -61,15 +62,25 @@ export function EveChatThreadSurface({
 }) {
   // Event stream eve persisted (1:1) = sumber timeline reload + cursor resume. `useThreadMessages`
   // = fallback thread LAMA (pra-event). `useThread` = resume handle (continuationToken) + pending.
-  const eventsQuery = useThreadEvents(threadId ?? "", Boolean(threadId));
-  const messagesQuery = useThreadMessages(threadId ?? "", Boolean(threadId));
   const threadDetail = useThread(threadId ?? "", Boolean(threadId));
+  const eventsQuery = useThreadEvents(threadId ?? "", {
+    enabled: Boolean(threadId),
+    poll: (latestEvents) =>
+      isStreamActive(latestEvents) ||
+      (latestEvents.length === 0 && threadDetail.data?.status === "streaming"),
+  });
+  const messagesQuery = useThreadMessages(threadId ?? "", Boolean(threadId));
   const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
+  const streamActive = useMemo(
+    () => isStreamActive(events) || (events.length === 0 && threadDetail.data?.status === "streaming"),
+    [events, threadDetail.data?.status],
+  );
 
-  // Log mentah = SATU sumber timeline (event-level overlay di ChatSurface). Tak ada lagi
-  // splitActiveTurn: turn aktif & selesai di log yang sama; resume melanjutkan dari ekornya.
-  const initialEvents = useMemo<EveAgentReducerEvent[]>(
-    () => events.map((e) => e.payload as EveAgentReducerEvent),
+  // Snapshot persisted ber-`event_index` = sumber timeline + dasar gabung by-index di
+  // ChatSurface. Tak ada splitActiveTurn: turn aktif & selesai di log yang sama; resume
+  // melanjutkan dari ekornya (`liveStartIndex`).
+  const initialEvents = useMemo<IndexedEvent[]>(
+    () => events.map((e) => ({ index: e.eventIndex, event: e.payload as EveAgentReducerEvent })),
     [events],
   );
   const legacy = useMemo(
@@ -108,7 +119,7 @@ export function EveChatThreadSurface({
           }}
           initialEvents={initialEvents}
           legacyHistory={legacy}
-          streamActive={isStreamActive(events)}
+          streamActive={streamActive}
           pendingUserMessage={recoverPending(
             events,
             threadDetail.data?.pendingUserMessage,

--- a/apps/web-v2/features/thread-experience/components/eve-chat-thread-surface.tsx
+++ b/apps/web-v2/features/thread-experience/components/eve-chat-thread-surface.tsx
@@ -63,12 +63,10 @@ export function EveChatThreadSurface({
   // Event stream eve persisted (1:1) = sumber timeline reload + cursor resume. `useThreadMessages`
   // = fallback thread LAMA (pra-event). `useThread` = resume handle (continuationToken) + pending.
   const threadDetail = useThread(threadId ?? "", Boolean(threadId));
-  const eventsQuery = useThreadEvents(threadId ?? "", {
-    enabled: Boolean(threadId),
-    poll: (latestEvents) =>
-      isStreamActive(latestEvents) ||
-      (latestEvents.length === 0 && threadDetail.data?.status === "streaming"),
-  });
+  // Snapshot SEKALI (cold-load). Turn in-flight di-stream live oleh resume stream di
+  // `ChatSurface` (`use-thread-resume`), bukan poll. `streamActive` (status + event terakhir
+  // snapshot) menentukan apakah resume dibuka; settle → invalidate → snapshot refetch.
+  const eventsQuery = useThreadEvents(threadId ?? "", Boolean(threadId));
   const messagesQuery = useThreadMessages(threadId ?? "", Boolean(threadId));
   const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
   const streamActive = useMemo(

--- a/apps/web-v2/features/threads/api.ts
+++ b/apps/web-v2/features/threads/api.ts
@@ -9,6 +9,28 @@ import { queryKeys, unwrap } from "@/lib/api-query";
 import type { ChatMessage, ChatThread, ChatThreadEvent, ResearchSource } from "./types";
 
 const LIST_PAGE_SIZE = 30;
+const ACTIVE_THREAD_EVENTS_POLL_MS = 2_000;
+
+/** Tipe delta kumulatif eve — hanya yang TERAKHIR per (type, turn, step) yang berarti. */
+const STREAMING_DELTA_TYPES = new Set(["message.appended", "reasoning.appended"]);
+
+/**
+ * Buang delta streaming yang sudah disusul dari log terakumulasi klien (jaga `prev` mungil
+ * di akumulasi poll). Kunci = (type, turn_id, stepIndex); simpan index tertinggi. Array masuk
+ * sudah urut `event_index` (poll selalu `> afterIndex`), jadi yang terakhir = terbaru.
+ */
+function compactThreadEvents(events: ChatThreadEvent[]): ChatThreadEvent[] {
+  const keyOf = (e: ChatThreadEvent) =>
+    `${e.type}:${e.turnId}:${String((e.payload as { data?: { stepIndex?: unknown } })?.data?.stepIndex)}`;
+  const lastAt = new Map<string, number>();
+  events.forEach((e, i) => {
+    if (STREAMING_DELTA_TYPES.has(e.type)) lastAt.set(keyOf(e), i);
+  });
+  if (lastAt.size === 0) return events;
+  return events.filter(
+    (e, i) => !STREAMING_DELTA_TYPES.has(e.type) || lastAt.get(keyOf(e)) === i,
+  );
+}
 
 /** List thread (infinite/keyset, DESC aktivitas). */
 export function useThreadsList() {
@@ -55,20 +77,53 @@ export function useThreadMessages(id: string, enabled = true) {
 
 /**
  * Event stream eve mentah per thread (1:1) — di-replay lewat `defaultMessageReducer` untuk
- * merekonstruksi timeline PENUH (tool/skill/subagent/HITL) saat reload. Snapshot SEKALI di
- * mount (TANPA poll): turn in-flight di-resume lewat durable stream eve (`useThreadResume`,
- * `ClientSession.stream`) — token streaming sejati, bukan poll granular. Refetch dipicu saat
- * resume settle (invalidate di chat-surface) → turn baru selesai pindah ke history.
- * `staleTime: 0` supaya invalidate selalu ambil event terbaru.
+ * merekonstruksi timeline PENUH (tool/skill/subagent/HITL) saat reload. Default = snapshot
+ * saat mount. Thread yang masih aktif boleh menyalakan polling pendek sebagai fallback durable
+ * untuk mengejar event persisted bila resume-stream putus/tertahan; polling berhenti begitu
+ * predicate active mengembalikan false. `staleTime: 0` supaya invalidate selalu ambil event
+ * terbaru.
  */
-export function useThreadEvents(id: string, enabled = true) {
+export function useThreadEvents(
+  id: string,
+  options: boolean | {
+    enabled?: boolean;
+    poll?: boolean | ((events: readonly ChatThreadEvent[]) => boolean);
+  } = true,
+) {
   const api = useApi();
+  const qc = useQueryClient();
+  const enabled = typeof options === "boolean" ? options : (options.enabled ?? true);
+  const poll = typeof options === "boolean" ? false : (options.poll ?? false);
   return useQuery({
     queryKey: queryKeys.threads.events(id),
     enabled,
     staleTime: 0,
-    queryFn: async () =>
-      (unwrap(await api.threads({ id }).events.get()) as { items: ChatThreadEvent[] }).items,
+    refetchInterval: (query) => {
+      if (!poll) return false;
+      const events = (query.state.data ?? []) as ChatThreadEvent[];
+      const shouldPoll = typeof poll === "function" ? poll(events) : poll;
+      return shouldPoll ? ACTIVE_THREAD_EVENTS_POLL_MS : false;
+    },
+    refetchIntervalInBackground: Boolean(poll),
+    // Akumulasi INCREMENTAL: poll mengejar hanya delta (`afterIndex` = event_index terakhir)
+    // lalu append — run `/deep` bisa ribuan event, re-fetch penuh tiap 2 dtk itu berat & jadi
+    // sumber "beku" (heavy reduce). Cold mount (cache kosong) → full snapshot. Delta kosong →
+    // kembalikan ref lama (tanpa re-render). Server meng-compact delta kumulatif (lihat
+    // `ChatThreadEventRepo.listByThread`); klien JUGA compact tiap append supaya `prev` tetap
+    // mungil — poll mengembalikan delta-terakhir step aktif tiap tick di index baru, tanpa
+    // dedup `prev` akan tumbuh O(n²) lagi.
+    queryFn: async () => {
+      const prev = (qc.getQueryData(queryKeys.threads.events(id)) ?? []) as ChatThreadEvent[];
+      const afterIndex = prev.length > 0 ? prev[prev.length - 1].eventIndex : undefined;
+      const { items } = unwrap(
+        await api.threads({ id }).events.get({
+          query: afterIndex !== undefined ? { afterIndex } : {},
+        }),
+      ) as { items: ChatThreadEvent[] };
+      if (afterIndex === undefined) return items;
+      if (items.length === 0) return prev;
+      return compactThreadEvents([...prev, ...items]);
+    },
   });
 }
 

--- a/apps/web-v2/features/threads/api.ts
+++ b/apps/web-v2/features/threads/api.ts
@@ -9,28 +9,6 @@ import { queryKeys, unwrap } from "@/lib/api-query";
 import type { ChatMessage, ChatThread, ChatThreadEvent, ResearchSource } from "./types";
 
 const LIST_PAGE_SIZE = 30;
-const ACTIVE_THREAD_EVENTS_POLL_MS = 2_000;
-
-/** Tipe delta kumulatif eve — hanya yang TERAKHIR per (type, turn, step) yang berarti. */
-const STREAMING_DELTA_TYPES = new Set(["message.appended", "reasoning.appended"]);
-
-/**
- * Buang delta streaming yang sudah disusul dari log terakumulasi klien (jaga `prev` mungil
- * di akumulasi poll). Kunci = (type, turn_id, stepIndex); simpan index tertinggi. Array masuk
- * sudah urut `event_index` (poll selalu `> afterIndex`), jadi yang terakhir = terbaru.
- */
-function compactThreadEvents(events: ChatThreadEvent[]): ChatThreadEvent[] {
-  const keyOf = (e: ChatThreadEvent) =>
-    `${e.type}:${e.turnId}:${String((e.payload as { data?: { stepIndex?: unknown } })?.data?.stepIndex)}`;
-  const lastAt = new Map<string, number>();
-  events.forEach((e, i) => {
-    if (STREAMING_DELTA_TYPES.has(e.type)) lastAt.set(keyOf(e), i);
-  });
-  if (lastAt.size === 0) return events;
-  return events.filter(
-    (e, i) => !STREAMING_DELTA_TYPES.has(e.type) || lastAt.get(keyOf(e)) === i,
-  );
-}
 
 /** List thread (infinite/keyset, DESC aktivitas). */
 export function useThreadsList() {
@@ -77,53 +55,23 @@ export function useThreadMessages(id: string, enabled = true) {
 
 /**
  * Event stream eve mentah per thread (1:1) — di-replay lewat `defaultMessageReducer` untuk
- * merekonstruksi timeline PENUH (tool/skill/subagent/HITL) saat reload. Default = snapshot
- * saat mount. Thread yang masih aktif boleh menyalakan polling pendek sebagai fallback durable
- * untuk mengejar event persisted bila resume-stream putus/tertahan; polling berhenti begitu
- * predicate active mengembalikan false. `staleTime: 0` supaya invalidate selalu ambil event
- * terbaru.
+ * merekonstruksi timeline PENUH (tool/skill/subagent/HITL) saat reload. **Snapshot SEKALI**
+ * saat mount (cold-load); turn in-flight di-stream live token-demi-token oleh resume stream
+ * (`use-thread-resume`, satu-satunya sumber live), BUKAN poll 2 dtk (dibuang — redundan dgn
+ * stream durable eve + sumber query berat). `staleTime: 0` + invalidate (resume settle / turn
+ * selesai, lihat `chat-surface`) → ambil snapshot terbaru yang kini memuat event terminal →
+ * `isStreamActive` false → composer unlock. Route masih dukung `afterIndex` (backfill manual
+ * bila perlu), tapi tak ada lagi loop poll yang men-detoast log tiap tick.
  */
-export function useThreadEvents(
-  id: string,
-  options: boolean | {
-    enabled?: boolean;
-    poll?: boolean | ((events: readonly ChatThreadEvent[]) => boolean);
-  } = true,
-) {
+export function useThreadEvents(id: string, enabled = true) {
   const api = useApi();
-  const qc = useQueryClient();
-  const enabled = typeof options === "boolean" ? options : (options.enabled ?? true);
-  const poll = typeof options === "boolean" ? false : (options.poll ?? false);
   return useQuery({
     queryKey: queryKeys.threads.events(id),
     enabled,
     staleTime: 0,
-    refetchInterval: (query) => {
-      if (!poll) return false;
-      const events = (query.state.data ?? []) as ChatThreadEvent[];
-      const shouldPoll = typeof poll === "function" ? poll(events) : poll;
-      return shouldPoll ? ACTIVE_THREAD_EVENTS_POLL_MS : false;
-    },
-    refetchIntervalInBackground: Boolean(poll),
-    // Akumulasi INCREMENTAL: poll mengejar hanya delta (`afterIndex` = event_index terakhir)
-    // lalu append — run `/deep` bisa ribuan event, re-fetch penuh tiap 2 dtk itu berat & jadi
-    // sumber "beku" (heavy reduce). Cold mount (cache kosong) → full snapshot. Delta kosong →
-    // kembalikan ref lama (tanpa re-render). Server meng-compact delta kumulatif (lihat
-    // `ChatThreadEventRepo.listByThread`); klien JUGA compact tiap append supaya `prev` tetap
-    // mungil — poll mengembalikan delta-terakhir step aktif tiap tick di index baru, tanpa
-    // dedup `prev` akan tumbuh O(n²) lagi.
-    queryFn: async () => {
-      const prev = (qc.getQueryData(queryKeys.threads.events(id)) ?? []) as ChatThreadEvent[];
-      const afterIndex = prev.length > 0 ? prev[prev.length - 1].eventIndex : undefined;
-      const { items } = unwrap(
-        await api.threads({ id }).events.get({
-          query: afterIndex !== undefined ? { afterIndex } : {},
-        }),
-      ) as { items: ChatThreadEvent[] };
-      if (afterIndex === undefined) return items;
-      if (items.length === 0) return prev;
-      return compactThreadEvents([...prev, ...items]);
-    },
+    queryFn: async () =>
+      (unwrap(await api.threads({ id }).events.get({ query: {} })) as { items: ChatThreadEvent[] })
+        .items,
   });
 }
 

--- a/apps/web-v2/features/threads/components/chat-surface.tsx
+++ b/apps/web-v2/features/threads/components/chat-surface.tsx
@@ -13,13 +13,23 @@ import { useApi } from "@/lib/api-client";
 import { queryKeys } from "@/lib/api-query";
 import { panelBodyPaddingClass, threadTranscriptColumnClass } from "@/lib/panel-surface";
 import { cn } from "@/lib/utils";
-import type { EveAgentReducerEvent } from "eve/react";
 import { useSendStatus, useThreadSources, useThreadsList } from "../api";
-import { eventsToTimeline, mergeStreamEventLogs, type TimelineMessage } from "../lib/eve-timeline";
+import {
+  acceptsFreeformText,
+  buildOrderedLog,
+  eventsToTimeline,
+  type IndexedEvent,
+  isApprovalRequest,
+  isStreamActive,
+  pendingInputRequests,
+  type InputResponsePayload,
+  type TimelineMessage,
+} from "../lib/eve-timeline";
 import { useAstraAgent } from "../lib/use-astra-agent";
 import { useThreadResume } from "../lib/use-thread-resume";
 import { threadTitle, type ResearchSource } from "../types";
 import { type ComposerNotice, Composer, type RecentThread } from "./composer";
+import { InputRequestPrompt } from "./input-request-prompt";
 import { MessageList } from "./message-list";
 
 /** Teks user terakhir di timeline (untuk dedup bubble pending lintas-reload). */
@@ -112,11 +122,11 @@ export function ChatSurface({
   ambientWorkspaceId = null,
 }: {
   initialSession?: { sessionId: string; streamIndex: number; continuationToken?: string | null };
-  /** Event log mentah persisted (1:1) — sumber timeline tunggal (digabung level event). */
-  initialEvents?: readonly EveAgentReducerEvent[];
+  /** Event log persisted (ber-`event_index`) — snapshot timeline + dasar gabung by-index. */
+  initialEvents?: readonly IndexedEvent[];
   /** Timeline thread PRA-event (teks `chat_messages` saja) → prefix read-only, kosong utk thread normal. */
   legacyHistory?: TimelineMessage[];
-  /** `isStreamActive(events)` saat mount → ada turn in-flight yang perlu di-resume. */
+  /** Event/status persisted menunjukkan ada turn in-flight yang perlu di-resume/di-poll. */
   streamActive?: boolean;
   /** Recovery pesan terkirim yang turn-nya belum settle (baseline template). */
   pendingUserMessage?: string | null;
@@ -131,7 +141,7 @@ export function ChatSurface({
   const sessionId = agent.session?.sessionId ?? initialSession?.sessionId ?? null;
 
   // Resume turn in-flight lintas-refresh: buka ULANG durable stream eve dari ekor turn aktif
-  // (`startIndex = max(event_index)+1`). Aktif HANYA saat reload masuk ke turn berjalan
+  // (`startIndex = max(event_index)+1`). Aktif HANYA saat persisted state masih berjalan
   // (`streamActive`) DAN tab ini tak sedang mengirim (`agent.status === "ready"`).
   const resume = useThreadResume({
     sessionId,
@@ -139,23 +149,31 @@ export function ChatSurface({
     enabled: streamActive && agent.status === "ready",
   });
   const resuming = resume.resuming;
-  const busy = agent.status === "submitted" || agent.status === "streaming" || resuming;
   const notice = blockedNotice(sendStatus.data);
   const blocked = notice !== null;
 
-  // Overlay swap (port template): saat resume aktif (atau punya buffer resume & tab ini tak kirim),
-  // base = prefix persisted ++ ekor resume (disjoint by `startIndex`). Selain itu, gabung event live
-  // (`agent.events`) ke prefix di level event (dedup). Reduce SEKALI → satu daftar pesan.
-  // ponytail: overlay = concat; invarian `useThreadEvents` tak di-refetch selagi resuming (chat-surface
-  // invalidate hanya saat settle) → disjoint. Pakai mergeStreamEventLogs di sini bila race refetch muncul.
+  // Posisi awal ekor live (= event_index turn aktif pertama), DIKUNCI di mount: cocok dengan
+  // `startIndex` resume DAN dengan offset `agent.events` (eve store baca streamIndex sekali).
+  const [liveStartIndex] = useState(() => initialSession?.streamIndex ?? 0);
+
+  // Base = snapshot persisted + ekor LIVE (resume cold-load ATAU `agent.events` warm-send),
+  // digabung by-`event_index` (O(n), overlap poll↔resume aman). Reduce SEKALI → satu daftar pesan.
   const hasResumeOverlay = resuming || (resume.resumedEvents.length > 0 && agent.events.length === 0);
+  const live = hasResumeOverlay ? resume.resumedEvents : agent.events;
   const base = useMemo(
-    () =>
-      hasResumeOverlay
-        ? [...initialEvents, ...resume.resumedEvents]
-        : mergeStreamEventLogs(initialEvents, agent.events),
-    [hasResumeOverlay, initialEvents, resume.resumedEvents, agent.events],
+    () => buildOrderedLog(initialEvents, live, liveStartIndex),
+    [initialEvents, live, liveStartIndex],
   );
+
+  // `busy` (loading + gate composer/HITL) diturunkan dari BASE (sudah memuat event live resume),
+  // bukan dari `streamActive` prop yang lag di belakang poll persisted. Efek: kartu HITL muncul
+  // SEKETIKA turn parkir (`session.waiting`/`input.requested` di base), tanpa jeda ≤2 dtk.
+  // `agent.status` tetap perlu untuk awal warm-send (base masih kosong sebelum event pertama).
+  const busy =
+    agent.status === "submitted" ||
+    agent.status === "streaming" ||
+    resuming ||
+    isStreamActive(base);
   // Reduce event log → timeline SEKALI per perubahan log/busy (bukan tiap render — keystroke
   // composer, toggle status, dll. tak memicu replay reducer + merge O(n) ulang).
   const messages = useMemo(
@@ -166,6 +184,12 @@ export function ChatSurface({
       ),
     [legacyHistory, base, busy, pendingUserMessage],
   );
+  const hitlRequests = useMemo(
+    () => (!busy ? pendingInputRequests(base) : []),
+    [base, busy],
+  );
+  const hasHitlPrompt = hitlRequests.length > 0;
+  const hasApprovalPrompt = hitlRequests.some(isApprovalRequest);
   const isEmpty = messages.length === 0 && !busy;
 
   // Resume settle → events/sources/detail di-refetch supaya turn yang baru selesai pindah ke
@@ -180,6 +204,19 @@ export function ChatSurface({
     }
     prevResuming.current = resuming;
   }, [resuming, sessionId, qc]);
+
+  // Poll fallback bisa melihat event terminal/parked sebelum resume stream selesai. Saat state
+  // persisted berubah dari active → settled, sinkronkan detail/sidebar/sources tanpa menunggu
+  // stream hook.
+  const prevStreamActive = useRef(false);
+  useEffect(() => {
+    if (prevStreamActive.current && !streamActive && sessionId) {
+      qc.invalidateQueries({ queryKey: queryKeys.threads.sources(sessionId) });
+      qc.invalidateQueries({ queryKey: queryKeys.threads.detail(sessionId) });
+      qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+    }
+    prevStreamActive.current = streamActive;
+  }, [streamActive, sessionId, qc]);
 
   // Retry (Slice 6.8): simpan teks turn terakhir; saat error, kembalikan ke composer
   // (resend = turn baru; turn gagal tanpa step.completed = tak ada debit → no re-charge).
@@ -221,8 +258,30 @@ export function ChatSurface({
     sendTurn(text);
   };
 
+  const respondToInput = (response: InputResponsePayload) => {
+    void agent.send({ inputResponses: [response] }).catch(() => {});
+  };
+
+  // Kirim dari composer. Bila ada pertanyaan freeform yang sedang parkir (BUKAN approval),
+  // jawab sebagai `inputResponse` terstruktur — bukan turn baru (yang membuat `ask_question`
+  // tercatat "ignored" + pesan ekstra). Approval sengaja TIDAK diauto-route: mengetik = lanjut
+  // tanpa menyetujui (eve auto-deny) — aksi destruktif wajib lewat tombol eksplisit di kartu.
+  const onComposerSend = (payload: { text: string; clientContext?: string[] }) => {
+    const text = payload.text.trim();
+    const freeformTargets = text
+      ? hitlRequests.filter((r) => !isApprovalRequest(r) && acceptsFreeformText(r))
+      : [];
+    if (freeformTargets.length > 0) {
+      void agent
+        .send({ inputResponses: freeformTargets.map((r) => ({ requestId: r.requestId, text })) })
+        .catch(() => {});
+      return;
+    }
+    sendTurn(payload.text, payload.clientContext);
+  };
+
   const wiring: ComposerWiring = {
-    onSend: (payload) => sendTurn(payload.text, payload.clientContext),
+    onSend: onComposerSend,
     onStop: () => agent.stop(),
     busy,
     disabled: blocked,
@@ -258,6 +317,9 @@ export function ChatSurface({
         <ConversationScrollButton />
       </Conversation>
       <div className={cn(threadTranscriptColumnClass, "pt-2.5 pb-4")}>
+        {hasHitlPrompt ? (
+          <InputRequestPrompt requests={hitlRequests} onRespond={respondToInput} />
+        ) : null}
         <Composer
           onSend={(p) => wiring.onSend(p)}
           onStop={wiring.onStop}
@@ -267,7 +329,13 @@ export function ChatSurface({
           threadId={wiring.threadId}
           errorDraft={wiring.errorDraft}
           ambientWorkspaceId={wiring.ambientWorkspaceId}
-          placeholder="Tulis pesan untuk Astra…"
+          placeholder={
+            hasApprovalPrompt
+              ? "Pilih opsi di atas untuk melanjutkan…"
+              : hasHitlPrompt
+                ? "Ketik jawaban atau pilih opsi di atas…"
+                : "Tulis pesan untuk Astra…"
+          }
         />
       </div>
     </div>

--- a/apps/web-v2/features/threads/components/chat-surface.tsx
+++ b/apps/web-v2/features/threads/components/chat-surface.tsx
@@ -17,11 +17,12 @@ import { useSendStatus, useThreadSources, useThreadsList } from "../api";
 import {
   acceptsFreeformText,
   buildOrderedLog,
-  eventsToTimeline,
+  evePartsToTimeline,
   type IndexedEvent,
   isApprovalRequest,
   isStreamActive,
-  pendingInputRequests,
+  pendingRequestsFromMessages,
+  reduceEventsToMessageData,
   type InputResponsePayload,
   type TimelineMessage,
 } from "../lib/eve-timeline";
@@ -165,28 +166,33 @@ export function ChatSurface({
     [initialEvents, live, liveStartIndex],
   );
 
-  // `busy` (loading + gate composer/HITL) diturunkan dari BASE (sudah memuat event live resume),
-  // bukan dari `streamActive` prop yang lag di belakang poll persisted. Efek: kartu HITL muncul
-  // SEKETIKA turn parkir (`session.waiting`/`input.requested` di base), tanpa jeda ≤2 dtk.
-  // `agent.status` tetap perlu untuk awal warm-send (base masih kosong sebelum event pertama).
+  // `busy` (loading + gate composer/HITL) diturunkan dari BASE (snapshot ⊕ ekor live: resume
+  // stream cold-load atau `agent.events` warm-send), bukan dari `streamActive` prop. Efek: kartu
+  // HITL muncul SEKETIKA turn parkir (`session.waiting`/`input.requested` masuk base — refresh
+  // ke turn parkir langsung dari snapshot karena `session.*` dipersist 1:1; turn yang berjalan
+  // saat refresh → resume menarik boundary). `agent.status` tetap perlu untuk awal warm-send
+  // (base masih kosong sebelum event pertama).
   const busy =
     agent.status === "submitted" ||
     agent.status === "streaming" ||
     resuming ||
     isStreamActive(base);
-  // Reduce event log → timeline SEKALI per perubahan log/busy (bukan tiap render — keystroke
-  // composer, toggle status, dll. tak memicu replay reducer + merge O(n) ulang).
+  // Reduce event log → pesan SEKALI per perubahan `base` (lewat `defaultMessageReducer`).
+  // Dipakai bersama oleh timeline + scan HITL → tak ada replay reducer ganda.
+  const reduced = useMemo(() => reduceEventsToMessageData(base), [base]);
+  // Timeline di-derive SEKALI per perubahan pesan/busy (bukan tiap render — keystroke
+  // composer, toggle status, dll. tak memicu reduce + merge O(n) ulang).
   const messages = useMemo(
     () =>
       appendPendingUserMessage(
-        [...legacyHistory, ...eventsToTimeline(base, busy)],
+        [...legacyHistory, ...evePartsToTimeline(reduced.messages, busy)],
         pendingUserMessage,
       ),
-    [legacyHistory, base, busy, pendingUserMessage],
+    [legacyHistory, reduced, busy, pendingUserMessage],
   );
   const hitlRequests = useMemo(
-    () => (!busy ? pendingInputRequests(base) : []),
-    [base, busy],
+    () => (!busy ? pendingRequestsFromMessages(reduced.messages) : []),
+    [reduced, busy],
   );
   const hasHitlPrompt = hitlRequests.length > 0;
   const hasApprovalPrompt = hitlRequests.some(isApprovalRequest);
@@ -205,9 +211,10 @@ export function ChatSurface({
     prevResuming.current = resuming;
   }, [resuming, sessionId, qc]);
 
-  // Poll fallback bisa melihat event terminal/parked sebelum resume stream selesai. Saat state
-  // persisted berubah dari active → settled, sinkronkan detail/sidebar/sources tanpa menunggu
-  // stream hook.
+  // Snapshot persisted (di-refetch saat invalidate) bisa berubah active → settled tanpa lewat
+  // siklus `resuming` (mis. refresh ke turn yang sudah parkir). Saat itu, sinkronkan
+  // detail/sidebar/sources. Redundan dgn efek `prevResuming` untuk jalur resume, tapi murah +
+  // menutup jalur non-resume.
   const prevStreamActive = useRef(false);
   useEffect(() => {
     if (prevStreamActive.current && !streamActive && sessionId) {
@@ -221,6 +228,10 @@ export function ChatSurface({
   // Retry (Slice 6.8): simpan teks turn terakhir; saat error, kembalikan ke composer
   // (resend = turn baru; turn gagal tanpa step.completed = tak ada debit → no re-charge).
   const [lastSent, setLastSent] = useState("");
+  // Kegagalan `agent.send()` (mis. eve menolak saat status≠ready akibat double-click/race, token
+  // kedaluwarsa, continuationToken hilang). `agent.error` HANYA terisi dari gagal stream, BUKAN
+  // dari promise send yang reject → tanpa ini jawaban HITL/pesan hilang sunyi tanpa umpan balik.
+  const [sendError, setSendError] = useState<string | null>(null);
 
   // Sumber riset per-turn (research_sources, di-map via turnId) → InlineSources di bawah
   // jawaban turn yang menghasilkannya. Refetch saat turn selesai (gated !busy).
@@ -240,12 +251,14 @@ export function ChatSurface({
   // `clearPending` saat kirim gagal. eve men-stream user message-nya sendiri (`message.received`).
   const sendTurn = (text: string, clientContext?: string[]) => {
     setLastSent(text);
+    setSendError(null);
     if (sessionId) {
       void api.threads({ id: sessionId }).pending.post({ message: text }).catch(() => {});
     }
     void agent
       .send({ message: text, ...(clientContext ? { clientContext } : {}) })
       .catch(() => {
+        setSendError("Gagal mengirim pesan. Coba lagi.");
         if (sessionId) void api.threads({ id: sessionId }).pending.delete().catch(() => {});
       });
   };
@@ -259,7 +272,10 @@ export function ChatSurface({
   };
 
   const respondToInput = (response: InputResponsePayload) => {
-    void agent.send({ inputResponses: [response] }).catch(() => {});
+    setSendError(null);
+    void agent.send({ inputResponses: [response] }).catch(() => {
+      setSendError("Gagal mengirim jawaban. Coba lagi.");
+    });
   };
 
   // Kirim dari composer. Bila ada pertanyaan freeform yang sedang parkir (BUKAN approval),
@@ -272,9 +288,12 @@ export function ChatSurface({
       ? hitlRequests.filter((r) => !isApprovalRequest(r) && acceptsFreeformText(r))
       : [];
     if (freeformTargets.length > 0) {
+      setSendError(null);
       void agent
         .send({ inputResponses: freeformTargets.map((r) => ({ requestId: r.requestId, text })) })
-        .catch(() => {});
+        .catch(() => {
+          setSendError("Gagal mengirim jawaban. Coba lagi.");
+        });
       return;
     }
     sendTurn(payload.text, payload.clientContext);
@@ -309,8 +328,10 @@ export function ChatSurface({
               sourcesByTurn={sourcesByTurn}
               onRegenerate={regenerate}
             />
-            {agent.error ? (
-              <p className="text-red-500 text-sm">{agent.error.message || "Terjadi kesalahan."}</p>
+            {agent.error || sendError ? (
+              <p className="text-red-500 text-sm">
+                {agent.error?.message || sendError || "Terjadi kesalahan."}
+              </p>
             ) : null}
           </div>
         </ConversationContent>

--- a/apps/web-v2/features/threads/components/elapsed-label.tsx
+++ b/apps/web-v2/features/threads/components/elapsed-label.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Shimmer } from "@/components/ai-elements/shimmer";
+
+/**
+ * Label "bekerja" dengan elapsed yang berdetak (muncul setelah 10 dtk). Riset mendalam yang
+ * menunggu subagent task-mode bisa diam bermenit-menit tanpa event (child stream tak di-stream
+ * ke induk: `childSessionId` 0 baris); timer yang jalan meyakinkan "masih bekerja", bukan beku.
+ * Terisolasi → hanya komponen ini yang re-render tiap detik.
+ *
+ * Dipakai blok "Proses" (`message-list`) DAN row subagent-call yang running (`tool-row`).
+ * ponytail: hitung dari mount (`Date.now()`), bukan `createdAt` event aktif pertama — reset saat
+ * refresh tapi tetap menunjukkan gerak; presisi lintas-reload = upgrade opsional.
+ */
+export function ElapsedLabel({ base }: { base: string }) {
+  const [start] = useState(() => Date.now());
+  const [now, setNow] = useState(start);
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+  const secs = Math.floor((now - start) / 1000);
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  const label = secs < 10 ? `${base}…` : `${base}… ${m > 0 ? `${m}m ` : ""}${s}s`;
+  return (
+    <Shimmer as="span" className="font-medium">
+      {label}
+    </Shimmer>
+  );
+}

--- a/apps/web-v2/features/threads/components/input-request-prompt.tsx
+++ b/apps/web-v2/features/threads/components/input-request-prompt.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { isApprovalRequest, type InputResponsePayload, type PendingInputRequest } from "../lib/eve-timeline";
+
+type InputOption = NonNullable<PendingInputRequest["options"]>[number];
+
+/**
+ * Copy approval ter-lokalisasi per tool. eve meng-generate prompt approval dalam bahasa
+ * Inggris (`Approve tool call: <toolName>`) + label "Yes"/"No" dan membocorkan nama tool
+ * mentah, jadi kita ganti dengan copy Indonesia di sini. Tool tak dikenal → `DEFAULT_APPROVAL`.
+ */
+const APPROVAL_COPY: Record<
+  string,
+  { prompt: string; approve: string; deny: string; danger?: boolean }
+> = {
+  delete_artifact: {
+    prompt: "Hapus dokumen ini? Tindakan ini permanen dan tidak bisa dibatalkan.",
+    approve: "Hapus",
+    deny: "Batal",
+    danger: true,
+  },
+};
+
+const DEFAULT_APPROVAL = { prompt: "Setujui tindakan ini?", approve: "Setujui", deny: "Tolak" } as const;
+
+function optionVariant(style?: "default" | "primary" | "danger") {
+  switch (style) {
+    case "danger":
+      return "destructive" as const;
+    case "primary":
+      return "default" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+/**
+ * Kartu HITL gaya Cursor — dipasang di atas composer saat eve parkir di `input.requested`
+ * (approval tool atau `ask_question`). Approval pakai copy ter-lokalisasi; `ask_question`
+ * pakai prompt/opsi yang ditulis model apa adanya.
+ */
+export function InputRequestPrompt({
+  requests,
+  onRespond,
+}: {
+  requests: readonly PendingInputRequest[];
+  onRespond: (response: InputResponsePayload) => void;
+}) {
+  if (requests.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 pb-2 animate-in slide-in-from-bottom-2 duration-200">
+      {requests.map((request) => (
+        <InputRequestCard key={request.requestId} request={request} onRespond={onRespond} />
+      ))}
+    </div>
+  );
+}
+
+function InputRequestCard({
+  request,
+  onRespond,
+}: {
+  request: PendingInputRequest;
+  onRespond: (response: InputResponsePayload) => void;
+}) {
+  const copy = isApprovalRequest(request) ? (APPROVAL_COPY[request.toolName] ?? DEFAULT_APPROVAL) : null;
+
+  const prompt = copy?.prompt ?? request.prompt;
+  const options: readonly InputOption[] = copy
+    ? [
+        { id: "approve", label: copy.approve, style: copy.danger ? "danger" : "primary" },
+        { id: "deny", label: copy.deny, style: "default" },
+      ]
+    : (request.options ?? []);
+
+  // Hint teks bebas hanya untuk pertanyaan (bukan approval) — user boleh jawab di composer.
+  const showFreeformHint =
+    copy === null && (request.allowFreeform || request.display === "text" || options.length === 0);
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border/85 bg-card/95 px-3.5 py-3 shadow-sm",
+        "animate-in fade-in slide-in-from-bottom-1 duration-200",
+      )}
+    >
+      <p className="text-sm font-medium leading-5 text-foreground">{prompt}</p>
+      {options.length > 0 ? (
+        <div className="mt-2.5 flex flex-wrap gap-2">
+          {options.map((opt) => (
+            <div key={opt.id} className="flex min-w-0 flex-col gap-0.5">
+              <Button
+                type="button"
+                size="sm"
+                variant={optionVariant(opt.style)}
+                onClick={() => onRespond({ requestId: request.requestId, optionId: opt.id })}
+              >
+                {opt.label}
+              </Button>
+              {opt.description ? (
+                <span className="max-w-48 px-0.5 text-[10px] leading-4 text-muted-foreground">
+                  {opt.description}
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {showFreeformHint ? (
+        <p className="mt-2 text-[11px] leading-4 text-muted-foreground">
+          Atau ketik jawaban di composer di bawah.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web-v2/features/threads/components/message-list.tsx
+++ b/apps/web-v2/features/threads/components/message-list.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@/components/ui/spinner";
 import type { TimelineMessage, TimelinePart } from "../lib/eve-timeline";
 import type { ResearchSource } from "../types";
 import { ChatArtifactCard } from "./chat-artifact-card";
+import { ElapsedLabel } from "./elapsed-label";
 import { InlineSources } from "./sources-panel";
 import { ToolRow } from "./tool-row";
 
@@ -241,29 +242,6 @@ function MessageActions({ text, onRegenerate }: { text: string; onRegenerate?: (
         </button>
       ) : null}
     </div>
-  );
-}
-
-/**
- * Label "bekerja" dengan elapsed yang berdetak (muncul setelah 10 dtk). Riset mendalam yang
- * menunggu subagent task-mode bisa diam bermenit-menit tanpa event; timer yang jalan meyakinkan
- * "masih bekerja", bukan beku. Terisolasi → hanya komponen ini yang re-render tiap detik.
- */
-function ElapsedLabel({ base }: { base: string }) {
-  const [start] = useState(() => Date.now());
-  const [now, setNow] = useState(start);
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
-  }, []);
-  const secs = Math.floor((now - start) / 1000);
-  const m = Math.floor(secs / 60);
-  const s = secs % 60;
-  const label = secs < 10 ? `${base}…` : `${base}… ${m > 0 ? `${m}m ` : ""}${s}s`;
-  return (
-    <Shimmer as="span" className="font-medium">
-      {label}
-    </Shimmer>
   );
 }
 

--- a/apps/web-v2/features/threads/components/message-list.tsx
+++ b/apps/web-v2/features/threads/components/message-list.tsx
@@ -17,8 +17,9 @@ import { ToolRow } from "./tool-row";
  * Timeline pesan (simplifikasi eve-chat-template) — render DATAR per pesan, mengikuti urutan
  * `defaultMessageReducer`. User = bubble; assistant = reasoning → blok "Proses" collapsible
  * (tool generik) → jawaban → artifact → sumber inline (per `turnId`) → aksi. TAK ADA grouping
- * run berfase / kartu HITL / kartu verifikasi-subagen (HITL = percakapan; verify+subagen =
- * tool-row generik). `/deep` multi-turn = beberapa pesan asisten berurutan — itu wajar.
+ * run berfase / kartu verifikasi-subagen (verify+subagen = tool-row generik). HITL approval /
+ * ask_question yang MENUNGGU jawaban dirender sebagai kartu di atas composer
+ * (`InputRequestPrompt`); jejak yang sudah diresolve tetap tampil sebagai tool-row.
  */
 export function MessageList({
   messages,
@@ -168,11 +169,7 @@ function ProcessBlock({
     prevStreaming.current = streaming;
   }, [streaming]);
   const open = override ?? streaming;
-  const label = streaming
-    ? "Sedang bekerja…"
-    : toolSteps > 0
-      ? `Selesai · ${toolSteps} langkah`
-      : "Proses";
+  const settledLabel = toolSteps > 0 ? `Selesai · ${toolSteps} langkah` : "Proses";
 
   return (
     <Collapsible className="min-w-0" open={open} onOpenChange={(next) => setOverride(next)}>
@@ -180,12 +177,12 @@ function ProcessBlock({
         {streaming ? (
           <>
             <Spinner className="size-3.5 shrink-0 text-primary" />
-            <Shimmer as="span" className="font-medium">
-              {label}
-            </Shimmer>
+            {/* Riset mendalam menunggu subagent (task mode) bisa diam bermenit-menit tanpa
+                event; elapsed yang berdetak meyakinkan "masih bekerja", bukan beku. */}
+            <ElapsedLabel base="Sedang bekerja" />
           </>
         ) : (
-          <span className="font-medium text-muted-foreground">{label}</span>
+          <span className="font-medium text-muted-foreground">{settledLabel}</span>
         )}
         <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
       </CollapsibleTrigger>
@@ -244,6 +241,29 @@ function MessageActions({ text, onRegenerate }: { text: string; onRegenerate?: (
         </button>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Label "bekerja" dengan elapsed yang berdetak (muncul setelah 10 dtk). Riset mendalam yang
+ * menunggu subagent task-mode bisa diam bermenit-menit tanpa event; timer yang jalan meyakinkan
+ * "masih bekerja", bukan beku. Terisolasi → hanya komponen ini yang re-render tiap detik.
+ */
+function ElapsedLabel({ base }: { base: string }) {
+  const [start] = useState(() => Date.now());
+  const [now, setNow] = useState(start);
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+  const secs = Math.floor((now - start) / 1000);
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  const label = secs < 10 ? `${base}…` : `${base}… ${m > 0 ? `${m}m ` : ""}${s}s`;
+  return (
+    <Shimmer as="span" className="font-medium">
+      {label}
+    </Shimmer>
   );
 }
 

--- a/apps/web-v2/features/threads/components/tool-row.tsx
+++ b/apps/web-v2/features/threads/components/tool-row.tsx
@@ -20,6 +20,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import type { ToolRow as ToolRowData, ToolRowModel, ToolStatus } from "../lib/eve-timeline";
+import { ElapsedLabel } from "./elapsed-label";
 
 // Ikon semantik per tool (kosmetik — data: `model.name` selalu ada). Switch mengembalikan
 // JSX konkret (bukan komponen dinamis) supaya lolos react-compiler. Tool tak dikenal → wrench.
@@ -123,6 +124,10 @@ export function ToolRow({ model }: { model: ToolRowModel }) {
   }, [model.isRunning]);
   const open = override ?? model.isRunning;
 
+  // Subagent task-mode (kind "subagent-call") berjalan di child-session sendiri yang event-nya
+  // TIDAK di-forward ke stream induk (childSessionId 0 baris) → induk diam 2–3 mnt = "frozen" semu.
+  // Elapsed berdetak (M:SS) menggantikan rasa beku selagi subagent bekerja. Tool biasa = Shimmer.
+  const isSubagentRunning = model.kind === "subagent-call" && model.isRunning;
   const header = (
     <span className={cn("flex min-w-0 items-start gap-1.5 leading-5", toneClass(model.status))}>
       <ToolStatusIcon
@@ -132,7 +137,13 @@ export function ToolRow({ model }: { model: ToolRowModel }) {
         className="mt-0.5 size-3.5 shrink-0"
       />
       <span className="min-w-0">
-        {model.isRunning ? <Shimmer as="span">{model.title}</Shimmer> : <span>{model.title}</span>}
+        {isSubagentRunning ? (
+          <ElapsedLabel base={model.title} />
+        ) : model.isRunning ? (
+          <Shimmer as="span">{model.title}</Shimmer>
+        ) : (
+          <span>{model.title}</span>
+        )}
         {liveQuery ? <span className="text-muted-foreground"> · {liveQuery}</span> : null}
       </span>
     </span>

--- a/apps/web-v2/features/threads/lib/eve-timeline.test.ts
+++ b/apps/web-v2/features/threads/lib/eve-timeline.test.ts
@@ -2,9 +2,13 @@ import type { EveAgentReducerEvent } from "eve/react";
 import { describe, expect, it } from "vitest";
 import type { ChatThreadEvent } from "../types";
 import {
+  acceptsFreeformText,
+  buildOrderedLog,
   eventsToTimeline,
+  type IndexedEvent,
+  isApprovalRequest,
   isStreamActive,
-  mergeStreamEventLogs,
+  pendingInputRequests,
   recoverPending,
   reduceEventsToMessageData,
   streamIndexFromEvents,
@@ -65,6 +69,21 @@ describe("isStreamActive", () => {
     ];
     expect(isStreamActive(events)).toBe(false);
   });
+  it.each([
+    "session.waiting",
+    "session.completed",
+    "session.failed",
+    "turn.completed",
+    "turn.failed",
+    "input.requested",
+  ])("%s → settle/parked", (type) => {
+    expect(
+      isStreamActive([
+        ev(0, "turn.started", { turnId: "turn1" }),
+        ev(1, type, { turnId: "turn1" }),
+      ]),
+    ).toBe(false);
+  });
 });
 
 describe("streamIndexFromEvents", () => {
@@ -90,31 +109,51 @@ describe("streamIndexFromEvents", () => {
   });
 });
 
-describe("mergeStreamEventLogs", () => {
-  it("streamed kosong → kembalikan salinan events apa adanya", () => {
-    const base = payloads([ev(0, "turn.started", { turnId: "t" })]);
-    const merged = mergeStreamEventLogs(base, []);
-    expect(merged).toEqual(base);
+describe("buildOrderedLog", () => {
+  /** Snapshot persisted → IndexedEvent[] (index = event_index = posisi stream eve). */
+  const indexed = (rows: readonly ReturnType<typeof ev>[]): IndexedEvent[] =>
+    rows.map((r) => ({ index: r.eventIndex, event: r.payload as Parameters<typeof eventsToTimeline>[0][number] }));
+
+  it("live kosong → snapshot apa adanya", () => {
+    const snap = indexed([ev(0, "turn.started", { turnId: "t" })]);
+    expect(buildOrderedLog(snap, [], 1)).toEqual(snap.map((s) => s.event));
   });
-  it("event live baru di-append di belakang prefix persisted", () => {
-    const base = payloads([
+  it("ekor live di-append di belakang snapshot", () => {
+    const snap = indexed([
       ev(0, "turn.started", { turnId: "t" }),
       ev(1, "message.received", { turnId: "t", message: "halo" }),
     ]);
-    const streamed = payloads([
+    const live = payloads([
       ev(2, "message.completed", { turnId: "t", stepIndex: 0, finishReason: "stop", message: "jawab" }),
       ev(3, "turn.completed", { turnId: "t" }),
     ]);
-    const merged = mergeStreamEventLogs(base, streamed);
-    expect(merged.length).toBe(4);
+    expect(buildOrderedLog(snap, live, 2).length).toBe(4);
   });
-  it("prefix yang ter-refetch (overlap JSON identik) di-dedup → tak dobel", () => {
-    const a = ev(0, "turn.started", { turnId: "t" });
-    const b = ev(1, "message.received", { turnId: "t", message: "halo" });
-    const c = ev(2, "turn.completed", { turnId: "t" });
-    // streamed mengandung ULANG a,b (persisted) + c baru → hasil tetap 3, bukan 5.
-    const merged = mergeStreamEventLogs(payloads([a, b]), payloads([a, b, c]));
-    expect(merged.length).toBe(3);
+  it("overlap poll↔resume di-dedup by event_index → tak dobel", () => {
+    // snapshot ter-poll sampai 0..3; resume mulai dari index 2 (overlap 2,3) + 4,5 baru.
+    const snap = indexed([
+      ev(0, "turn.started", { turnId: "t" }),
+      ev(1, "message.received", { turnId: "t", message: "halo" }),
+      ev(2, "actions.requested", { turnId: "t", stepIndex: 0, actions: [] }),
+      ev(3, "action.result", { turnId: "t", stepIndex: 0, status: "completed", result: {} }),
+    ]);
+    const resumed = payloads([
+      ev(2, "actions.requested", { turnId: "t", stepIndex: 0, actions: [] }),
+      ev(3, "action.result", { turnId: "t", stepIndex: 0, status: "completed", result: {} }),
+      ev(4, "message.completed", { turnId: "t", stepIndex: 0, finishReason: "stop", message: "jawab" }),
+      ev(5, "turn.completed", { turnId: "t" }),
+    ]);
+    const merged = buildOrderedLog(snap, resumed, 2);
+    expect(merged.length).toBe(6); // 0,1,2,3,4,5 — bukan 8
+  });
+  it("tahan-gap: index snapshot hilang tetap terurut, ekor live menyambung", () => {
+    const snap = indexed([
+      ev(0, "turn.started", { turnId: "t" }),
+      ev(1, "message.received", { turnId: "t", message: "x" }),
+      ev(3, "message.completed", { turnId: "t", message: "y" }), // index 2 hilang
+    ]);
+    const merged = buildOrderedLog(snap, payloads([ev(4, "turn.completed", { turnId: "t" })]), 4);
+    expect(merged.length).toBe(4); // 0,1,3,4 terurut
   });
 });
 
@@ -182,5 +221,121 @@ describe("recoverPending", () => {
   });
   it("ada event settled SETELAH createdAt → null (turn selesai, bubble basi)", () => {
     expect(recoverPending(settledAfter, "hai", 1)).toBeNull();
+  });
+});
+
+describe("pendingInputRequests", () => {
+  const turnId = "turn1";
+  // Gerbang approval delete_artifact: prompt + label Inggris yang di-generate eve.
+  const approvalRequested = ev(2, "input.requested", {
+    turnId,
+    stepIndex: 0,
+    requests: [
+      {
+        requestId: "req1",
+        action: { kind: "tool-call", callId: "c1", toolName: "delete_artifact", input: { artifactId: "a1" } },
+        prompt: "Approve tool call: delete_artifact",
+        options: [
+          { id: "approve", label: "Yes" },
+          { id: "deny", label: "No" },
+        ],
+        display: "confirmation",
+        allowFreeform: false,
+      },
+    ],
+  });
+  // action.result setelah approval disetujui → tool jalan → output-available.
+  const resultDone = ev(3, "action.result", {
+    turnId,
+    stepIndex: 0,
+    status: "completed",
+    result: { kind: "tool-result", callId: "c1", toolName: "delete_artifact", output: { ok: true } },
+  });
+
+  it("parkir di approval-requested → 1 pending + bawa toolName (utk lokalisasi)", () => {
+    const pending = pendingInputRequests(payloads([ev(0, "turn.started", { turnId }), approvalRequested]));
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.requestId).toBe("req1");
+    expect(pending[0]?.toolName).toBe("delete_artifact");
+    expect(isApprovalRequest(pending[0]!)).toBe(true);
+  });
+
+  // INTI fix P0: setelah action.result, `inputResponse` TAK pernah di-set di event-log server,
+  // tapi state part jadi output-available → JANGAN lagi tampak pending (kartu basi).
+  it("setelah action.result (resolved) → 0 pending (tak muncul lagi)", () => {
+    const pending = pendingInputRequests(
+      payloads([ev(0, "turn.started", { turnId }), approvalRequested, resultDone]),
+    );
+    expect(pending).toHaveLength(0);
+  });
+
+  it("ask_question (opsi + allowFreeform) terdeteksi non-approval & boleh teks bebas", () => {
+    const pending = pendingInputRequests(
+      payloads([
+        ev(0, "turn.started", { turnId }),
+        ev(2, "input.requested", {
+          turnId,
+          stepIndex: 0,
+          requests: [
+            {
+              requestId: "q1",
+              action: { kind: "tool-call", callId: "c2", toolName: "ask_question", input: {} },
+              prompt: "Rentang tahun?",
+              options: [{ id: "5y", label: "5 tahun terakhir" }],
+              allowFreeform: true,
+            },
+          ],
+        }),
+      ]),
+    );
+    expect(pending).toHaveLength(1);
+    expect(isApprovalRequest(pending[0]!)).toBe(false);
+    expect(acceptsFreeformText(pending[0]!)).toBe(true);
+  });
+
+  /** ask_question TAK pernah emit action.result; resolusinya = turn berikutnya dimulai. */
+  function askQuestionTurn(turnStartIdx: number, t: string, requestId: string, callId: string) {
+    return [
+      ev(turnStartIdx, "turn.started", { turnId: t }),
+      ev(turnStartIdx + 1, "input.requested", {
+        turnId: t,
+        stepIndex: 0,
+        requests: [
+          {
+            requestId,
+            action: { kind: "tool-call", callId, toolName: "ask_question", input: {} },
+            prompt: `Q ${requestId}`,
+            options: [{ id: "a", label: "A" }],
+            allowFreeform: true,
+          },
+        ],
+      }),
+      ev(turnStartIdx + 2, "turn.completed", { turnId: t }),
+    ];
+  }
+
+  // INTI bug issue-2: pertanyaan turn lama TANPA action.result + ada turn baru → TIDAK pending.
+  it("ask_question turn lama + turn baru setelahnya → 0 pending (anti kartu basi)", () => {
+    const pending = pendingInputRequests(
+      payloads([
+        ...askQuestionTurn(0, "turn_0", "q0", "c0"),
+        ev(3, "turn.started", { turnId: "turn_1" }),
+        ev(4, "message.completed", { turnId: "turn_1", stepIndex: 0, message: "Selesai." }),
+        ev(5, "turn.completed", { turnId: "turn_1" }),
+      ]),
+    );
+    expect(pending).toHaveLength(0);
+  });
+
+  // Replika screenshot: 3 pertanyaan di 3 turn → HANYA yang terakhir pending, tidak menumpuk.
+  it("3 ask_question lintas turn → hanya pertanyaan turn TERAKHIR (tidak menumpuk)", () => {
+    const pending = pendingInputRequests(
+      payloads([
+        ...askQuestionTurn(0, "turn_0", "q0", "c0"),
+        ...askQuestionTurn(3, "turn_1", "q1", "c1"),
+        ...askQuestionTurn(6, "turn_2", "q2", "c2"),
+      ]),
+    );
+    expect(pending.map((p) => p.requestId)).toEqual(["q2"]);
   });
 });

--- a/apps/web-v2/features/threads/lib/eve-timeline.ts
+++ b/apps/web-v2/features/threads/lib/eve-timeline.ts
@@ -277,7 +277,14 @@ export function acceptsFreeformText(
 export function pendingInputRequests(
   events: readonly EveAgentReducerEvent[],
 ): PendingInputRequest[] {
-  const { messages } = reduceEventsToMessageData(events);
+  return pendingRequestsFromMessages(reduceEventsToMessageData(events).messages);
+}
+
+/** Scan pesan ter-reduce untuk request HITL parkir. Dipakai langsung saat `messages`
+ *  sudah di-reduce (hindari reduce ganda dgn `eventsToTimeline`). */
+export function pendingRequestsFromMessages(
+  messages: readonly EveMessage[],
+): PendingInputRequest[] {
   let last: EveMessage | undefined;
   for (const m of messages) if (m.role === "assistant") last = m;
   if (!last) return [];
@@ -330,10 +337,11 @@ const SETTLED_OR_PARKED_LAST = new Set([...SETTLED_EVENT_TYPES, "input.requested
  * - selain itu (`actions.requested`/`action.result`/`step.*`/`reasoning.*`/`message.*`/
  *   `subagent.*`/`turn.started`) → masih eksekusi → aktif.
  *
- * Dipakai (a) menyalakan poll endpoint events (progress in-flight terlihat setelah refresh),
+ * Dipakai (a) memutuskan membuka resume stream (turn in-flight terlihat setelah refresh),
  * (b) gate indikator live + lock composer (`resuming`). Turn berurutan (eve serial per
- * session) → event terakhir mencerminkan state turn terbaru. (`session.*` tak dipersist,
- * jadi `turn.completed`/`input.requested` adalah penanda terakhir yang tersimpan.)
+ * session) → event terakhir mencerminkan state turn terbaru. (`session.*` DIPERSIST 1:1 —
+ * lihat hook proyeksi `"*"` + DB; `session.waiting` parkir HITL = penanda terakhir tersimpan,
+ * jadi resume yang menariknya bersih → `isStreamActive` false → composer unlock.)
  *
  * Catatan: turn yang MACET (proses mati tanpa `turn.completed`) tetap tampak aktif →
  * poll sampai user pindah thread; reconciler server-side adalah peningkatannya.

--- a/apps/web-v2/features/threads/lib/eve-timeline.ts
+++ b/apps/web-v2/features/threads/lib/eve-timeline.ts
@@ -14,6 +14,7 @@ import type {
   EveAgentReducerEvent,
   EveDynamicToolPart,
   EveMessage,
+  EveMessageInputRequest,
   EveMessagePart,
 } from "eve/react";
 import type { ChatMessage, ChatThreadEvent } from "../types";
@@ -89,9 +90,12 @@ function mapPart(part: EveMessagePart, id: string, active: boolean): TimelinePar
       return { kind: "reasoning", id, text, thinking: active && part.state === "streaming" };
     }
     case "dynamic-tool": {
+      // HITL yang MASIH parkir (approval/ask_question menunggu jawaban) dirender sebagai kartu
+      // di atas composer (`InputRequestPrompt`), bukan di transkrip — hindari tampil ganda.
+      // Setelah diresolve (`output-*`) tampil normal sebagai tool-row (jejak audit).
+      if (part.state === "approval-requested") return null;
       // propose_artifact sukses → kartu artifact clickable + Save-to-workspace (satu-satunya
-      // kartu khusus yang disisakan). Sisanya — subagen, verify_*, semua tool — jadi tool-row
-      // generik. HITL = percakapan murni (tak ada lagi inputRequest card; agent tanya via teks).
+      // kartu khusus yang disisakan). Sisanya — subagen, verify_*, semua tool — jadi tool-row generik.
       const artifact = artifactCardModel(part);
       if (artifact) return { kind: "artifact", id: part.toolCallId, model: artifact };
       const model = toolPartModel(part);
@@ -160,41 +164,134 @@ export function evePartsToTimeline(
   });
 }
 
-// ── gabung event log di LEVEL EVENT (port eve-chat-template) ───────────────────
+// ── gabung event log di LEVEL EVENT (indexed by event_index) ───────────────────
 //
-// SATU event log mentah → gabung prefix-aware → `defaultMessageReducer` SEKALI → pesan.
-// Menggantikan merge 3-sumber + dedup turnId di level render (akar flicker/stale-card).
+// SATU event log mentah → `defaultMessageReducer` SEKALI → pesan. Menggantikan merge
+// 3-sumber + dedup turnId (akar flicker/stale-card).
 
-/** Dua event stream sama bila JSON-nya identik (eve emit event immutable per posisi). */
-function areSameStreamEvent(a: EveAgentReducerEvent, b: EveAgentReducerEvent): boolean {
-  return a === b || JSON.stringify(a) === JSON.stringify(b);
+/** Event persisted dengan posisi durable-nya (`event_index` = posisi stream eve). */
+export type IndexedEvent = { readonly index: number; readonly event: EveAgentReducerEvent };
+
+/**
+ * Gabung snapshot persisted (`snapshot`, ber-`index`) dengan ekor LIVE (`live`, dari resume
+ * stream ATAU `agent.events`, kontigu mulai `liveStartIndex`) → satu log terurut.
+ *
+ * Dedup **by `event_index`** (posisi durable di stream eve), BUKAN `JSON.stringify` — bekas
+ * implementasi O(n²) `JSON.stringify` per-banding × tiap event yang membuat run besar (ribuan
+ * event `/deep`) nge-jank seakan beku. Map by-index → O(n). Snapshot & live boleh overlap
+ * (poll re-fetch ↔ resume) tanpa duplikat; live menimpa snapshot di index sama (event identik).
+ */
+export function buildOrderedLog(
+  snapshot: readonly IndexedEvent[],
+  live: readonly EveAgentReducerEvent[],
+  liveStartIndex: number,
+): EveAgentReducerEvent[] {
+  if (live.length === 0) return snapshot.map((s) => s.event);
+  const byIndex = new Map<number, EveAgentReducerEvent>();
+  for (const s of snapshot) byIndex.set(s.index, s.event);
+  for (let i = 0; i < live.length; i += 1) byIndex.set(liveStartIndex + i, live[i]);
+  return [...byIndex.keys()].sort((a, b) => a - b).map((i) => byIndex.get(i) as EveAgentReducerEvent);
 }
 
 /**
- * Gabung log persisted (`events`) dengan event live (`streamed`) → satu log. `streamed` yang
- * sudah ada di `events` (prefix yang ter-refetch usai turn) di-skip → tak dobel. `events` =
- * prefix server-authoritative; `streamed` = buffer live `agent.events`. Pola template
- * `mergeStreamEventLogs`/`appendUniqueStreamEvent`. Resume pakai overlay `[...events,...resumed]`
- * langsung (range disjoint), bukan fungsi ini.
+ * Buang delta streaming yang SUDAH disusul: simpan hanya `message.appended`/`reasoning.appended`
+ * TERAKHIR per (type, turnId, stepIndex). Reducer eve men-`upsert` part teks dengan `messageSoFar`
+ * (KUMULATIF) tiap delta → hanya delta terakhir yang menentukan teks final, sisanya redundan.
+ * Riset `/deep` bisa ribuan delta × teks-kumulatif = O(n²) (terukur 18MB) → reduce penuh tiap
+ * token nge-jank (gejala "token per token sangat lama"). Compaction → reduce hanya teks-final
+ * per langkah (O(n) byte). Aman: part teks di-REPLACE (bukan di-append), hasil reduksi identik.
+ * Scan murah (hanya baca type/turnId/stepIndex, tak menyentuh string besar).
  */
-export function mergeStreamEventLogs(
+const STREAMING_DELTA_TYPES = new Set(["message.appended", "reasoning.appended"]);
+
+function deltaKey(e: EveAgentReducerEvent): string {
+  const d = (e as { data?: { turnId?: unknown; stepIndex?: unknown } }).data;
+  return `${e.type}:${String(d?.turnId)}:${String(d?.stepIndex)}`;
+}
+
+export function compactStreamingDeltas(
   events: readonly EveAgentReducerEvent[],
-  streamed: readonly EveAgentReducerEvent[],
-): EveAgentReducerEvent[] {
-  if (streamed.length === 0) return events.slice();
-  const merged = events.slice();
-  for (const ev of streamed) {
-    if (!merged.some((existing) => areSameStreamEvent(existing, ev))) merged.push(ev);
-  }
-  return merged;
+): readonly EveAgentReducerEvent[] {
+  const lastAt = new Map<string, number>();
+  events.forEach((e, i) => {
+    if (STREAMING_DELTA_TYPES.has(e.type)) lastAt.set(deltaKey(e), i);
+  });
+  if (lastAt.size === 0) return events;
+  return events.filter(
+    (e, i) => !STREAMING_DELTA_TYPES.has(e.type) || lastAt.get(deltaKey(e)) === i,
+  );
 }
 
 /** Reduce satu event log → data pesan, lewat `defaultMessageReducer` SEKALI (jalur tunggal). */
 export function reduceEventsToMessageData(events: readonly EveAgentReducerEvent[]) {
   const reducer = defaultMessageReducer();
   let data = reducer.initial();
-  for (const ev of events) data = reducer.reduce(data, ev);
+  for (const ev of compactStreamingDeltas(events)) data = reducer.reduce(data, ev);
   return data;
+}
+
+/** Proyeksi UI pending HITL dari reducer eve (approval / ask_question), + nama tool pemicu
+ *  (`eve.name`) untuk melokalkan copy approval yang di-generate eve dalam bahasa Inggris. */
+export type PendingInputRequest = EveMessageInputRequest & { readonly toolName: string };
+
+/** Payload jawaban HITL → `agent.send({ inputResponses })`. */
+export type InputResponsePayload = {
+  requestId: string;
+  optionId?: string;
+  text?: string;
+};
+
+/** Approval eve = persis dua opsi ber-id `approve`/`deny` (lihat harness `isApprovalRequest`).
+ *  Bukan approval → `ask_question` model (prompt/opsi sudah ditulis model, dipakai apa adanya). */
+export function isApprovalRequest(req: Pick<PendingInputRequest, "options">): boolean {
+  const opts = req.options;
+  return (
+    opts !== undefined && opts.length === 2 && opts[0]?.id === "approve" && opts[1]?.id === "deny"
+  );
+}
+
+/** Boleh dijawab teks bebas: model set `allowFreeform`, atau tak ada opsi untuk dipilih. */
+export function acceptsFreeformText(
+  req: Pick<PendingInputRequest, "allowFreeform" | "options">,
+): boolean {
+  return req.allowFreeform === true || req.options === undefined || req.options.length === 0;
+}
+
+/**
+ * Permintaan input yang BENAR-BENAR menunggu user = part `approval-requested` di PESAN ASISTEN
+ * TERAKHIR saja (turn terakhir). Alasannya halus tapi krusial:
+ *
+ * - `ask_question` TIDAK pernah meng-emit `action.result` ke event-log server, dan
+ *   `eve.inputResponse` HANYA di-set event proyeksi klien (`client.input.responded`) yang tak
+ *   pernah masuk event-log/persisted. Jadi part `ask_question` **nyangkut di `approval-requested`
+ *   SELAMANYA** di turn-turn lama. Kalau dipindai lintas semua pesan, tiap pertanyaan lama
+ *   menumpuk jadi kartu basi (persis bug: 3 kartu menumpuk + muncul lagi setelah turn selesai).
+ *   (Cek state saja TIDAK cukup — beda dgn approval yg dapat `action.result` → `output-*`.)
+ * - eve serial per session: begitu user menjawab, turn BARU dimulai → pesan asisten baru jadi
+ *   yang terakhir → pertanyaan lama otomatis bukan "terakhir" lagi = tidak pending.
+ * - Approval yang sudah diresolve mid-turn → `action.result` → `output-*` (bukan
+ *   `approval-requested`) → tetap terfilter walau berada di turn terakhir.
+ *
+ * Batch paralel (>1 pertanyaan dalam satu step) tetap didukung: semuanya ada di pesan terakhir.
+ */
+export function pendingInputRequests(
+  events: readonly EveAgentReducerEvent[],
+): PendingInputRequest[] {
+  const { messages } = reduceEventsToMessageData(events);
+  let last: EveMessage | undefined;
+  for (const m of messages) if (m.role === "assistant") last = m;
+  if (!last) return [];
+
+  const out: PendingInputRequest[] = [];
+  const seen = new Set<string>();
+  for (const part of last.parts) {
+    if (part.type !== "dynamic-tool" || part.state !== "approval-requested") continue;
+    const req = part.toolMetadata?.eve?.inputRequest;
+    if (!req || seen.has(req.requestId)) continue;
+    seen.add(req.requestId);
+    out.push({ ...req, toolName: part.toolMetadata?.eve?.name ?? part.toolName });
+  }
+  return out;
 }
 
 // ── replay event stream persisted (fix timeline persist) ──────────────────────
@@ -218,8 +315,8 @@ const SETTLED_EVENT_TYPES = new Set([
 ]);
 
 /**
- * Settled ATAU parkir-menunggu-input. `input.requested` ditambahkan: walau HITL kini
- * percakapan, `ask_question` masih di harness → bila model memakainya, stream eve parkir di
+ * Settled ATAU parkir-menunggu-input. `input.requested` ditambahkan: bila model memakai
+ * `ask_question` atau tool ber-`needsApproval`, stream eve parkir di
  * `session.waiting` dan `agent.status` jadi `ready` (composer terbuka). Kalau reload
  * menganggapnya "berjalan", `busy` mengunci composer → user tak bisa menjawab.
  */

--- a/apps/web-v2/features/threads/lib/use-astra-agent.ts
+++ b/apps/web-v2/features/threads/lib/use-astra-agent.ts
@@ -64,22 +64,30 @@ export function useAstraAgent(initialSession?: {
   const discoverFirstTurnSession = useCallback(async () => {
     if (discoveringRef.current || boundRef.current) return;
     discoveringRef.current = true;
-    const since = Date.now() - DISCOVER_SINCE_BUFFER_MS;
-    for (let attempt = 0; attempt < DISCOVER_ATTEMPTS && !boundRef.current; attempt += 1) {
-      const thread = await api.threads["recent-active"]
-        .get({ query: { since } })
-        .then((r) => unwrap(r) as ChatThread | null)
-        .catch(() => null);
-      if (thread?.id) {
-        sessionIdRef.current = thread.id;
-        if (!boundRef.current && typeof window !== "undefined") {
-          boundRef.current = true;
-          window.history.replaceState(window.history.state, "", `/app/threads/${thread.id}`);
-          qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+    try {
+      const since = Date.now() - DISCOVER_SINCE_BUFFER_MS;
+      for (let attempt = 0; attempt < DISCOVER_ATTEMPTS && !boundRef.current; attempt += 1) {
+        const thread = await api.threads["recent-active"]
+          .get({ query: { since } })
+          .then((r) => unwrap(r) as ChatThread | null)
+          .catch(() => null);
+        if (thread?.id) {
+          sessionIdRef.current = thread.id;
+          if (!boundRef.current && typeof window !== "undefined") {
+            boundRef.current = true;
+            window.history.replaceState(window.history.state, "", `/app/threads/${thread.id}`);
+            qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+          }
+          return;
         }
-        return;
+        await new Promise((resolve) => setTimeout(resolve, DISCOVER_DELAY_MS));
       }
-      await new Promise((resolve) => setTimeout(resolve, DISCOVER_DELAY_MS));
+    } finally {
+      // Lepas guard tiap ronde selesai: bila SEMUA attempt gagal (hook `session.started`
+      // lambat) tanpa ini `discoveringRef` macet `true` → `onEvent` berikutnya early-return →
+      // discovery mati permanen untuk mount ini (URL baru terkoreksi saat turn selesai). Pada
+      // jalur sukses `boundRef` sudah `true` jadi guard tetap short-circuit.
+      discoveringRef.current = false;
     }
   }, [api, qc]);
 
@@ -121,16 +129,10 @@ export function useAstraAgent(initialSession?: {
         boundRef.current = true;
         window.history.replaceState(window.history.state, "", `/app/threads/${session.sessionId}`);
       }
-      // Persist handle-resume eve KLIEN (ter-namespace SEKALI) → approval HITL `inputResponses`
-      // + follow-up lintas-reload bisa di-`deliver`. eve menamespace lagi saat dikirim balik;
-      // token server (`channel.continuationToken`) ganda → `deliver` gagal (lihat ThreadService
-      // .saveContinuation). Best-effort; turn settle berikutnya menulis ulang token terbaru.
-      if (session.sessionId && session.continuationToken) {
-        void api
-          .threads({ id: session.sessionId })
-          .session.post({ continuationToken: session.continuationToken })
-          .catch(() => {});
-      }
+      // Token continuation TIDAK lagi ditangkap di sini: proxy-tee respons create/continue eve
+      // (`app/eve/v1/[...path]/route.ts` → upsert race-proof api-v2) yang menyimpannya server-side,
+      // andal walau turn parkir SEBELUM klien bind sessionId (akar fix B). onSessionChange cuma
+      // mengoreksi URL ke id eve otoritatif.
     },
     onFinish() {
       qc.invalidateQueries({ queryKey: queryKeys.threads.all });

--- a/apps/web-v2/features/threads/lib/use-astra-agent.ts
+++ b/apps/web-v2/features/threads/lib/use-astra-agent.ts
@@ -5,7 +5,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEveAgent } from "eve/react";
 import { useCallback, useRef } from "react";
 import { useApi } from "@/lib/api-client";
-import { queryKeys } from "@/lib/api-query";
+import { queryKeys, unwrap } from "@/lib/api-query";
+import type { ChatThread } from "../types";
+
+/** Retry singkat menunggu hook `session.started` membuat thread (race klien↔hook). */
+const DISCOVER_ATTEMPTS = 16;
+const DISCOVER_DELAY_MS = 250;
+/** Toleransi skew jam klien↔server saat menyaring thread `streaming` basi. */
+const DISCOVER_SINCE_BUFFER_MS = 120_000;
 
 /**
  * Wrapper `useEveAgent` untuk Astra (Slice 6.1):
@@ -40,8 +47,41 @@ export function useAstraAgent(initialSession?: {
   const api = useApi();
   const boundRef = useRef(initialSession != null);
   const sessionIdRef = useRef<string | null>(initialSession?.sessionId ?? null);
+  const discoveringRef = useRef(false);
 
   const bearer = useCallback(async () => (await getToken()) ?? "", [getToken]);
+
+  /**
+   * Turn PERTAMA: `useEveAgent` baru surface sessionId di akhir turn (`onSessionChange` di
+   * `finally` send()), dan `session.started` TAK membawa sessionId → URL tetap `/app/threads`
+   * selama agent menyusun plan. Refresh di jendela itu mendarat di halaman kosong. Solusi:
+   * begitu event PERTAMA tiba (stream jalan), temukan sessionId via thread `streaming` termuda
+   * milik caller (`GET /threads/recent-active`, retry singkat untuk race hook `session.started`)
+   * lalu bump URL SEGERA. `since` menyaring thread streaming basi. No-op untuk continue-thread
+   * (`initialSession` ada → boundRef sudah true). onSessionChange tetap mengoreksi ke id eve
+   * otoritatif bila berbeda.
+   */
+  const discoverFirstTurnSession = useCallback(async () => {
+    if (discoveringRef.current || boundRef.current) return;
+    discoveringRef.current = true;
+    const since = Date.now() - DISCOVER_SINCE_BUFFER_MS;
+    for (let attempt = 0; attempt < DISCOVER_ATTEMPTS && !boundRef.current; attempt += 1) {
+      const thread = await api.threads["recent-active"]
+        .get({ query: { since } })
+        .then((r) => unwrap(r) as ChatThread | null)
+        .catch(() => null);
+      if (thread?.id) {
+        sessionIdRef.current = thread.id;
+        if (!boundRef.current && typeof window !== "undefined") {
+          boundRef.current = true;
+          window.history.replaceState(window.history.state, "", `/app/threads/${thread.id}`);
+          qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+        }
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, DISCOVER_DELAY_MS));
+    }
+  }, [api, qc]);
 
   // eve SessionState: continuationToken `string | undefined` (bukan null). Tanpa token,
   // continue route ditolak ("Missing or empty continuationToken") → wajib teruskan saat ada.
@@ -57,10 +97,27 @@ export function useAstraAgent(initialSession?: {
 
   const agent = useEveAgent({
     auth: { bearer },
+    // Resiliensi reconnect (default eve = 3). Akar masalah streaming sudah ditangani proxy
+    // Route Handler (`app/eve/v1/[...path]/route.ts`); ini cadangan untuk putus sungguhan:
+    // saat /deep menjalankan subagent, turn induk bisa diam bermenit-menit tanpa event, dan
+    // eve tak mengirim keepalive — bila socket tertutup (dev server restart, blip), klien
+    // reconnect dari cursor & melanjutkan. Boundary (session.waiting/completed/failed)
+    // menghentikan loop seketika saat turn selesai, jadi nilai tinggi tak menimbulkan churn.
+    maxReconnectAttempts: 120,
     ...(eveInitialSession ? { initialSession: eveInitialSession } : {}),
+    // Event PERTAMA tiba (stream jalan) → temukan sessionId turn-pertama lebih awal & bump URL,
+    // supaya refresh saat agent menyusun plan tak mendarat di halaman kosong (lihat
+    // `discoverFirstTurnSession`). No-op begitu terikat (continue-thread / sudah ketemu).
+    onEvent() {
+      if (!boundRef.current) void discoverFirstTurnSession();
+    },
     onSessionChange(session) {
-      if (session.sessionId) sessionIdRef.current = session.sessionId;
-      if (session.sessionId && !boundRef.current && typeof window !== "undefined") {
+      if (!session.sessionId) return;
+      // Koreksi ke id eve OTORITATIF: discovery turn-pertama bisa keliru di kasus langka
+      // (thread streaming lain di jendela `since`) → samakan URL ke id sebenarnya di akhir turn.
+      const changed = sessionIdRef.current !== session.sessionId;
+      sessionIdRef.current = session.sessionId;
+      if (typeof window !== "undefined" && (!boundRef.current || changed)) {
         boundRef.current = true;
         window.history.replaceState(window.history.state, "", `/app/threads/${session.sessionId}`);
       }

--- a/apps/web-v2/features/threads/lib/use-smooth-text.tsx
+++ b/apps/web-v2/features/threads/lib/use-smooth-text.tsx
@@ -27,7 +27,12 @@ export function useSmoothText(
     targetRef.current = text;
   }, [text]);
 
-  const [shown, setShown] = useState(enabled ? "" : text);
+  // Mulai dari teks yang SUDAH ada (bukan ""). Kalau cold-load/refresh saat turn in-flight,
+  // jawaban-sejauh-ini bisa puluhan ribu char — reveal dari 0 @ ~180 char/dtk = crawl
+  // bermenit-menit (gejala "token per token sangat lama" setelah refresh). Kita tampilkan
+  // teks yang ada SEKETIKA, animasi hanya untuk PERTUMBUHAN baru. Fresh turn: text="" → 0
+  // → tetap mengetik dari awal.
+  const [shown, setShown] = useState(text);
 
   useEffect(() => {
     if (!enabled) {
@@ -35,7 +40,7 @@ export function useSmoothText(
       return;
     }
     let raf = 0;
-    let shownLen = 0;
+    let shownLen = targetRef.current.length;
     let lastSet = -1;
     let last = 0;
     const step = (ts: number) => {

--- a/apps/web-v2/features/threads/lib/use-thread-resume.ts
+++ b/apps/web-v2/features/threads/lib/use-thread-resume.ts
@@ -21,19 +21,42 @@ import { useEffect, useRef, useState } from "react";
  * (zod/workflow → `node:module`) yang tak bisa di-bundle ke browser — persis seperti template yang
  * juga hand-roll `streamSessionEvents`.
  *
- * **Stop = body-close BERSIH dari server ATAU idle-timeout**, BUKAN tipe event. Kontrak eve
- * `openStreamIterable`: server menutup body saat turn benar-benar usai (incl. saat agent bertanya →
- * turn settle). `/deep` multi-turn auto-lanjut: `session.waiting` transien muncul di batas turn tapi
- * server MENJAGA body terbuka → kita ride sampai close. (Dulu stop di `session.waiting`/`input.requested`
- * → resume putus tiap batas → KEDIP. HITL kini percakapan → tak ada `input.requested`.)
+ * **EOF bersih ≠ turn selesai.** eve dev bisa MENUTUP body stream per-snapshot (bukan satu tail
+ * panjang yang dijaga terbuka sampai turn usai). Jadi resume meniru jalur SEND eve: setelah EOF
+ * tanpa boundary, buka lagi dari `nextIndex`. Bila snapshot tadi berisi event baru, reconnect
+ * langsung supaya token jawaban akhir tetap terasa realtime setelah refresh/nav-balik. Bila EOF
+ * kosong, pakai backoff pendek supaya thread yang lama diam (mis. subagent /deep) tidak hot-loop.
+ * Resume berhenti HANYA saat event terakhir = boundary turn
+ * (`session.waiting`/`session.completed`/`session.failed`). Idle-timeout = pengaman turn yang
+ * benar-benar mati/hang.
  */
-const IDLE_TIMEOUT_MS = 120_000;
+const IDLE_TIMEOUT_MS = 600_000; // 10 mnt: tahan gap subagent /deep yang panjang (tanpa event), tetap stop turn mati
+const EOF_AFTER_PROGRESS_DELAY_MS = 0; // token sudah bergerak → reconnect segera agar resume tetap realtime
+const EOF_EMPTY_INITIAL_DELAY_MS = 150; // snapshot kosong → tunggu singkat sebelum long-poll ulang
+const EOF_EMPTY_MAX_DELAY_MS = 1_000; // cap backoff saat turn aktif tapi parent stream lama diam
 const RECONNECT_DELAY_MS = 300;
 const MAX_RECONNECTS = 3;
 const RETRYABLE_OPEN = new Set([404, 409, 425, 500, 502, 503, 504]);
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+/** Event terakhir menandai turn benar-benar settle/parkir → resume boleh berhenti. */
+const TERMINAL_EVENT_TYPES = new Set(["session.waiting", "session.completed", "session.failed"]);
+function lastEventIsTerminal(events: readonly EveAgentReducerEvent[]): boolean {
+  const last = events[events.length - 1] as { type?: string } | undefined;
+  return last != null && TERMINAL_EVENT_TYPES.has(last.type ?? "");
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(done, ms);
+    const onAbort = () => done();
+    function done() {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /** Baca body NDJSON eve → yield tiap event (satu JSON per baris). */
@@ -83,8 +106,6 @@ export function useThreadResume(params: {
     getTokenRef.current = getToken;
     startIndexRef.current = startIndex;
   });
-  // Sekali-resume per sessionId. Self-managing lintas-thread: sessionId baru ≠ key → buka lagi.
-  const startedKeyRef = useRef<string | null>(null);
 
   // Pindah thread → buang buffer resume thread lama (pola "adjust state during render", bukan
   // effect → tak ada cascading-render warning; konvergen saat trackedSession == sessionId).
@@ -95,10 +116,14 @@ export function useThreadResume(params: {
     setResuming(false);
   }
 
+  // Buka resume HANYA saat aktif. JANGAN pakai ref-guard "sekali per sessionId": React
+  // StrictMode (dev) mount→cleanup→mount, jadi guard ref yang bertahan lintas cleanup
+  // membuat invocation KEDUA early-return → stream tak pernah benar-benar terbuka (resume
+  // mati di dev). Cleanup effect SUDAH meng-abort loop lama sebelum re-run, jadi guard tak
+  // diperlukan: deps `[enabled, sessionId]` → re-run hanya saat keduanya berubah, idempoten
+  // (dedup by event_index di surface).
   useEffect(() => {
     if (!enabled || !sessionId) return;
-    if (startedKeyRef.current === sessionId) return;
-    startedKeyRef.current = sessionId;
 
     const abort = new AbortController();
     let cancelled = false;
@@ -108,12 +133,15 @@ export function useThreadResume(params: {
       idleTimer = setTimeout(() => abort.abort(), IDLE_TIMEOUT_MS);
     };
 
-    setResuming(true);
     const acc: EveAgentReducerEvent[] = [];
 
+    // `setResuming(true)` di dalam IIFE (bukan langsung di badan effect) → tak memicu
+    // cascading-render sinkron (react-hooks/set-state-in-effect).
     void (async () => {
+      setResuming(true);
       let nextIndex = startIndexRef.current;
       let reconnects = MAX_RECONNECTS;
+      let emptyEofDelay = EOF_EMPTY_INITIAL_DELAY_MS;
       let stop = false;
       try {
         bumpIdle();
@@ -126,26 +154,38 @@ export function useThreadResume(params: {
           );
           if (!res.ok || !res.body) {
             if (RETRYABLE_OPEN.has(res.status) && reconnects-- > 0) {
-              await sleep(RECONNECT_DELAY_MS);
+              await sleep(RECONNECT_DELAY_MS, abort.signal);
               continue;
             }
             break;
           }
           try {
+            let sawEvent = false;
             for await (const ev of readNdjson(res.body)) {
               if (cancelled) return;
               bumpIdle();
               reconnects = MAX_RECONNECTS; // progress → pulihkan budget reconnect
+              sawEvent = true;
+              emptyEofDelay = EOF_EMPTY_INITIAL_DELAY_MS;
               nextIndex += 1;
               acc.push(ev as EveAgentReducerEvent);
               setResumedEvents(acc.slice());
             }
-            // Body ditutup server tanpa boundary = turn selesai (eve menutup body usai turn).
-            stop = true;
+            // EOF bersih. Berhenti HANYA bila turn sudah settle/parkir; selain itu reconnect dari
+            // nextIndex. Setelah snapshot yang berisi event, jangan tidur: delay itulah yang dulu
+            // membuat jawaban akhir terasa batch per 1-2 detik setelah refresh/nav-balik.
+            if (lastEventIsTerminal(acc)) stop = true;
+            else {
+              const delay = sawEvent ? EOF_AFTER_PROGRESS_DELAY_MS : emptyEofDelay;
+              if (!sawEvent) {
+                emptyEofDelay = Math.min(EOF_EMPTY_MAX_DELAY_MS, Math.round(emptyEofDelay * 1.5));
+              }
+              await sleep(delay, abort.signal);
+            }
           } catch {
             if (cancelled || abort.signal.aborted) return;
             if (reconnects-- <= 0) stop = true; // putus transient → reconnect dari nextIndex
-            else await sleep(RECONNECT_DELAY_MS);
+            else await sleep(RECONNECT_DELAY_MS, abort.signal);
           }
         }
       } catch {

--- a/apps/web-v2/next.config.ts
+++ b/apps/web-v2/next.config.ts
@@ -1,13 +1,13 @@
 import type { NextConfig } from "next";
 import path from "node:path";
 
-// Agent Astra (eve) kini app TERPISAH `@aqsha/agent-v2` yang jalan sebagai service
-// sendiri (`eve dev`/`eve start`). web-v2 = pure consumer: rewrite same-origin
-// `/eve/v1/*` → origin agent-v2 supaya `useEveAgent` tetap same-origin (TANPA CORS;
-// eve tak punya CORS bawaan) dan bearer Clerk diteruskan apa adanya — channel eve
-// (`agent/channels/eve.ts` di agent-v2) yang verifikasi. Server-side env (bukan
-// NEXT_PUBLIC): browser tak pernah melihat origin agent-v2.
-const AGENT_ORIGIN = process.env.AGENT_ORIGIN ?? "http://localhost:4317";
+// Agent Astra (eve) = app TERPISAH `@aqsha/agent-v2` (`eve dev`/`eve start`). web-v2 = pure
+// consumer: proxy same-origin `/eve/v1/*` → origin agent-v2 supaya `useEveAgent` tetap
+// same-origin (TANPA CORS; eve tak punya CORS bawaan) dan bearer Clerk diteruskan apa adanya.
+//
+// Proxy `/eve/v1/*` ADA DI Route Handler streaming (`app/eve/v1/[...path]/route.ts`), BUKAN
+// `rewrites()`: rewrites menahan stream long-lived (turn in-flight) → progres beku, boundary
+// `session.waiting` tak sampai (token resume hilang → HITL tak bisa dijawab), resume nav-balik macet.
 
 // Base disalin dari apps/web; DROP redirects V1 + @aqsha/convex.
 const nextConfig: NextConfig = {
@@ -17,9 +17,6 @@ const nextConfig: NextConfig = {
   transpilePackages: ["@aqsha/ui", "@aqsha/api-v2"],
   turbopack: {
     root: path.resolve(__dirname, "../.."),
-  },
-  async rewrites() {
-    return [{ source: "/eve/v1/:path*", destination: `${AGENT_ORIGIN}/eve/v1/:path*` }];
   },
 };
 

--- a/docs/v2/agent-streaming-hitl-bigbang-plan.md
+++ b/docs/v2/agent-streaming-hitl-bigbang-plan.md
@@ -1,0 +1,173 @@
+# Big-Bang Plan — Streaming + HITL Redesign (eve, web-v2)
+
+> Implement in a fresh Claude session. Branch: `feat/v2-agent`.
+> Companion docs (READ FIRST): `docs/v2/agent-streaming-hitl-redesign-research.md` (the verdict + 5 pillars),
+> `docs/v2/hitl-streaming-audit-live.md` (live repro + DB evidence).
+> This plan **corrects 3 mechanisms** from the research doc (verified against eve dist source + live DB) —
+> see "Traps" before coding.
+
+---
+
+## Context (kenapa)
+
+Stack streaming/HITL web-v2 over-engineered: ia menulis ulang dengan tangan apa yang eve 0.11.6 sudah
+berikan native (durable stream replayable by `startIndex`). Lima gejala live-terbukti masih ada:
+**A** kartu HITL tak muncul live (baru setelah refresh), **B** menjawab HITL error/"no token",
+**C** cold-load lambat (~2 dtk detoast 32 MB), **D** frozen 2–3,7 mnt dead-air subagent,
+**E** thread "zombie" (`status='streaming'` selamanya → composer terkunci, refresh tak menolong).
+
+Owner memilih **big-bang penuh termasuk storage rewrite**. Plan ini memperbaiki kelimanya + memangkas
+storage 32 MB→KB. Prinsip: **eve durable stream = SoT turn aktif; Postgres = history + status; klien =
+render, bukan rekonsiliasi. Hapus lebih banyak dari menambah.**
+
+---
+
+## Sumber kebenaran eve (terverifikasi di dist 0.11.6 + DB)
+
+- `GET /eve/v1/session/:id/stream?startIndex=N` durable + replayable (skip `<N`, lalu tail). Event **tak
+  ber-index**; klien hitung posisi (`streamIndex`) sendiri.
+- `useEveAgent` **TIDAK** auto-attach saat mount (`initialSession`/`initialEvents` seed-only; stream buka
+  saat `.send()`). → resume in-flight WAJIB dibuka manual (`useThreadResume` tetap dipakai).
+- Reducer (`dist/src/client/message-reducer.js`): `message.completed.data.message` = **teks final lengkap
+  (tanpa perlu delta)**; TAPI **`reasoning.completed` di-emit 0×** oleh agent kita → reasoning final HANYA
+  ada di `reasoning.appended` TERAKHIR. Reducer **tak punya** handler `subagent.called/completed`
+  (subagent tampil via `actions.requested` kind `subagent-call`).
+- `channel.continuationToken` (handler `events`) = bentuk **double-namespace `eve:eve:…` (internal)** — BUKAN
+  token klien yang benar (`eve:…` single). Token tak re-mint per turn (stabil se-sesi).
+- DB: `subagent.called`/`childSessionId` = **0 baris** (delegasi model-driven hanya emit `actions.requested`);
+  `session.waiting`/`session.completed` **DIPERSIST**; satu `/deep` = 6119 event / 32 MB, 99% = `*.appended` kumulatif.
+
+---
+
+## Phase 0 — Prep
+- **Commit/checkpoint** working tree `feat/v2-agent` dulu (kotor dgn iterasi lama) → diff refactor legible/revertible.
+- Migrasi: committed terakhir `0012`. Memori menyebut 0013/0014 hand-authored di branch lain — **cek &
+  rekonsiliasi nomor** sebelum `drizzle-kit generate` (pakai nomor bebas berikutnya).
+- Luruskan komentar usang yang menyesatkan: `eve-timeline.ts:~336` ("session.* tak dipersist" — SALAH, dipersist),
+  `chatThreads.ts` ("dipersist tiap session.waiting oleh channel" — SALAH).
+
+## Phase 1 — Single stream (fix A + sebagian C)
+**Goal:** satu sumber live (resume stream), buang poll 2 dtk. Akar **A = `busy` tak pernah clear**: di jalur
+SEND live, saat parkir eve menutup body per-snapshot → `agent.events` kehilangan ekor `input.requested`/
+`session.waiting` → `isStreamActive(base)` tetap true → `busy` true → `hitlRequests = !busy ? … : []` = kosong
+sampai refresh. Fix = resume stream mengirim boundary itu dengan andal.
+
+- `features/threads/api.ts`: **hapus polling** `useThreadEvents` (refetchInterval) + `compactThreadEvents`.
+  Sisakan fetch snapshot **sekali** (cold-load) + `afterIndex` untuk backfill bila perlu.
+- `features/thread-experience/components/eve-chat-thread-surface.tsx`: stop poll; `initialEvents` = snapshot
+  mount sekali; `streamActive` dari `status` + last-event; pertahankan surfacing token (`initialSession.continuationToken`, line ~118).
+- `features/threads/components/chat-surface.tsx`: **`buildOrderedLog` TETAP** (kini 2-source: history ⊕ activeEvents
+  — JANGAN hapus). Pastikan setelah `agent.send()` parkir tanpa boundary, **resume re-attach dari cursor menarik
+  boundary** (sudah enabled `streamActive && status==='ready'`) → `base` dapat `session.waiting` → `busy` clear →
+  kartu muncul live. Verifikasi gating `busy`/`hitlRequests`.
+- `features/threads/lib/use-thread-resume.ts`: **TETAP** (hand-roll fetch wajib — `eve/client` seret `node:module`,
+  tak bisa di-bundle browser). Ini jadi satu-satunya sumber live pasca-poll. Bisa disederhanakan (EOF/backoff)
+  tapi inti = buka `/stream?startIndex=cursor`, feed reducer.
+- Reuse: reducer tunggal `reduceEventsToMessageData`/`eventsToTimeline` (`eve-timeline.ts`).
+- **Catat:** snapshot-close yang membuang ekor sebagian artefak `eve dev`; uji A juga di build prod-style.
+
+## Phase 2 — Token capture race fix (fix B)
+**Goal:** token `eve:…` (single) tersimpan andal walau turn parkir SEBELUM klien bind `sessionId` (race 1/5).
+**JANGAN** tambah handler `events:{"session.waiting"}` di channel (menyimpan `eve:eve:…` double → kirim ulang
+triple-namespace → "Cannot deliver" = regres B; sudah tried-and-reverted, lihat `channels/eve.ts:60-67`).
+
+- **Primary (robust): proxy-tee respons create-POST.** `apps/web-v2/app/eve/v1/[...path]/route.ts`: deteksi
+  `POST /eve/v1/session` (create), clone respons kecil `{sessionId, continuationToken:"eve:…"}` (token BENAR/single),
+  lalu **upsert server-side** via api-v2 (sertakan bearer yang sama). Tak bergantung klien bind sessionId.
+- `apps/api-v2/src/routes/threads.ts`: endpoint upsert token **race-proof** (create-if-absent keyed by
+  sessionId+owner) — respons create (202) mendahului hook `session.started` yang bikin row, jadi **upsert**,
+  bukan `saveContinuation` ber-assertOwner (butuh row). Bisa kolom `chat_threads.continuation_token` (upsert row
+  minimal) atau tabel kecil `session_tokens`. Pilih upsert ke `chat_threads` bila row sudah ada di mayoritas kasus + retry.
+- `features/threads/lib/use-astra-agent.ts`: **hapus** capture klien `onSessionChange→saveContinuation` (digantikan
+  proxy-tee), ATAU jadikan **idempotent + retry** sampai row ada (alternatif lebih ringan tanpa proxy DB).
+- (Opsional harden) `POST /:id/answer` yang inject token server-side & panggil eve continue — hanya dgn token
+  single tersimpan, JANGAN `channel.continuationToken`.
+
+## Phase 3 — step_index read fix (fix C tuntas)
+**Goal:** bunuh 2 dtk. Penyebab: subquery compaction `GROUP BY (payload->'data'->>'stepIndex')` **men-detoast 32 MB
+hanya untuk baca stepIndex**.
+- `packages/db/src/schema/chatThreadEvents.ts`: tambah kolom `step_index int` (nullable) + index `(thread_id, type, step_index)`.
+- `apps/agent-v2/agent/lib/store.ts` `appendThreadEvent`: tulis `step_index` dari `payload.data.stepIndex`.
+- `packages/db/src/repositories/chatThreadEventRepo.ts` `listByThread`: `GROUP BY step_index` (bukan ekspresi JSON) →
+  tak ada detoast. Backfill 1× (batched per thread): `UPDATE … SET step_index=(payload->'data'->>'stepIndex')::int`.
+- Migrasi `00NN_step_index.sql` (kolom + index + backfill). **Cursor & klien tak berubah.**
+
+## Phase 4 — Subagent elapsed indicator (fix D)
+**Goal:** matikan "frozen" semu. Child-stream **TAK tersedia** (`childSessionId` 0 baris; reducer tak handle subagent).
+Parent-heartbeat **mustahil** (parent parkir tanpa compute). Solusi tanpa eve-change/child-id:
+- `features/threads/lib/eve-timeline.ts` (`toolPartModel`) + `features/threads/components/tool-row.tsx`: untuk row
+  `subagent-call` ber-status running, tampilkan **elapsed timer** ("Menelaah literatur… M:SS"). **Reuse `ElapsedLabel`**
+  dari `features/threads/components/message-list.tsx`.
+- Bergantung Phase 1 menjaga stream attached saat gap (sudah: `IDLE_TIMEOUT_MS=600_000` `use-thread-resume.ts:33`,
+  `maxReconnectAttempts:120` `use-astra-agent.ts:106`).
+
+## Phase 5 — Zombie reconciler (fix E)
+**Goal:** turn crash (a.l. ENOSPC) tak menulis event terminal → busy selamanya. **Reuse `registerRepeatable`**
+(`apps/api-v2/src/workers/index.ts:~63`, pola feed-hydration).
+- Queue + Worker baru `reconcile-stale-threads`, cron (mis. tiap jam). Untuk tiap `status='streaming'` dgn
+  `last_activity_at < now()-AMBANG`:
+  1. **Append event terminal sintetik** `turn.failed` (∈ `SETTLED_OR_PARKED_LAST`) via `appendThreadEvent` (reuse),
+     supaya `isStreamActive(base)` → false (klien unlock composer).
+  2. `setThreadStatus('failed')` (DB & heuristik selaras).
+- **AMBANG > gap subagent sah** (terukur 5,7 mnt) — set **30 mnt** (tunable). Catatan: selama dead-air TIDAK ada
+  event dipersist, jadi `last_activity_at` tetap lama → ambang 30 mnt aman utk run normal; subagent >30 mnt = edge,
+  terima/tunable.
+- Klien: `streamActive`/`busy` sudah memakai `status` + last-event → otomatis benar setelah reconciler.
+- Operasional (bukan kode): **jaga disk lega** — ENOSPC = penyebab utama crash→zombie (lihat audit §ENOSPC).
+
+## Phase 6 — Storage rewrite (opted-in; deploy ATOMIC, lakukan TERAKHIR)
+**Goal:** 32 MB→KB at-rest. **Mekanisme = B-strip (lebih aman dari drop-deltas+cursor-decouple):** simpan baris 1:1
+(jadi `event_index == eveStreamIndex`, **cursor resume tak tersentuh, nol risiko cursor in-flight**), tapi **strip
+payload delta tersusul**. Reasoning aman (delta TERAKHIR tak di-strip → reasoning final tetap ada).
+> Catatan ke owner: kamu memilih "incl cursor decouple". Plan pakai **B-strip** karena hasil shrink SAMA tapi tanpa
+> landmine cursor/migrasi-index (review Plan-agent). Bila tetap mau drop-deltas+`eve_stream_index` counter, itu opsi
+> lebih berisiko (counter idempotency saat durable replay) — bisa, tapi tak disarankan.
+- `apps/agent-v2/agent/hooks/projection.ts`: di handler `step.completed` (atau `message.completed`), **strip payload
+  delta tersusul** untuk step itu (1 UPDATE/step, bukan per-delta) — `SET payload = <minimal> WHERE thread=… AND turn=…
+  AND step_index=… AND type IN ('message.appended','reasoning.appended') AND event_index < max(step)`. JANGAN sentuh
+  idempotency key billing `step.completed` (`sessionId:turnId:stepIndex`).
+- **Data migrasi 1×** thread lama (batched): strip delta tersusul yang sudah ada (`… AND event_index NOT IN (SELECT
+  max(event_index) … GROUP BY thread,turn,type,step_index)`). Baris/index TETAP → cursor lama valid.
+- **Deploy atomic**: ini satu-satunya fase yang menyentuh jalur tulis; deploy agent-v2 + jalankan migrasi bersamaan.
+  Fase 1–5 semuanya additive/read-side → cursor in-flight tetap valid lintas-deploy.
+
+---
+
+## Migration & back-compat
+- Thread 32 MB lama: Fase 1–5 tetap terbaca (rows 1:1; `step_index` backfilled; `eventsToTimeline` rekonstruksi penuh;
+  `legacyHistory` `eve-chat-thread-surface.ts:~32` = fallback pra-event). Tak ada data loss.
+- Sesi in-flight lintas-deploy: sesi eve durable (survive redeploy); klien reconnect via cursor. **Hanya Fase 6** yang
+  bisa renumber semantik tulis → karena B-strip tak mengubah index, in-flight aman; tetap deploy Fase 6 atomic.
+- Billing (`consumeCredits` di handler `step.completed`) tak disentuh fase manapun — jaga idempotency key.
+
+## Verifikasi E2E (lokal: web-v2:3000 → api-v2:3001 → eve:4317 → VPS PG; Claude-in-Chrome + psql MCP)
+1. **Baseline (sebelum):** psql histogram tipe event + `pg_column_size` sum + waktu `listByThread` (≈2 dtk).
+2. **A (HITL live):** `/deep` → di park konfirmasi-rencana, kartu muncul **tanpa refresh**; `read_network_requests`:
+   resume stream membawa `input.requested`, **tak ada** loop poll `/events` 2 dtk.
+3. **B (jawab pasca-refresh):** di park, hard-refresh, klik opsi. `POST /eve/v1/session/:id` → 200 (bukan "Cannot
+   deliver"); psql: `continuation_token` = `eve:…` (single) non-null **bahkan pada fast-first-turn-park** (kasus 5-event).
+4. **C (cold-load):** buka thread 6119-event dingin; TTFB `/messages`+`/events` ≪ 2 dtk; `EXPLAIN ANALYZE` query baru =
+   tanpa full detoast.
+5. **D (dead-air):** saat gap subagent, row `subagent-call` menampilkan elapsed hidup + stream tetap attached (console: reconnect).
+6. **E (zombie):** psql `UPDATE … SET status='streaming', last_activity_at=<31 mnt lalu>` pada thread settled; jalankan
+   reconciler; status→`failed`, event terminal ter-append, composer unlock.
+7. **Regresi:** reload `/deep` settled — tool rows, artifact, sources, **DAN reasoning** tetap render (jebakan
+   reasoning-delete Fase 6 — uji eksplisit). Gates: `tsc`/`eslint` 0, `eve-timeline.test.ts` hijau.
+
+## Traps (JANGAN lakukan)
+- **JANGAN** simpan `channel.continuationToken` (double-namespace → regres B). Token benar = dari respons create-POST.
+- **JANGAN** drop SEMUA delta — `reasoning.completed` 0× → reasoning final hilang. Strip-keep-last (Fase 6), bukan drop.
+- **JANGAN** kejar child-stream subagent — `childSessionId` tak ada; reducer tak handle. Pakai elapsed indicator.
+- **JANGAN** hapus `buildOrderedLog`/`use-thread-resume` — keduanya tetap perlu (kini 2-source / satu-satunya live source).
+- Reconciler **WAJIB** tulis event terminal + status (bukan status saja) atau heuristik klien & DB divergen.
+
+## File-file kritis
+- agent-v2: `agent/lib/store.ts` (step_index, synthetic terminal, strip), `agent/hooks/projection.ts` (Fase 6 strip),
+  `agent/channels/eve.ts` (BIARKAN — komentar 60-67 benar).
+- db: `src/schema/chatThreadEvents.ts` (step_index), `src/repositories/chatThreadEventRepo.ts` (GROUP BY step_index),
+  migrasi baru.
+- api-v2: `src/routes/threads.ts` (token upsert; hapus dukungan poll bila perlu), `src/workers/index.ts` + worker reconciler baru.
+- web-v2: `features/threads/api.ts` (hapus poll), `features/thread-experience/components/eve-chat-thread-surface.tsx`
+  (stop poll), `features/threads/components/chat-surface.tsx` (busy/HITL gating), `features/threads/lib/use-astra-agent.ts`
+  (token capture), `app/eve/v1/[...path]/route.ts` (proxy-tee), `features/threads/lib/eve-timeline.ts` +
+  `components/tool-row.tsx` (subagent elapsed, reuse `ElapsedLabel` dari `message-list.tsx`).

--- a/docs/v2/agent-streaming-hitl-redesign-research.md
+++ b/docs/v2/agent-streaming-hitl-redesign-research.md
@@ -1,0 +1,286 @@
+# Riset & Brainstorming: Streaming + HITL untuk Long-Running Agent (eve)
+
+> Branch: `feat/v2-agent` · Tanggal: 2026-06-26
+> Tujuan: menjawab pertanyaan owner — **apakah pendekatan streaming/HITL kita saat ini
+> over-engineering**, dan **apa cara paling matang** untuk: (a) streaming tetap real-time saat
+> user refresh, (b) run jalan terus di background saat user pindah halaman lalu kembali ke progres
+> terbaru yang tetap di-stream live, (c) HITL (ask_question/approval) yang mulus.
+> Metode: baca **dokumen resmi eve 0.11.6 yang ter-bundle** + **source dist eve** (verifikasi
+> runtime) + riset pola industri (AI SDK, Vercel Workflow, LangGraph) via context7/web + DB.
+> **Belum mengubah kode** (riset dulu, sesuai permintaan).
+
+---
+
+## 0. Jawaban singkat (TL;DR)
+
+**Ya — pendekatan saat ini over-engineering.** Kita **menulis ulang dengan tangan** apa yang eve
+sudah sediakan secara native, lalu menambah beberapa lapis kompensasi di atasnya. Bukan karena
+butuh kapabilitas baru, tapi karena kita **kurang memakai eve** (under-using), bukan kekurangan tool.
+
+**Tidak — tidak butuh infrastruktur/library/framework baru.** eve **sudah** durable-workflow
+(checkpoint per step, park tanpa konsumsi resource, stream durable yang bisa di-replay by index,
+multi-client, background). Postgres yang kita punya sudah cukup sebagai store history. **Tanpa
+Redis, tanpa pub/sub baru, tanpa SSE library.** Yang perlu justru **menghapus** kode, bukan menambah.
+
+**Sebagian kompleksitas memang wajar** untuk agent long-running + HITL — TAPI bentuknya jauh lebih
+kecil dari sekarang: **satu durable event stream (milik eve) + satu cursor index + token HITL yang
+disimpan server-side.** Sisanya (3-source merge, poll 2 dtk, client-captured token, persist tiap
+delta, compaction 3-lapis) bisa dibuang.
+
+---
+
+## 1. Apa yang eve SEBENARNYA sediakan (terverifikasi)
+
+Semua di bawah dikutip dari docs eve ter-bundle (`node_modules/eve/docs/`) + diverifikasi di source
+dist `0.11.6`.
+
+### 1.1 Stream durable yang replayable by index — INI yang kita tiru dengan tangan
+> *"The stream is durable. Every event is recorded before a step completes, so the whole stream is
+> replayable. Pass `startIndex` to reconnect by event count and pick up where you dropped off, or
+> rewind to the start."* — `docs/concepts/sessions-runs-and-streaming.md`
+
+`GET /eve/v1/session/:id/stream?startIndex=N` = **resume bawaan eve**. Server skip event `< N` lalu
+lanjut live. Inilah persis yang `useThreadResume` kita lakukan manual — tapi eve sudah
+menjadikannya kontrak resmi. Client `eve/client` juga punya `ClientSession.stream({ startIndex })`.
+
+### 1.2 `useEveAgent` TIDAK auto-attach saat mount (linchpin terverifikasi)
+Source dist (`react/eve-agent-store.js`): `initialSession` + `initialEvents` **hanya seed state**
+("seed prior state on construction"); **stream baru terbuka saat `send()`**, bukan saat mount, dan
+**tidak ada flag `resume`/`autoAttach`**. → Jadi resume turn-in-flight **memang** harus kita buka
+sendiri (premis lama benar). Tapi cara matang = **buka stream durable eve dari cursor** (1 fetch),
+bukan 3-source merge + poll.
+
+### 1.3 `continuationToken` di-ekspos ke handler channel SERVER-SIDE (kunci fix HITL)
+Source dist (`public/definitions/defineChannel.d.ts`):
+```ts
+export interface ChannelSessionOps {
+  readonly continuationToken: string;
+  setContinuationToken(token: string): void;
+}
+// handler `events: { "session.waiting": (data, channel, ctx) => {...} }` menerima `channel.continuationToken`
+```
+Artinya: channel eve milik kita (`agent-v2/agent/channels/eve.ts`) bisa **menyimpan token segar
+server-side tiap kali parkir** (`session.waiting`), key = sessionId. **Klien tak perlu menangkap
+token sama sekali.** Ini menyelesaikan akar "answering HITL fails / no token" secara tuntas.
+> Catatan: token **tidak** bisa di-regenerate via endpoint eve (hanya muncul di respons POST +
+> handler channel). Karena channel = milik kita, kita jadikan server SoT untuk token.
+
+### 1.4 HITL = park durable; jawab dengan `inputResponses` atau follow-up `message`
+> *"eve emits an `input.requested` stream event… The turn parks at `session.waiting`, durably, for
+> as long as it takes… The client answers with `inputResponses` (keyed by `requestId`) or a normal
+> follow-up `message`… The run picks back up exactly where it parked. Because the pause is durable,
+> nothing is held in memory while it waits — the process can restart and the parked turn survives."*
+> — `docs/tools/human-in-the-loop.md`
+
+### 1.5 Subagent = child session terpisah; parent HANYA dapat control-event
+> *"Each delegated subagent spins up its own child session and stream. The parent stream carries
+> only the control-plane events `subagent.called` and `subagent.completed`. To follow the child's
+> full progress, read `subagent.called.data.childSessionId` and subscribe at
+> `GET /eve/v1/session/:childSessionId/stream`."* — `docs/subagents.mdx`
+
+DB membuktikan: thread `/deep` selesai punya **`subagent.completed` × 8** tapi **0 event subagent
+selama subagent berjalan** → itulah **dead-air** 2–3,7 menit. **Bukan bug eve — desain.** Progres
+subagent ada, tapi di **child stream** yang tak kita subscribe.
+
+### 1.6 Background + multi-client = native, GRATIS
+> *"An eve session is a durable conversation. It can run for days and survives process restarts and
+> redeploys… the workflow suspends and holds no compute until the input it's waiting on arrives."*
+> — `docs/concepts/execution-model-and-durability.md`
+
+Run jalan terus server-side tanpa klien. Banyak klien boleh attach ke `GET …/stream` bersamaan
+(read-only feed). → **"pindah halaman, run lanjut, balik lihat progres terbaru live"** = cukup
+**re-attach ke stream dari cursor**. Tak perlu apa pun yang baru.
+
+---
+
+## 2. Apa yang KITA bangun di atasnya (inventaris over-engineering)
+
+| Yang kita bangun | eve sudah sediakan | Verdict |
+|---|---|---|
+| `useThreadResume` (hand-roll NDJSON fetch + EOF-reconnect + idle-timeout) | `GET …/stream?startIndex=N` durable + `ClientSession.stream({startIndex})` | Reinvensi. Inti (fetch stream dari cursor) wajar; sisanya (EOF poll, backoff, merge) berlebih |
+| `buildOrderedLog` **3-source merge** (poll ⊕ `agent.events` ⊕ `resumedEvents`) by index | Satu stream durable = satu log terurut | Buang — ganti 1 stream (active) + history terpisah |
+| `useThreadEvents` **poll 2 dtk** (`?afterIndex`) | Stream durable sudah live + replay | Buang — redundan, DAN sumber query O(n²) |
+| **Client-captured token** (`onSessionChange`→`saveContinuation`) | `channel.continuationToken` di handler `session.waiting` (server) | Pindah ke server — hapus kerapuhan |
+| **Persist tiap delta 1:1** (`messageSoFar` kumulatif) → 32 MB/run | Stream durable eve = SoT turn aktif; history cukup pesan final | Buang persist delta — simpan pesan final saja |
+| **Compaction 3 lapis** (SQL + `compactStreamingDeltas` + `compactThreadEvents`) | — | Hilang sendiri begitu delta tak dipersist |
+| `useSmoothText` custom | — | Boleh tetap (kecil), tak terkait akar |
+
+**Kenapa dulu di-hand-roll?** Alasan tercatat: *"eve/client menyeret runtime (node:module) tak bisa
+di-bundle ke browser"* + *"useEveAgent tak resume di mount"*. **Keduanya benar sebagian** — tapi
+solusinya **bukan** 3-source merge + poll: cukup **fetch endpoint stream durable eve** (HTTP biasa,
+sudah kita proxy) dan **feed ke reducer yang sama**. Itu satu jalur, bukan tiga.
+
+---
+
+## 3. Akar tiap gejala dalam istilah arsitektur ini
+
+- **Case A — kartu HITL tak muncul live, baru muncul setelah refresh.** Di jalur SEND live
+  (`agent.events`), saat turn parkir eve menutup stream send; `agent.events` (buffer turn aktif)
+  bisa **kehilangan ekor** `input.requested`/`session.waiting` saat di-handoff, sementara `base`
+  (3-source) hanya sinkron via poll 2 dtk yang berat/telat → `busy` jadi `false` tapi
+  `pendingInputRequests(base)` belum lihat part `approval-requested` → **0 kartu** sampai refresh
+  menarik snapshot dari DB. Akar = **mengandalkan merge multi-source yang tak sinkron**, bukan satu
+  stream durable yang otoritatif.
+- **Case B — klik opsi error / no token.** Token di-capture klien dari boundary `session.waiting`.
+  Kalau jalur live tak pernah sampai boundary bersih (Case A), token tak tersimpan → `continue`
+  ditolak "Missing continuationToken". Akar = **token di klien**, bukan server.
+- **Slow pasca-refresh / "Memuat thread…".** `/events` cold-load + tiap poll men-detoast **32 MB**
+  (query compaction tanpa index, tanpa `afterIndex` di subquery). Akar = **persist tiap delta** →
+  O(n²). (Lihat audit `hitl-streaming-audit-live.md`.)
+- **Frozen 2–3,7 mnt.** Dead-air subagent (§1.5) — child stream tak di-subscribe.
+- **Zombie (busy selamanya).** Turn crash (a.l. ENOSPC) tak menulis event terminal → `isStreamActive`
+  (heuristik last-event) selamanya true. Akar = **tak ada reconciler** + **menebak status dari
+  event terakhir** alih-alih status durable.
+
+> Semua akar ini berakar pada **satu** keputusan arsitektur: menjadikan **gabungan klien (merge +
+> poll + token + delta-persist)** sebagai SoT, alih-alih **stream durable eve + server**.
+
+---
+
+## 4. Arsitektur matang yang diusulkan (target)
+
+Prinsip: **eve durable stream = SoT turn aktif. Postgres = history pesan final + token + status.
+Klien = render, bukan rekonsiliasi.** Lima pilar:
+
+### Pilar 1 — Satu stream, satu cursor (resume = live = background, satu mekanisme)
+- Turn aktif (baik baru-`send` maupun resume pasca-refresh/nav) → **buka `GET /eve/v1/session/:id/
+  stream?startIndex=N`** dan feed ke reducer eve. `N` = index event terakhir yang sudah dilihat.
+- **Mount in-flight** → buka dari `startIndex = lastSeenIndex` → eve replay gap + live. **Tanpa poll,
+  tanpa 3-source merge.** Background/nav-balik = kasus yang sama (re-attach dari cursor); run sudah
+  jalan server-side.
+- History turn lama → render dari **pesan final** (Postgres), bukan event log. Active turn =
+  overlay stream di atas history. Dua bagian **terpisah jelas** (history vs active), bukan merge by-index.
+
+### Pilar 2 — Token HITL disimpan SERVER-SIDE
+- Di `agent-v2/agent/channels/eve.ts`, tambah `events: { "session.waiting": (d, channel) =>
+  persistToken(sessionId, channel.continuationToken) }`. (1.3)
+- Klien menjawab **lewat api-v2 by sessionId** (`POST /threads/:id/answer {requestId, optionId|text}`),
+  api-v2 ambil token tersimpan → panggil eve `continue`. **Klien tak pernah pegang token.** Survive
+  refresh/nav/redeploy. (Opsi lebih ringan: tetap kirim token ke klien via `initialSession`, tapi
+  **sumbernya** persist server-side yang andal — bukan capture klien.)
+
+### Pilar 3 — Persist pesan FINAL, bukan delta
+- Jalur tulis (`store.ts`): berhenti `insert` tiap `message.appended` kumulatif. Simpan **pesan
+  final per (turn, step)** saat `step.completed`/`message.completed` (sudah ada `recordAssistantMessage`).
+- Hilangkan **3 lapis compaction** + query O(n²). Cold-load jadi kecil (pesan final, bukan 32 MB).
+- Token-level live tetap dari **stream durable eve** (bukan dari delta Postgres).
+- Cursor resume = `SessionState.streamIndex` milik eve (bukan `count(*)` baris kita) → decouple.
+
+### Pilar 4 — Subagent: subscribe child stream (bunuh dead-air)
+- Saat parent emit `subagent.called` (childSessionId), buka `GET …/session/:childSessionId/stream`
+  dan tampilkan progres child di timeline parent (mis. "literature-searcher: cari arXiv… 8 ditemukan").
+  Heartbeat alami → tak ada lagi diam 3 menit. (Verifikasi field pembawa `childSessionId` saat impl;
+  DB kita saat ini menyimpan `subagent.completed`, perlu cek `subagent.called`.)
+
+### Pilar 5 — Status durable + reconciler (bunuh zombie)
+- Status turn dari **lifecycle event terminal** (`turn.completed/failed`, `session.waiting/completed/
+  failed`), bukan tebak last-event. Turn crash → reconciler tandai `failed` + event terminal sintetik
+  bila `streaming` tanpa event > N menit. (+ heartbeat child dari Pilar 4 menjaga turn hidup "fresh".)
+- Operasional: **disk penuh = penyebab crash → zombie.** Jaga disk lega (lihat audit §ENOSPC).
+
+---
+
+## 5. Opsi & trade-off per area (matang)
+
+### A. Mekanisme resume/stream
+- **A1 (rekomendasi) — Proxy stream durable eve + reducer tunggal.** Browser fetch
+  `GET /eve/v1/session/:id/stream?startIndex=N` (sudah ada Route Handler proxy), reduce sekali.
+  Buang poll + 3-source. *Minimal, tanpa infra.* Ceiling: butuh sedikit logika "kapan buka stream"
+  (mount-if-in-flight) — tapi jauh lebih kecil dari sekarang.
+- **A2 — `WorkflowChatTransport`-style auto-resume** (pola AI SDK v7). Transport deteksi stream
+  berakhir tanpa finish → reconnect otomatis. Elegan, tapi mengikat ke AI SDK transport; eve punya
+  client sendiri → A1 lebih lurus.
+- **A3 — Tetap pakai `useEveAgent` + thin server resume.** Karena `useEveAgent` tak attach di mount
+  (§1.2), sediakan endpoint server (api-v2, node, boleh `eve/client`) yang attach lalu re-stream ke
+  browser. Menghindari hand-roll di browser, tapi nambah hop. A1 lebih simpel.
+
+### B. Token HITL
+- **B1 (rekomendasi, matang) — Server SoT penuh.** Persist token di handler `session.waiting`;
+  jawab via api-v2 by sessionId. Klien bebas token.
+- **B2 (lazy) — Token tetap di `initialSession`, tapi sumber = persist server-side andal.** Perubahan
+  kecil; hilangkan capture klien `onSessionChange` yang rapuh. Cukup untuk fix Case B sekarang.
+
+### C. Storage history
+- **C1 (rekomendasi) — Hanya pesan final.** Hapus persist delta; reload kecil & cepat.
+- **C2 (band-aid) — Tetap persist delta + index ekspresi** untuk mempercepat query compaction. Tak
+  menyelesaikan storage; hanya tunda. (lihat audit opsi C2.)
+
+### D. Dead-air subagent
+- **D1 (rekomendasi) — Subscribe child stream**, tampilkan progres.
+- **D2 — Heartbeat parent** tiap 15–20 dtk saat menunggu subagent (lebih murah, kurang informatif).
+  Bisa dikombinasi.
+
+### E. Zombie
+- **E1 — Reconciler server-side** (cron / on-open) tandai `streaming` basi → `failed` + terminal event.
+- **E2 — Staleness guard klien** (last-event > ambang → treat settled). Pasangkan dengan D2 supaya
+  ambang aman. (lihat audit §A.)
+
+---
+
+## 6. Apakah butuh infrastruktur / library / framework baru?
+
+**Tidak.** Bukti dari riset pola industri:
+
+- **AI SDK `resumable-stream` (Redis pub/sub)** ada **justru untuk backend stateless/serverless yang
+  TIDAK durable** — Redis dipakai sebagai buffer durable. *Kita sudah punya backend durable (eve =
+  Vercel Workflow) + event log Postgres → ingredient yang sama, tanpa Redis.* (Sumber: AI SDK
+  "Chatbot Resume Streams"; `vercel/resumable-stream`.)
+- **Vercel Workflow DevKit resumable streams** (`getRun(id).getReadable({ startIndex })`) = **tanpa
+  Redis**, durabilitas inheren ke run — **persis model eve `startIndex`**. Ini "best fit" dan kita
+  **sudah punya** (lewat eve). (Sumber: Workflow DevKit – Resumable Streams.)
+- **SSE `Last-Event-ID`** = primitive generik (replay event setelah id terakhir). eve `startIndex`
+  adalah bentuk yang sama. Tak perlu library SSE.
+- **HITL tanpa token klien**: LangGraph `interrupt()`+`Command(resume)` by `thread_id`; Vercel
+  Workflow `hook.resume(token)` by `toolCallId`. **Pola yang sama** bisa kita capai dalam batas eve
+  via **token server-side** (§1.3) — `thread.id == eve sessionId` kita = "stable id" itu.
+
+> Satu-satunya skenario yang menuntut infra baru (Redis) adalah jika kita **meninggalkan
+> durabilitas eve** dan menjalankan agent stateless. Kita tidak melakukan itu — jadi **nol infra baru.**
+
+---
+
+## 7. Verdict over-engineering (jawab langsung ke owner)
+
+**Kamu benar.** Yang terjadi sekarang over-engineering: kita membangun **resume + merge + poll +
+token + delta-persist + compaction** untuk meniru kapabilitas yang **eve sudah berikan durable &
+by-index**. Kompleksitas itu **bukan** harga wajib dari "agent long-running + HITL" — buktinya pola
+matang (Workflow DevKit, LangGraph) justru **lebih sedikit bagian bergerak**: satu durable log + satu
+cursor + resume by stable-id.
+
+**Sebagian kompleksitas memang inheren** ke domain (durable run, park HITL, resume cursor, persist
+history) — tapi eve **sudah menanggungnya**. Tugas kita tinggal **memakainya**, bukan menduplikasi.
+Arah fix matang = **hapus lebih banyak daripada menambah**: turunkan ke 1 stream + token server-side
++ pesan final + child-subscribe + reconciler.
+
+---
+
+## 8. Migrasi bertahap (tanpa big-bang)
+
+1. **B1/B2 token server-side** (kecil, fix Case B sekarang) — handler `session.waiting` persist token.
+2. **A1 stream tunggal** — ganti `useThreadResume`+`buildOrderedLog`+poll dengan: history (pesan
+   final) + overlay 1 stream durable dari cursor. Fix Case A + frozen-pasca-refresh.
+3. **C1 pesan final** — stop persist delta; fix slow + storage O(n²). (Migrasi: turn lama tetap
+   terbaca via fallback; turn baru ringan.)
+4. **D1 child-subscribe** — fix dead-air.
+5. **E1 reconciler** — fix zombie.
+
+Tiap langkah berdiri sendiri & menghapus kode. Urutan 1→2 memberi dampak terbesar paling cepat.
+
+---
+
+## 9. Referensi
+
+**eve (bundled docs, v0.11.6):** `docs/concepts/sessions-runs-and-streaming.md`,
+`docs/concepts/execution-model-and-durability.md`, `docs/tools/human-in-the-loop.md`,
+`docs/subagents.mdx`, `docs/guides/client/continuations.mdx`, `docs/guides/client/streaming.mdx`,
+`docs/guides/frontend/overview.mdx`, `docs/channels/eve.mdx`.
+**eve source (dist 0.11.6):** `react/eve-agent-store.js` (no mount-attach),
+`public/definitions/defineChannel.d.ts` (`ChannelSessionOps.continuationToken`),
+`protocol/routes.d.ts`, `protocol/message.d.ts`, `client/session.d.ts` (`stream({startIndex})`).
+**Industri:** [AI SDK – Chatbot Resume Streams](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-resume-streams) ·
+[vercel/resumable-stream](https://github.com/vercel/resumable-stream) ·
+[Workflow DevKit – Resumable Streams](https://workflow-sdk.dev/docs/ai/resumable-streams) ·
+[Workflow DevKit – Human-in-the-Loop](https://workflow-sdk.dev/docs/ai/human-in-the-loop) ·
+[LangGraph – Interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts) ·
+[WHATWG – Server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html).
+**Audit pendamping:** `docs/v2/hitl-streaming-audit-live.md` (reproduksi live + bukti DB).

--- a/docs/v2/hitl-streaming-audit-live.md
+++ b/docs/v2/hitl-streaming-audit-live.md
@@ -1,0 +1,261 @@
+# Audit Langsung HITL & Streaming — Reproduksi E2E (browser + DB + network)
+
+> Branch: `feat/v2-agent` · Tanggal audit: 2026-06-26
+> Metode: kontrol **Claude-in-Chrome (Brave)** terhadap stack lokal yang baru di-start
+> (`web-v2 :3000` → `api-v2 :3001` → `eve agent-v2 :4317`, data Postgres VPS `100.75.23.41`),
+> + inspeksi langsung `chat_thread_events`/`chat_threads` (Postgres) + `read_network_requests`/
+> `read_console_messages`.
+> Konteks: lanjutan `hitl-streaming-fixes.md` (§1–§9). Owner melapor **4 gejala masih eksis**
+> meski fix §9 sudah ada. Dokumen ini = hasil reproduksi langsung + akar yang sebenarnya tersisa
+> + opsi solusi matang. **Belum ada perubahan kode** (audit-only, sesuai permintaan).
+
+---
+
+## 0. TL;DR (verdict)
+
+Stack lokal **yang baru di-restart penuh** ternyata menjalankan fix §1–§9 dengan **benar**. Dari 4
+gejala yang dilaporkan owner, **2 tidak ter-reproduksi** (sudah beres) dan **2 ter-reproduksi tapi
+akarnya BUKAN yang ditangani §1–§9**:
+
+| # | Gejala dilaporkan | Verdict live | Akar sebenarnya |
+|---|---|---|---|
+| 1 | Progres beku / hanya maju saat refresh | **Ter-reproduksi (2 bentuk)** | **(A) Thread "zombie"** (proses mati mid-turn → busy selamanya, composer terkunci, refresh tak menolong) **+ (B) dead-air subagent** 2–3 mnt (genuine) |
+| 2 | Kartu HITL menumpuk / muncul lagi | **TIDAK ter-reproduksi** | Anti-pileup (`pendingInputRequests` last-assistant-message) bekerja |
+| 3 | Lambat pasca-refresh (crawl / "Memuat thread…") | **Sebagian** | Cold-load ~2 dtk di thread 32 MB = **biaya query compaction** (detoast 32 MB tiap panggil), BUKAN payload (117 kB). `useSmoothText` fix benar |
+| 4 | Menjawab HITL gagal (klik opsi / ketik) | **TIDAK ter-reproduksi** | Klik opsi & teks-bebas dua-duanya jalan; `continuation_token` tertangkap |
+
+**Kesimpulan inti:** fix §1–§9 **secara kode sudah benar**. Yang membuat owner masih melihat "isu
+tetap eksis" ada dua kemungkinan, dan keduanya nyata:
+
+1. **Lingkungan basi (stale env).** Fix §9 **belum di-commit** (semua di working tree). Dua fix
+   kunci — hapus `rewrites()` di `next.config.ts` **dan** Route Handler baru
+   `app/eve/v1/[...path]/route.ts` — **butuh RESTART penuh Next**, bukan Fast Refresh. Saat audit,
+   console menunjukkan `[Fast Refresh] rebuilding`. Jika owner mengedit file lalu hanya
+   meng-andalkan HMR (tanpa kill+restart `dev:web-v2`), server bisa **masih memakai jalur
+   rewrites lama** (buffer stream → beku) — persis gejala §5.
+2. **Tiga akar yang §1–§9 memang tak menyentuh** (di bawah). Ini yang harus difokuskan ke depan.
+
+---
+
+## 1. Yang DIVERIFIKASI BEKERJA (live)
+
+Satu run `/deep "manfaat dan risiko puasa intermiten untuk pemula"` (thread
+`wrun_01KW17JPN7N28GBCAPCYEK700D`) dipakai untuk menguji jalur interaktif:
+
+- ✅ **Turn pertama streaming + URL bump.** `POST /eve/v1/session` 202 → discovery
+  `GET /threads/recent-active` → URL melompat `/app` → `/app/threads/wrun_…` saat agen menyusun
+  jawaban (tak mendarat di halaman kosong).
+- ✅ **Kartu HITL muncul.** `ask_question` ("Untuk apa hasil riset ini digunakan?") render sebagai
+  kartu di atas composer + placeholder berubah jadi sadar-konteks.
+- ✅ **Refresh saat parkir.** Reload di tengah kartu → kartu **tetap ada**, judul auto-gen, tanpa
+  "Memuat thread…" macet. DB: `status=idle`, `last_event=session.waiting`,
+  `continuation_token=eve:13c5acf3-…` **tersimpan** (single-namespace).
+- ✅ **Menjawab via klik opsi.** Kartu hilang, turn baru jalan, **tanpa** `Session.send requires…`.
+  Network: `POST /eve/v1/session/wrun_…` 200 + `GET …/stream?startIndex=76` 200 (selaras
+  `liveStartIndex`).
+- ✅ **Menjawab via teks bebas** (§4). Ketik "ya lanjutkan risetnya" → kartu hilang, **tak ada
+  bubble user palsu**, riset lanjut → ter-route ke `inputResponses`, bukan turn baru.
+- ✅ **Anti-pileup.** Saat kartu #2 (konfirmasi rencana) muncul, kartu #1 **sudah hilang** — hanya
+  1 kartu tampil. Tak menumpuk.
+- ✅ **Resume pasca-refresh men-track burst live.** Refresh saat subagent jalan → resume
+  `GET …/stream?startIndex=358` terbuka + poll `?afterIndex=357` jalan; saat subagent selesai, UI
+  menampilkan "Menelaah literatur · 8/12/9 hasil" **tanpa refresh lagi**.
+
+Artinya: gejala #2 dan #4 **tidak bisa direproduksi** di stack yang benar; jalur resume §9.1 juga
+**bekerja**.
+
+---
+
+## 2. Akar nyata #A — Thread "zombie" (busy selamanya) — **PALING PARAH**
+
+### Bukti
+Thread `wrun_01KVWSTHH4T32QZ47260BPPNX9` ("Tren Agen AI 2026"):
+
+| field | nilai |
+|---|---|
+| `status` | **`streaming`** (sejak **06-24 12:52**, >2 hari) |
+| `last_event_type` | **`message.appended`** (NON-terminal — mati di tengah "tulis laporan akhir") |
+| `max_idx` | 1090 |
+| `continuation_token` | ada |
+
+Saat dibuka di browser:
+- UI tampil **"Sedang bekerja… 12s"** + composer **terkunci ("Stop")** — padahal turn mati 2 hari lalu.
+- Network: `GET /eve/v1/session/wrun_…/stream?startIndex=1091` → **`pending` (menggantung selamanya)**.
+  eve menahan stream durable terbuka; workflow-nya suspended/mati → tak pernah emit → `resuming=true`
+  selamanya.
+- **Refresh tak menolong**: `status` permanen `streaming`, `last_event` permanen non-terminal,
+  resume buka ulang stream yang sama (menggantung). User **tak bisa mengetik** (composer terkunci).
+
+### Mekanisme
+Klien menentukan "turn masih jalan" dari **tipe event TERAKHIR** (`isStreamActive` di
+`eve-timeline.ts`). Turn yang **mati tanpa** menulis event terminal (`turn.completed`/`turn.failed`/
+`session.waiting`/`session.failed`) → event terakhir selamanya non-terminal → `isStreamActive=true`
+→ `streamActive=true` → resume enabled + `busy=true` → composer terkunci + resume menggantung.
+Kode sendiri mengakui ini gap (`eve-timeline.ts`): *"turn yang MACET (proses mati tanpa
+turn.completed) tetap tampak aktif → poll sampai user pindah thread; reconciler server-side adalah
+peningkatannya."*
+
+> Catatan: bahkan `IDLE_TIMEOUT_MS=600_000` (10 mnt) di `useThreadResume` tak menyelamatkan — saat
+> resume menyerah, `busy` tetap `true` lewat `isStreamActive(base)` (event terakhir tetap
+> non-terminal). Jadi lock-nya permanen.
+
+**Ini kandidat terkuat "frozen, refresh tak menolong, tak bisa apa-apa" yang dirasakan owner.** Tiap
+run `/deep` yang crash (OOM, dev restart, disk penuh — lihat §9.5 lama: ENOSPC) meninggalkan satu
+thread zombie.
+
+---
+
+## 3. Akar nyata #B — Dead-air subagent 2–3 menit (genuine, "frozen" semu)
+
+### Bukti
+Pada run uji, subagent `literature-searcher` dipanggil sebagai **`actions.requested`** biasa
+(**`n_subagent_events = 0`** — tak ada event `subagent.*` yang di-stream/persist ke induk). Saat 5
+subagent jalan paralel (task-mode), stream induk **diam total**:
+
+| snapshot | `max_idx` | `secs_since_last_event` |
+|---|---|---|
+| awal subagent | 357 | **170 dtk** (≈2m50s) macet di `step.completed` |
+| fase berikutnya | 397 | **136 dtk** macet lagi |
+
+Selama gap ini: resume stream terbuka (startIndex 358) **menerima 0**, poll `?afterIndex=357`
+**balik kosong**, `max_idx` tak gerak. UI menampilkan snapshot + **"Sedang bekerja… N s"**
+(`ElapsedLabel` berdetak). **Bukan rusak** — tapi 2–3 menit tanpa konten baru **terasa beku** bagi user.
+
+### Mekanisme
+Subagent task-mode berjalan di **child-session** sendiri; event progres mereka **tidak** di-forward
+ke stream induk (DB-verified: 0 event `subagent.*`). Induk hanya menerima `action.result` saat tiap
+subagent **selesai**. Di antaranya = dead-air. `/deep` punya BANYAK fase begini (5 lit-searcher →
+counter-evidence → verify → sintesis), jadi beberapa gap 2–3 mnt menumpuk → terasa "beku berulang".
+
+> Subkasus "refresh melompat maju": terjadi bila event **ter-persist** tapi jalur live tak
+> menampilkannya. Di stack benar TIDAK ter-reproduksi (eve menahan stream + push burst → UI track
+> live; lihat §1). Bila owner masih melihatnya, kemungkinan besar **stale env** (jalur rewrites lama
+> mem-buffer) ATAU edge-case reconnect klien eve saat gap sangat panjang.
+
+---
+
+## 4. Akar nyata #C — Storage O(n²) + query compaction berat
+
+### Bukti (DB)
+`message.appended`/`reasoning.appended` membawa teks **kumulatif** (`messageSoFar`) dan **di-persist
+1:1** (`projection.ts` hook `"*"` → `store.ts appendThreadEvent`). Akibatnya storage tumbuh O(n²):
+
+| thread | events | payload | deltas | catatan |
+|---|---|---|---|---|
+| `wrun_01KVZ4WYH2…` | 6119 | **32 MB** | 6041 (=seluruh 32 MB) | 1 run `/deep` selesai |
+| `wrun_01KVYWFCEF…` | 2731 | 10 MB | 2623 | — |
+
+Compaction **jalur-baca** bekerja bagus: `listByThread` (SQL) memangkas **6119 baris/32 MB → 84
+baris/117 kB** (~280×). **TAPI**:
+- `/events` cold-load di thread 32 MB terukur **~1983 ms** (Performance API). Payload cuma 117 kB +
+  latensi Tailscale rendah → **~2 dtk itu murni biaya query**: subquery `GROUP BY type, turn_id,
+  (payload->'data'->>'stepIndex')` harus **men-detoast 32 MB JSONB** tiap panggil, dan satu-satunya
+  index = `(thread_id, event_index)` (tak ada index pendukung GROUP BY).
+- **Subquery compaction TIDAK ber-`afterIndex`** — ia meng-agregasi **seluruh thread** walau poll
+  hanya minta ekor. Jadi **tiap poll 2 dtk** (saat turn aktif) men-detoast ulang seluruh log. Saat
+  `/deep` berjalan, log membengkak → query poll makin berat → mendekati/melampaui interval 2 dtk →
+  tekanan DB + poll telat. Ini memperburuk rasa "beku/lambat" pada thread besar/turn panjang.
+
+`useSmoothText` fix (§9.2, mulai dari teks yang ada) **benar secara kode** (terbaca: `shownLen =
+targetRef.current.length`), jadi crawl-dari-0 tidak akan terjadi pada thread yang kode-nya terpasang.
+
+---
+
+## 5. Temuan kecil
+
+- **`ElapsedLabel` reset tiap refresh.** `useState(() => Date.now())` per-mount → thread zombie 2
+  hari pun tampil "Sedang bekerja… 12s". Memperkuat ilusi "baru mulai kerja" pada turn yang sebenarnya
+  mati. (Hitung dari `createdAt` event aktif pertama, bukan mount.)
+- **Komentar usang `proxy.ts`** masih menyebut "rewrite Next (next.config) mem-proxy route eve" —
+  padahal `rewrites()` sudah dihapus dan diganti Route Handler. Tidak fungsional, tapi menyesatkan.
+- **Persist via `swallow("event", …)`** (projection): bila SATU insert gagal (mis. ENOSPC), event
+  di-drop diam-diam → `event_index` DB bergeser dari index stream eve sebenarnya → cursor resume
+  bisa meleset (di-flag di `streamIndexFromEvents`). Fragil tapi jarang.
+
+---
+
+## 6. Opsi solusi (matang, lazy-first)
+
+### #A Zombie thread (PRIORITAS 1 — paling mengganggu, paling mudah)
+- **A1 — Staleness guard di klien (paling lazy, ~10 baris).** `isStreamActive` kembalikan `false`
+  bila event terakhir non-terminal **tapi `createdAt`-nya lebih tua dari ambang** (mis. 90–120 dtk).
+  Efek: composer ke-unlock, resume berhenti, user bisa lanjut/retry. *Ceiling:* ambang harus > gap
+  dead-air sah → **pasangkan dengan heartbeat (B3)** supaya turn yang benar-benar hidup tetap "fresh"
+  dan ambang bisa ketat. Tanpa heartbeat, ambang harus ≥ ~3–4 mnt (lebih longgar, tetap memperbaiki
+  zombie).
+- **A2 — Reconciler server-side (durable, "fix benar").** Job berkala / on-thread-GET: thread
+  `status='streaming'` tanpa event > N mnt → set `status='failed'` + append event terminal sintetik
+  (`turn.failed`). Beres untuk semua klien + bersihkan DB. Ini "reconciler" yang dicatat TODO kode.
+- **A3 — Tanya eve status sesi.** Cek state sesi/turn eve langsung (apakah workflow benar mati).
+  Paling akurat, tapi tergantung API eve + lebih berat.
+- **Rekomendasi:** A1 (+B3) **segera** untuk unblock; A2 sebagai pembersih durable.
+
+### #B Dead-air subagent (PRIORITAS 2)
+- **B3 — Heartbeat induk (paling lazy & paling berleverage).** Selama menunggu subagent, emit event
+  "masih bekerja" berkala (mis. tiap 15–20 dtk) ke stream/persist. Sekaligus: (a) liveness nyata,
+  (b) membuat staleness-guard A1 aman (turn hidup = `createdAt` selalu fresh; hanya turn mati yang
+  jadi basi). Satu mekanisme, dua masalah teratasi.
+- **B2 — Forward progres subagent ke induk (UX terbaik).** Jembatani event child-session (mis.
+  `subagent.started/step/completed`, "literature-searcher: cari arXiv… 8 ditemukan") ke timeline
+  induk. Saat ini **0** event subagent ter-forward → dead-air total. Bahkan progres kasar membunuh
+  rasa beku. Lebih besar; cek dukungan eve untuk forwarding event subagent.
+- **Rekomendasi:** B3 dulu (murah, sinergi dengan A1), B2 menyusul untuk UX kaya.
+
+### #C Storage O(n²) + query compaction (PRIORITAS 3 — skala)
+- **C2 — Index ekspresi (band-aid query, paling lazy, no migrasi data).** Tambah index untuk
+  mendukung GROUP BY, mis. partial index pada delta:
+  `(thread_id, type, turn_id, (payload->'data'->>'stepIndex'), event_index)`. Mempercepat subquery
+  `max(event_index)` per step tanpa ubah kode. *Ceiling:* tak mengecilkan storage; payload tetap
+  di-detoast saat SELECT baris final.
+- **C1 — Stop persist delta tersusul (jalur-tulis, fix nyata storage).** Di `store.ts`, untuk
+  `*.appended` **UPDATE baris delta (type,turnId,stepIndex) yang sama** alih-alih INSERT baru →
+  storage O(n) (32 MB → ~117 kB at-rest), query baca trivial (tak perlu compaction). **Syarat:**
+  pisahkan **cursor resume dari jumlah baris** (resume `startIndex` harus = index stream eve, bukan
+  `count`). Simpan index stream eve native per thread. Medium, tapi menyelesaikan akar.
+- **C4 — Jangan persist delta sama sekali.** Persist hanya event non-delta + **teks final** per
+  (turn, step) saat `step.completed`. Token-level live tetap dari stream eve (bukan DB). Kemenangan
+  storage terbesar + baca paling simpel; resume token-level mid-step datang dari stream eve, DB cukup
+  untuk reload. Sama-sama butuh decouple cursor (seperti C1).
+- **Rekomendasi:** C2 **segera** (cepat, aman); lalu C1 **atau** C4 + decouple cursor sebagai fix akar.
+
+### Kecil
+- **`ElapsedLabel`**: hitung dari `createdAt` event aktif pertama turn, bukan `Date.now()` mount.
+- Luruskan komentar `proxy.ts` (sudah Route Handler, bukan rewrites).
+
+---
+
+## 7. Rekomendasi prioritas
+
+1. **Verifikasi lingkungan dulu (gratis).** Pastikan owner menjalankan **`bun dev:v2` segar**
+   (kill semua, lalu start) — `next.config.ts` + Route Handler baru **wajib restart penuh Next**,
+   tak cukup Fast Refresh. Konfirmasi di Network tab: `/eve/v1/.../stream?startIndex=` ter-request
+   dan men-`pending` saat turn jalan. Bila ya, gejala #2/#4 mestinya hilang (sesuai audit ini).
+2. **A1 + B3** (staleness guard + heartbeat) — membunuh zombie & melembutkan dead-air. Dampak
+   tertinggi, usaha terendah.
+3. **C2** (index) — redam tekanan query poll pada thread besar.
+4. **A2 / B2 / C1-C4** — fix durable (reconciler, forward subagent, decouple cursor) sebagai fase
+   berikutnya.
+5. **Commit fix §9** yang masih di working tree, supaya tidak hilang & deploy konsisten.
+
+---
+
+## 8. Lampiran — cara cek lingkungan tidak basi
+
+- `git status` → fix §9 masih `M`/`??` (uncommitted). Pastikan file aktif di server = versi ini.
+- Restart penuh: kill `dev:web-v2`/`dev:eve`/`dev:api`, lalu `bun dev:v2`. **Jangan** andalkan HMR
+  untuk `next.config.ts` & route handler baru.
+- Network saat `/deep` aktif: harus ada `GET /eve/v1/session/<id>/stream?startIndex=N` (status
+  `pending`/`200`) **dan** `GET /threads/<id>/events?afterIndex=N`. Bila yang muncul malah jalur
+  rewrites lama / tak ada Route Handler → stale.
+- DB sanity: `select status,count(*) from chat_threads group by 1;` — banyak `streaming` basi =
+  zombie menumpuk (butuh A1/A2).
+
+---
+
+## 9. Ringkasan thread bukti
+
+| thread | peran di audit |
+|---|---|
+| `wrun_01KW17JPN7N28GBCAPCYEK700D` | run `/deep` uji — semua jalur interaktif + dead-air subagent |
+| `wrun_01KVWSTHH4T32QZ47260BPPNX9` | **zombie** `status=streaming` 2 hari, composer terkunci, resume menggantung |
+| `wrun_01KVZ4WYH2Y6S8RXK232YHVRZJ` | `/deep` selesai 32 MB/6119 event — cold-load ~2 dtk (biaya query compaction) |

--- a/docs/v2/hitl-streaming-fixes.md
+++ b/docs/v2/hitl-streaming-fixes.md
@@ -1,0 +1,470 @@
+# HITL & Streaming Fixes — Thread Experience (eve)
+
+> Branch: `feat/v2-agent`
+> Cakupan: `apps/web-v2` (thread UI + proxy eve) dan `apps/agent-v2` (tool gate).
+> Konteks: penambahan **approval** (`needsApproval`) dan **`ask_question`** untuk Astra, lalu
+> serangkaian audit yang menemukan bug logika HITL + masalah streaming di local dev.
+
+Dokumen ini merangkum **isu utama** yang kita hadapi dan **solusi yang sudah diimplementasikan**,
+beserta mekanisme internal eve yang menjadi akar tiap masalah.
+
+---
+
+## 0. Ground truth eve yang relevan
+
+Beberapa fakta dari source eve `0.11.6` yang dirujuk berulang di bawah:
+
+- **Reducer event-log.** Timeline thread direkonstruksi dengan mereduksi event stream eve
+  (`defaultMessageReducer`). Adapter di `eve-timeline.ts` me-reduce **event-log** ini (bukan
+  hanya buffer live), agar reload/resume identik dengan live.
+- **HITL = `input.requested`.** Approval tool (`needsApproval`) dan `ask_question` sama-sama
+  muncul sebagai event `input.requested` → part `dynamic-tool` ber-state **`approval-requested`**.
+- **`client.input.responded` itu event proyeksi KLIEN (optimistic).** Per dok
+  `use-eve-agent.ts`: *"Optimistic events are reducer-facing projection events only. They are not
+  exposed through `events`."* Artinya jawaban HITL **tidak pernah** masuk `agent.events` maupun
+  event-log yang dipersist.
+- **`ask_question` TIDAK meng-emit `action.result`.** Hanya approval yang **ditolak** yang
+  meng-emit `action.result` (rejected); approval yang **disetujui** memicu eksekusi tool →
+  `action.result`. `ask_question` tidak menghasilkan `action.result` sama sekali (terverifikasi
+  via DB: callId `ask_question` tak punya baris `action.result`).
+- **`continuationToken`** dicetak di route CREATE channel eve (`eve:<uuid>`), dikembalikan di
+  respons POST `202`, dan hanya **disimpan klien** oleh `advanceSession` **bila stream mencapai
+  boundary `session.waiting`** (`turn.completed` BUKAN boundary).
+- **Proxy.** `useEveAgent` memanggil `/eve/v1/*` same-origin di web-v2, lalu diteruskan ke app
+  `@aqsha/agent-v2` (`eve dev`/`eve start`). Channel eve yang melakukan auth (bearer Clerk).
+
+---
+
+## 1. Kartu HITL basi & menumpuk (P0 — paling kritis)
+
+### Gejala
+Setelah `/deep`, beberapa kartu `ask_question` lama **muncul kembali dan menumpuk** (3 kartu
+sekaligus) di atas composer — termasuk setelah turn/riset selesai dan setelah refresh.
+
+### Akar masalah
+`pendingInputRequests` (di `eve-timeline.ts`) mula-mula menentukan "masih pending" dari
+**ketiadaan `eve.inputResponse`** pada part, lalu sempat dikoreksi ke **state `approval-requested`**.
+Keduanya **salah untuk `ask_question`**:
+
+- `eve.inputResponse` hanya diisi event proyeksi klien `client.input.responded` → **tak pernah ada**
+  di event-log yang direduksi → part selalu tampak "belum dijawab".
+- `ask_question` tak pernah meng-emit `action.result`, jadi part-nya **nyangkut di
+  `approval-requested` SELAMANYA** di turn lama → gate berbasis state pun tetap menampilkannya.
+
+Karena eve serial per session, satu-satunya pertanyaan yang benar-benar menunggu user adalah yang
+ada di **turn terakhir**.
+
+### Solusi
+`pendingInputRequests` kini hanya memindai **pesan asisten TERAKHIR** dan mengambil part
+`approval-requested` di sana:
+
+```ts
+export function pendingInputRequests(events): PendingInputRequest[] {
+  const { messages } = reduceEventsToMessageData(events);
+  let last: EveMessage | undefined;
+  for (const m of messages) if (m.role === "assistant") last = m; // turn terakhir
+  if (!last) return [];
+
+  const out: PendingInputRequest[] = [];
+  const seen = new Set<string>();
+  for (const part of last.parts) {
+    if (part.type !== "dynamic-tool" || part.state !== "approval-requested") continue;
+    const req = part.toolMetadata?.eve?.inputRequest;
+    if (!req || seen.has(req.requestId)) continue;
+    seen.add(req.requestId);
+    out.push({ ...req, toolName: part.toolMetadata?.eve?.name ?? part.toolName });
+  }
+  return out;
+}
+```
+
+- Begitu user menjawab → turn baru dimulai → pesan asisten baru jadi yang terakhir → pertanyaan
+  lama otomatis bukan lagi "terakhir" = **tidak pending** (anti-menumpuk).
+- Turn selesai (sintesis) → pesan terakhir tak punya part `approval-requested` → **0 kartu**
+  (anti-basi).
+- Approval yang resolve mid-turn → `action.result` → state `output-*` → terfilter walau di turn
+  terakhir.
+- Batch paralel tetap didukung (semuanya di pesan terakhir yang sama).
+
+**Catatan arsitektur:** `upsertMessage` eve meng-update pesan **in-place** (tak me-reorder), dan
+turn serial dengan event terurut → pesan asisten terakhir di array = turn terbaru. Properti ini
+yang membuat "pesan terakhir" andal.
+
+### File
+- `apps/web-v2/features/threads/lib/eve-timeline.ts`
+
+---
+
+## 2. Part HITL ganda di transkrip
+
+### Gejala
+Pertanyaan/approval yang sedang parkir juga muncul sebagai **tool-row generik** ("Bertanya",
+"Menghapus artefak") di blok "Proses" — tampil ganda dengan kartu di atas composer.
+
+### Solusi
+`mapPart` menyembunyikan part HITL yang **masih** parkir dari transkrip; yang sudah diresolve tetap
+tampil sebagai tool-row (jejak audit):
+
+```ts
+case "dynamic-tool": {
+  if (part.state === "approval-requested") return null; // dirender sbg kartu, bukan tool-row
+  // ...
+}
+```
+
+### File
+- `apps/web-v2/features/threads/lib/eve-timeline.ts`
+- `apps/web-v2/features/threads/components/message-list.tsx` (komentar diluruskan)
+
+---
+
+## 3. Copy kartu approval berbahasa Inggris & bocor nama tool
+
+### Gejala
+Kartu approval untuk `delete_artifact` menampilkan prompt Inggris mentah
+(`Approve tool call: delete_artifact`) + tombol **Yes/No** (di-generate eve di
+`harness/input-extraction.ts`).
+
+### Solusi
+Tetap pakai gate native `needsApproval: always()` (dapat auto-deny-on-continue yang aman untuk aksi
+destruktif), tapi **lokalkan di kartu** berdasar `toolName` yang kini ikut dibawa
+`pendingInputRequests`:
+
+```ts
+const APPROVAL_COPY = {
+  delete_artifact: {
+    prompt: "Hapus dokumen ini? Tindakan ini permanen dan tidak bisa dibatalkan.",
+    approve: "Hapus", deny: "Batal", danger: true,
+  },
+};
+const DEFAULT_APPROVAL = { prompt: "Setujui tindakan ini?", approve: "Setujui", deny: "Tolak" };
+```
+
+`ask_question` (prompt/opsi ditulis model, sudah Bahasa Indonesia) dipakai apa adanya. Prop
+`responding` & `DEFAULT_CONFIRM_OPTIONS` yang dead-code dihapus.
+
+### File
+- `apps/web-v2/features/threads/components/input-request-prompt.tsx`
+
+---
+
+## 4. Jawaban teks bebas untuk `ask_question`
+
+### Gejala
+Composer mengundang user mengetik jawaban, tapi teks dikirim sebagai **pesan biasa** →
+`ask_question` ter-resolve `{status:"ignored"}` + teks jadi turn baru (bukan jawaban terstruktur).
+
+### Solusi
+Composer me-route teks ke `inputResponses` bila ada `ask_question` freeform yang parkir
+(**bukan approval** — approval tetap wajib lewat tombol, mengetik = lanjut tanpa menyetujui = eve
+auto-deny, aman untuk aksi destruktif):
+
+```ts
+const onComposerSend = (payload) => {
+  const text = payload.text.trim();
+  const targets = text
+    ? hitlRequests.filter((r) => !isApprovalRequest(r) && acceptsFreeformText(r))
+    : [];
+  if (targets.length > 0) {
+    void agent.send({ inputResponses: targets.map((r) => ({ requestId: r.requestId, text })) });
+    return;
+  }
+  sendTurn(payload.text, payload.clientContext);
+};
+```
+
+Placeholder composer juga sadar-konteks (approval → "Pilih opsi di atas untuk melanjutkan…").
+
+### File
+- `apps/web-v2/features/threads/components/chat-surface.tsx`
+- helper `isApprovalRequest` / `acceptsFreeformText` di `eve-timeline.ts`
+
+---
+
+## 5. Akar TUNGGAL streaming: Next `rewrites()` menahan stream long-lived (LOCAL DEV)
+
+Tiga gejala yang awalnya tampak terpisah ternyata **satu akar**. Penting: isu terjadi di
+**local development, tanpa nginx/produksi**. Rantainya:
+
+```
+browser → next dev (rewrites /eve/v1/*) → eve dev (agent-v2 :4317)
+```
+
+Satu-satunya hop proxy = **Next `rewrites()`**. Tanda-tandanya klasik **proxy mem-buffer stream
+long-lived**:
+
+- **Stream pendek self-closing → lolos.** Resume pasca-refresh = replay event yang sudah
+  persisted; server kirim cepat lalu EOF → proxy flush saat tutup. **Itu sebabnya "refresh works".**
+- **Stream long-lived (turn in-flight) → tertahan.** Selama turn berjalan, koneksi GET stream tetap
+  terbuka; `rewrites()` ke origin eksternal tak meneruskan body inkremental untuk koneksi yang tak
+  kunjung tutup → event ditahan.
+
+### Gejala turunan
+
+| # | Gejala | Sebab |
+|---|---|---|
+| **5a** | Progres beku, perlu refresh | event live ditahan proxy (stream tak pernah tutup → tak flush) |
+| **5b** | `Session.send requires a non-empty message, inputResponses, or both` saat klik opsi | boundary `session.waiting` ikut tertahan → `advanceSession` membuang `continuationToken` → klik = `inputResponses` tanpa token → `createHandleMessageBody` return `null` → throw |
+| **5c** | Nav-balik (pindah halaman lalu kembali) tak ada card | resume turn-in-flight = stream long-lived → tertahan → tak update sampai refresh |
+
+**Bukti 5b (DB):**
+
+| thread | `continuation_token` | hasil |
+|---|---|---|
+| `wrun_01KVYZTRP9…` (gagal) | **NULL** | macet di pertanyaan pertama |
+| `wrun_01KVYWFCEF…` (sukses) | `eve:02a77b0f-…` | riset selesai penuh |
+
+Server pada kedua thread mem-park dengan benar (`input.requested` → `turn.completed` →
+`session.waiting`). Bedanya murni: klien yang gagal **tak pernah menangkap** `continuationToken`
+karena `session.waiting` tak sampai. `refresh` **tidak** memperbaiki 5b: saat mount,
+`initialSession.continuationToken = threadDetail.continuationToken` = NULL → thread ter-brick.
+
+### Solusi: proxy streaming eksplisit (Route Handler)
+
+`/eve/v1/*` dipindah dari `rewrites()` ke **Route Handler streaming**:
+
+```ts
+// apps/web-v2/app/eve/v1/[...path]/route.ts
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+const AGENT_ORIGIN = process.env.AGENT_ORIGIN ?? "http://localhost:4317";
+
+async function proxy(req: NextRequest): Promise<Response> {
+  const target = `${AGENT_ORIGIN}${req.nextUrl.pathname}${req.nextUrl.search}`;
+  const headers = new Headers(req.headers);
+  headers.delete("host"); headers.delete("connection"); headers.delete("content-length");
+  const init: RequestInit = { method: req.method, headers, redirect: "manual", signal: req.signal };
+  if (req.method !== "GET" && req.method !== "HEAD") init.body = await req.arrayBuffer();
+
+  const upstream = await fetch(target, init);
+  const resHeaders = new Headers(upstream.headers);
+  resHeaders.delete("content-length"); resHeaders.delete("content-encoding");
+  resHeaders.set("x-accel-buffering", "no");
+  return new Response(upstream.body, { status: upstream.status, headers: resHeaders }); // STREAM
+}
+export const GET = proxy;
+export const POST = proxy;
+```
+
+- `return new Response(upstream.body)` mengalirkan `ReadableStream` upstream **apa adanya**,
+  termasuk long-lived — pola streaming standar App Router (yang dipakai app AI chat). `rewrites()`
+  bukan jalur ini.
+- Same-origin tetap terjaga (bearer Clerk diteruskan; `/eve/v1` sudah di-exclude dari Clerk
+  middleware di `proxy.ts`).
+- `rewrites()` dihapus dari `next.config.ts`.
+
+Dengan event live (incl. `session.waiting`) tiba real-time → **5a, 5b, 5c selesai dari satu akar**.
+
+### Resiliensi tambahan
+`maxReconnectAttempts: 120` di `useAstraAgent` (default eve = 3) — cadangan untuk putus sungguhan
+(dev restart, gap idle subagent yang lama). Boundary `session.waiting/completed/failed`
+menghentikan loop reconnect seketika saat turn selesai, jadi nilai tinggi tak menimbulkan churn.
+
+### File
+- `apps/web-v2/app/eve/v1/[...path]/route.ts` (baru)
+- `apps/web-v2/next.config.ts` (hapus `rewrites()`)
+- `apps/web-v2/features/threads/lib/use-astra-agent.ts` (`maxReconnectAttempts`)
+
+---
+
+## 5b. Resume macet setelah refresh/nav-balik (poll-on-EOF) — BUKAN proxy
+
+### Gejala (tersisa setelah fix Section 5)
+Saat long-running task berjalan, lalu **refresh/pindah-halaman → kembali**: progres tampak
+**macet** (tetap "on progress", bukan stop) — tak ada step lanjutan. Tiap **refresh** memunculkan
+snapshot progres terbaru, refresh lagi maju lagi, sampai akhirnya respons terakhir.
+
+### Akar masalah (ASIMETRI klien, terkonfirmasi dari source eve)
+Bukan proxy. Route Handler meneruskan stream eve apa adanya (termasuk EOF-nya). Akarnya: **eve dev
+menutup body GET `/stream` per-snapshot** (bukan satu tail panjang yang dijaga terbuka sampai turn
+usai), dan **dua jalur klien menanganinya berbeda**:
+
+| Jalur | Saat EOF bersih tanpa boundary | Hasil |
+|---|---|---|
+| **Send** (`#createEventStream`, eve) | **reconnect** dari cursor (poll) sampai boundary | progres live ✓ |
+| **Resume** (`useThreadResume`, hand-rolled meniru `openStreamIterable`) | **`return`/stop** (anggap turn selesai) | macet (satu snapshot) ✗ |
+
+`openStreamIterable` memang `return` pada EOF bersih (hanya reconnect saat *disconnect error*),
+dan `useThreadResume` menirunya (`stop = true` di EOF). Jadi begitu eve dev menutup body di tengah
+turn, resume berhenti setelah satu snapshot → "macet"; refresh = re-fetch snapshot baru + resume
+ulang → maju satu langkah lagi. Itulah pola "refresh → maju, refresh lagi → maju".
+
+### Solusi
+`useThreadResume` kini **meniru jalur SEND**: pada EOF bersih, berhenti **hanya** bila event
+terakhir = boundary turn (`session.waiting`/`session.completed`/`session.failed`); selain itu
+**reconnect dari `nextIndex` (poll)** untuk mengejar event baru.
+
+```ts
+for await (const ev of readNdjson(res.body)) { /* …push, bumpIdle, nextIndex++ */ }
+// EOF bersih:
+if (lastEventIsTerminal(acc)) stop = true;     // turn settle/parkir → berhenti
+else await sleep(EOF_POLL_DELAY_MS);           // belum → reconnect dari nextIndex (poll)
+```
+
+- `IDLE_TIMEOUT_MS` dinaikkan 120s → **600s** agar bertahan melewati gap subagent `/deep` yang
+  panjang (mis. 5,5 mnt tanpa event) tanpa menyerah; tetap menghentikan turn yang benar-benar
+  mati/hang.
+- Robust untuk dua kemungkinan runtime: bila body **di-tail** (tetap terbuka) → satu baca panjang,
+  berhenti di boundary; bila body **per-snapshot** → poll tiap `EOF_POLL_DELAY_MS`. Cursor
+  (`nextIndex`) maju monoton → tiap reconnect hanya menarik event baru (tanpa re-fetch).
+- Overlay tetap disjoint by-cursor; reducer eve idempoten (upsert by id/callId) → tak ada duplikat.
+
+### File
+- `apps/web-v2/features/threads/lib/use-thread-resume.ts`
+
+---
+
+## 6. Ringkasan file yang berubah
+
+| File | Perubahan |
+|---|---|
+| `app/eve/v1/[...path]/route.ts` | **Baru** — proxy streaming eve (gantikan rewrites) |
+| `next.config.ts` | Hapus `rewrites()` `/eve/v1/*` |
+| `features/threads/lib/use-astra-agent.ts` | `maxReconnectAttempts: 120` |
+| `features/threads/lib/use-thread-resume.ts` | Resume reconnect-poll on EOF-tanpa-boundary (anti-macet pasca refresh/nav); idle 120s→600s |
+| `features/threads/lib/eve-timeline.ts` | `pendingInputRequests` (last-assistant-message) + `isApprovalRequest`/`acceptsFreeformText` + `PendingInputRequest.toolName` + `mapPart` sembunyikan HITL parkir |
+| `features/threads/components/input-request-prompt.tsx` | Copy approval ter-lokalisasi; hapus dead `responding`/`DEFAULT_CONFIRM_OPTIONS` |
+| `features/threads/components/chat-surface.tsx` | Freeform → `inputResponses`; placeholder sadar-konteks |
+| `features/threads/components/message-list.tsx` | Luruskan komentar HITL |
+| `features/threads/lib/eve-timeline.test.ts` | +tes anti-basi & anti-menumpuk lintas turn |
+| `apps/agent-v2/agent/tools/delete_artifact.ts` | `needsApproval: always()` (gate UI) |
+
+---
+
+## 7. Verifikasi
+
+- **Unit tests** `eve-timeline.test.ts`: 22/22 hijau (termasuk replika persis bug 3-kartu-menumpuk
+  & kartu-basi-pasca-selesai).
+- **Typecheck** web-v2: bersih.
+- **Lint** web-v2: 0 error.
+
+### Tes manual yang perlu dijalankan owner
+1. **Restart `dev:web-v2`** (perubahan `next.config.ts` + route handler baru perlu restart Next).
+2. `/deep <topik>`:
+   - progres mengalir live (tak beku),
+   - klik opsi pada kartu → jalan (tak ada `Session.send requires…`),
+   - ketik jawaban di composer → terkirim sbg jawaban terstruktur,
+   - pindah halaman lalu kembali → progres/kartu tampil tanpa refresh.
+3. `delete_artifact`: kartu Bahasa Indonesia ("Hapus dokumen ini?" / **Hapus** / **Batal**).
+
+---
+
+## 8. Batasan & tindak lanjut
+
+- **Verifikasi streaming butuh dev server berjalan.** Perbaikan proxy diuji via typecheck/lint,
+  tapi perilaku streaming inkremental hanya terbukti saat dijalankan. Bila Route Handler masih
+  kurang (mis. `eve dev` sendiri yang menahan, bukan rewrite), langkah lanjut: arahkan klien eve
+  langsung ke `:4317` + aktifkan CORS dev di channel eve (keluarkan Next dari jalur sepenuhnya).
+- **Thread ter-brick lama (token NULL) tak bisa dipulihkan** — token `eve:<uuid>` hanya hidup di
+  respons POST (sekali) + kunci internal workflow; tak ada salinan server yang queryable. Mulai
+  `/deep` baru untuk mengetes.
+- **Fragilitas mendasar (upstream eve):** kemampuan menjawab HITL bergantung pada klien menangkap
+  `continuationToken` dari boundary `session.waiting`. Selama streaming andal, ini aman; idealnya
+  eve menyediakan token yang dapat dipulihkan server-side (usulan upstream).
+- **`ask_question` tanpa `action.result`** berarti Q&A yang dijawab via opsi tak meninggalkan
+  bubble user di transkrip (jawaban = tool-result, bukan pesan). Saat ini diterima; bila ingin
+  jejak Q&A eksplisit, perlu render terpisah.
+
+---
+
+## 9. Audit E2E langsung (browser + DB) — akar SEBENARNYA + fixes
+
+> Setelah fix §1–§8 ter-deploy di dev, owner melapor isu yang sama MASIH terjadi. Dilakukan
+> audit E2E langsung: kontrol browser (Claude-in-Chrome) + inspeksi `chat_thread_events`
+> (Postgres VPS) + `read_network_requests`/`read_console_messages`. Ditemukan **tiga akar
+> berbeda** yang §1–§8 belum sentuh. Semua di bawah **terverifikasi live**, bukan hanya
+> typecheck.
+
+### 9.0 Fondasi yang sudah dibenahi sebelum audit (4 layer)
+- **B (proxy `node:http`):** `app/eve/v1/[...path]/route.ts` ditulis ulang dari `fetch`/undici ke
+  `node:http`/`node:https` + `upstream.setTimeout(0)`. undici default `bodyTimeout` 300 dtk
+  MEMBUNUH koneksi stream saat gap subagent idle (terverifikasi 341 dtk > 300). Soket node:http
+  tanpa idle-timeout → stream long-lived bertahan.
+- **C (api incremental):** `GET /threads/:id/events?afterIndex=N` (delta) + `GET /threads/recent-active?since=`.
+- **D (klien O(n)):** `buildOrderedLog` dedup by `event_index` (ganti `mergeStreamEventLogs`
+  O(n²) `JSON.stringify`); `busy` diturunkan dari `isStreamActive(base)`; first-turn URL bump
+  dini; poll incremental.
+- **A (elapsed):** `ElapsedLabel` "Sedang bekerja… M:SS" untuk dead-air subagent.
+
+### 9.1 Akar "frozen until refresh" SEBENARNYA: bug React StrictMode di resume
+Console membuktikan saat refresh di tengah turn: `enabled:true, status:"ready", streamActive:true`
+TAPI `resuming:false` dan **resume stream `/eve/v1/.../stream` TAK PERNAH terbuka**. Sebab:
+guard `startedKeyRef` di `useThreadResume`. React **StrictMode (dev)** menjalankan effect
+**mount→cleanup→mount**: run-1 set ref + buka stream → cleanup batalkan → run-2 lihat
+`ref === sessionId` → **early-return → stream mati selamanya**. Jadi pasca-refresh TAK ADA
+streaming token-level; cuma poll (yang dulu O(n²) → beku). **Itulah "frozen until refresh".**
+(Bug PRA-ADA di hook resume, bukan dari §1–§8.)
+
+**Fix:** hapus guard `startedKeyRef` (cleanup effect SUDAH meng-abort loop lama sebelum re-run;
+deps `[enabled, sessionId]`, idempoten via dedup-by-index). `setResuming(true)` dipindah ke
+dalam IIFE async (hindari `react-hooks/set-state-in-effect`).
+**Terverifikasi live:** resume `GET /stream?startIndex=169` held-open `pending`; `streamIndex`
+naik **183→205→225→250 dalam 7 dtk** (`resuming:true`); sintesis stream token-level pasca-refresh.
+- File: `features/threads/lib/use-thread-resume.ts`.
+
+### 9.2 "Token per token sangat lama setelah refresh": `useSmoothText` re-reveal dari NOL
+`useSmoothText` memulai `shownLen = 0` tiap mount. Saat cold-load/refresh turn in-flight,
+jawaban-sejauh-ini (terukur **23.750 char**) di-ketik ULANG dari 0 @ ~180 char/dtk = **±2 menit
+merangkak**, padahal datanya sudah ada. Inilah gejala "lambat" paling kelihatan setelah refresh.
+
+**Fix:** mulai dari teks yang SUDAH ada — `useState(text)` + `shownLen = targetRef.current.length`;
+animasi hanya untuk PERTUMBUHAN baru (turn fresh `text=""` → tetap mengetik dari awal).
+**Terverifikasi live:** pasca-refresh jawaban penuh tampil <1 dtk, tak ada crawl.
+- File: `features/threads/lib/use-smooth-text.tsx`.
+
+### 9.3 Akar terbesar: log event **O(n²) = 23 MB** (cumulative `messageSoFar`)
+eve `message.appended`/`reasoning.appended` membawa `messageSoFar`/`reasoningSoFar` **KUMULATIF**
+(tumbuh sampai 20.553 char); reducer eve me-**REPLACE** part teks tiap delta (bukan append). Hook
+proyeksi persist 1:1 → 3.090 delta × teks-kumulatif = **18–23 MB** untuk SATU thread `/deep`.
+Akibat (DB-verified `pg_column_size`):
+- **Cold-load >9 dtk** ("Memuat thread…") — api-v2 menarik 23 MB dari Postgres VPS (remote) tiap buka.
+- **Jank per-token** — klien me-reduce 23 MB tiap delta (O(n²) sepanjang turn).
+
+**Fix (3 lapis, semua simpan hanya delta TERAKHIR per `(type, turn, stepIndex)`):**
+1. **DB query** `ChatThreadEventRepo.listByThread`: filter SQL buang delta tersusul.
+   Terukur **23 MB/3543 row → 124 kB/87 row** (185×), `max(event_index)` tetap (3542=3542) →
+   **cursor resume tetap benar**.
+2. **Klien reduce** `compactStreamingDeltas` di `reduceEventsToMessageData` (eve-timeline.ts) →
+   reduce hanya teks-final per langkah; hasil reduksi IDENTIK (tested 29/29).
+3. **Akumulasi poll** `compactThreadEvents` di `useThreadEvents` (api.ts) → `prev` tetap mungil
+   (poll kembalikan delta-tail step aktif tiap tick di index baru; tanpa dedup `prev` tumbuh O(n²) lagi).
+
+Token-level realtime TETAP via resume stream eve. **Terverifikasi live:** cold-load penuh
+(23.750 char) **<3 dtk** (sebelumnya masih "Memuat thread…" di 9 dtk).
+- File: `packages/db/src/repositories/chatThreadEventRepo.ts`, `features/threads/lib/eve-timeline.ts`,
+  `features/threads/api.ts`.
+
+### 9.4 Yang TETAP genuine (bukan bug)
+- **Dead-air subagent.** DB-verified: parent dapat **0 event 2–3 mnt** saat subagent task-mode
+  jalan (mis. `max_idx` macet 102 selama 139 dtk; 149 selama 120 dtk). Tak ada yang bisa
+  di-stream (belum ada datanya); poll auto-recover tiap gap (102→147→…), `ElapsedLabel` tampilkan
+  liveness. Refresh TAK menolong di tengah gap.
+- **Rate model.** Delta ~7 char tiap ~330 ms (deepseek-v4-flash via gateway OpenAI-compatible) =
+  batas atas upstream; frontend tak bisa lebih cepat dari produksi token.
+
+### 9.5 Catatan operasional
+- **Disk penuh (ENOSPC)** sempat memblok edit/cmd di tengah sesi & kemungkinan memperburuk
+  kestabilan dev (tab crash, Next gagal nulis cache). Pastikan disk lega saat dev.
+- **Storage DB tetap O(n²)** — compaction §9.3 hanya di jalur BACA (query). Tabel masih simpan
+  cumulative penuh. Tindak lanjut opsional: strip `messageSoFar` di tulisan (`store.ts`) atau
+  jangan persist delta sama sekali (butuh decouple cursor dari hitungan persisted).
+
+### 9.6 Verifikasi
+- Gates: `tsc` 0 (db/services/api-v2/web-v2), `eslint` 0, `eve-timeline.test.ts` 29/29.
+- Live E2E (browser + DB + network): first-turn URL, resume token-level pasca-refresh, HITL kartu
+  tanpa flicker, elapsed timer, cold-load <3 dtk, poll incremental `afterIndex`, recovery gap
+  subagent — semua terkonfirmasi.
+
+### 9.7 Ringkasan file (sesi audit)
+| File | Perubahan |
+|---|---|
+| `features/threads/lib/use-thread-resume.ts` | Hapus guard `startedKeyRef` (fix StrictMode resume mati); `setResuming` ke IIFE |
+| `features/threads/lib/use-smooth-text.tsx` | Mulai reveal dari teks yang ada (anti crawl-dari-0 pasca refresh) |
+| `packages/db/src/repositories/chatThreadEventRepo.ts` | Compaction SQL delta kumulatif (23MB→124kB) |
+| `features/threads/lib/eve-timeline.ts` | `compactStreamingDeltas` sebelum reduce (anti jank per-token) |
+| `features/threads/api.ts` | `compactThreadEvents` di akumulasi poll (prev tetap mungil) |
+| `app/eve/v1/[...path]/route.ts` | Proxy `node:http` tanpa idle-timeout (§9.0-B) |
+| `apps/api-v2/src/routes/threads.ts` | `?afterIndex` + `/recent-active?since=` (§9.0-C) |
+| `features/threads/lib/use-astra-agent.ts` | Discovery sessionId turn-pertama → bump URL dini (§9.0-D) |
+| `features/threads/components/chat-surface.tsx` | `buildOrderedLog` + `busy` dari base (§9.0-D) |
+| `features/threads/components/message-list.tsx` | `ElapsedLabel` dead-air (§9.0-A) |

--- a/packages/db/migrations/0013_romantic_stature.sql
+++ b/packages/db/migrations/0013_romantic_stature.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "chat_thread_events" ADD COLUMN "step_index" integer;--> statement-breakpoint
+CREATE INDEX "chat_thread_events_thread_type_step" ON "chat_thread_events" USING btree ("thread_id","type","step_index");--> statement-breakpoint
+-- Backfill step_index dari payload (Phase 3, fix C). 1×, idempoten via `step_index IS NULL`.
+-- Guard regex `^[0-9]+$` → hanya cast nilai integer valid (stepIndex absen/null/non-numerik
+-- dilewati tanpa error). Tabel sangat besar → boleh jalankan ber-batch manual; single UPDATE
+-- ok untuk deploy terjadwal (append-only: insert baris baru tak konflik dgn update baris lama).
+UPDATE "chat_thread_events"
+SET "step_index" = ("payload" -> 'data' ->> 'stepIndex')::int
+WHERE "step_index" IS NULL
+  AND ("payload" -> 'data' ->> 'stepIndex') ~ '^[0-9]+$';

--- a/packages/db/migrations/0014_bstrip_superseded_deltas.sql
+++ b/packages/db/migrations/0014_bstrip_superseded_deltas.sql
@@ -1,0 +1,25 @@
+-- B-strip data migration 1× (Phase 6, fix C storage) — kosongkan payload delta `*.appended` LAMA
+-- yang SUDAH disusul, sisakan delta TERAKHIR per (thread, turn, type, step). Baris TETAP
+-- (event_index tak berubah) → cursor resume valid (nol risiko). Idempoten via
+-- `payload->>'stripped' IS NULL` (re-runnable; aman bila interupsi). EXISTS(delta tipe sama yang
+-- lebih baru di grup yang sama) = "tersusul"; pakai index `(thread_id, type, step_index)`.
+--
+-- Reasoning AMAN: delta TERAKHIR tiap (type, step) tak punya "later" → tak di-strip → reasoning
+-- final + teks final tetap utuh (`reasoning.completed` di-emit 0× oleh agent kita, jadi final
+-- HANYA ada di delta terakhir — jangan sampai ke-strip).
+--
+-- Tabel SANGAT besar → boleh dijalankan ber-batch manual per thread (tambah `AND e.thread_id =
+-- '<id>'`); single statement ok untuk deploy terjadwal (append-only: insert baris baru tak konflik
+-- dgn update baris lama). Deploy fase ini ATOMIC bersama redeploy agent-v2.
+UPDATE "chat_thread_events" e
+SET "payload" = '{"stripped":true}'::jsonb
+WHERE e."type" IN ('message.appended', 'reasoning.appended')
+  AND e."payload" ->> 'stripped' IS NULL
+  AND EXISTS (
+    SELECT 1 FROM "chat_thread_events" l
+    WHERE l."thread_id" = e."thread_id"
+      AND l."turn_id" IS NOT DISTINCT FROM e."turn_id"
+      AND l."step_index" IS NOT DISTINCT FROM e."step_index"
+      AND l."type" = e."type"
+      AND l."event_index" > e."event_index"
+  );

--- a/packages/db/migrations/meta/0013_snapshot.json
+++ b/packages/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,4191 @@
+{
+  "id": "e2637f6b-918b-4329-a16d-25fd79401524",
+  "prevId": "5dfe3294-7e63-4b87-89bd-33efa25ea27d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_completed_at": {
+          "name": "deletion_completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_status": {
+          "name": "deletion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "users_by_email": {
+          "name": "users_by_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_deletion_status_check": {
+          "name": "users_deletion_status_check",
+          "value": "\"users\".\"deletion_status\" in ('active', 'deleting', 'deleted', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workspaces_by_owner_status_updated": {
+          "name": "workspaces_by_owner_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_by_owner_updated": {
+          "name": "workspaces_by_owner_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_users_owner_user_id_fk": {
+          "name": "workspaces_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspaces_status_check": {
+          "name": "workspaces_status_check",
+          "value": "\"workspaces\".\"status\" in ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_folders": {
+      "name": "workspace_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_folders_by_owner_workspace_status_updated": {
+          "name": "workspace_folders_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_folders_by_owner_workspace_name": {
+          "name": "workspace_folders_by_owner_workspace_name",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_folders_owner_user_id_users_owner_user_id_fk": {
+          "name": "workspace_folders_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "workspace_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_folders_workspace_id_workspaces_id_fk": {
+          "name": "workspace_folders_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_folders",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_folders_status_check": {
+          "name": "workspace_folders_status_check",
+          "value": "\"workspace_folders\".\"status\" in ('active', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_about_source": {
+          "name": "heard_about_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_about_other": {
+          "name": "heard_about_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_onboarding_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_onboarding_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feed_interests": {
+      "name": "user_feed_interests",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feed_interests_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_feed_interests_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_feed_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_feed_interests_owner_user_id_topic_pk": {
+          "name": "user_feed_interests_owner_user_id_topic_pk",
+          "columns": [
+            "owner_user_id",
+            "topic"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_family": {
+          "name": "artifact_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexing_status": {
+          "name": "indexing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_indexed'"
+        },
+        "indexing_failure_reason": {
+          "name": "indexing_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_document_kind": {
+          "name": "detected_document_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_r2_key": {
+          "name": "storage_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rag_entry_id": {
+          "name": "rag_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text_preview": {
+          "name": "plain_text_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifacts_by_owner_status_updated": {
+          "name": "artifacts_by_owner_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_workspace_status_updated": {
+          "name": "artifacts_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_workspace_folder_status_updated": {
+          "name": "artifacts_by_owner_workspace_folder_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_thread_created": {
+          "name": "artifacts_by_owner_thread_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_thread_source_status_created": {
+          "name": "artifacts_by_owner_thread_source_status_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifacts_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_workspace_id_workspaces_id_fk": {
+          "name": "artifacts_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifacts_folder_id_workspace_folders_id_fk": {
+          "name": "artifacts_folder_id_workspace_folders_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "workspace_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifacts_artifact_type_check": {
+          "name": "artifacts_artifact_type_check",
+          "value": "\"artifacts\".\"artifact_type\" in ('markdown', 'plain_text', 'pdf', 'docx', 'html', 'svg', 'mermaid', 'json', 'csv', 'code', 'url')"
+        },
+        "artifacts_artifact_family_check": {
+          "name": "artifacts_artifact_family_check",
+          "value": "\"artifacts\".\"artifact_family\" in ('text', 'file', 'interactive', 'visual', 'data', 'link')"
+        },
+        "artifacts_source_check": {
+          "name": "artifacts_source_check",
+          "value": "\"artifacts\".\"source\" in ('manual', 'upload', 'agent', 'url')"
+        },
+        "artifacts_indexing_status_check": {
+          "name": "artifacts_indexing_status_check",
+          "value": "\"artifacts\".\"indexing_status\" in ('not_indexed', 'pending', 'ready', 'failed')"
+        },
+        "artifacts_detected_document_kind_check": {
+          "name": "artifacts_detected_document_kind_check",
+          "value": "\"artifacts\".\"detected_document_kind\" is null or \"artifacts\".\"detected_document_kind\" in ('generic', 'scholarly_paper')"
+        },
+        "artifacts_status_check": {
+          "name": "artifacts_status_check",
+          "value": "\"artifacts\".\"status\" in ('active', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_contents": {
+      "name": "artifact_contents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks_json": {
+          "name": "blocks_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text": {
+          "name": "plain_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_text": {
+          "name": "context_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text_r2_key": {
+          "name": "plain_text_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocks_json_r2_key": {
+          "name": "blocks_json_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown_r2_key": {
+          "name": "markdown_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_contents_by_owner_artifact": {
+          "name": "artifact_contents_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_contents_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_contents_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_contents_workspace_id_workspaces_id_fk": {
+          "name": "artifact_contents_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_contents_artifact_id_artifacts_id_fk": {
+          "name": "artifact_contents_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_extractions": {
+      "name": "artifact_extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractor": {
+          "name": "extractor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_extractions_by_owner_artifact_extractor": {
+          "name": "artifact_extractions_by_owner_artifact_extractor",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extractor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_extractions_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_extractions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_extractions_artifact_id_artifacts_id_fk": {
+          "name": "artifact_extractions_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_extractions_workspace_id_workspaces_id_fk": {
+          "name": "artifact_extractions_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_extractions_extractor_check": {
+          "name": "artifact_extractions_extractor_check",
+          "value": "\"artifact_extractions\".\"extractor\" in ('pdf_text', 'docx_text', 'url_reader')"
+        },
+        "artifact_extractions_status_check": {
+          "name": "artifact_extractions_status_check",
+          "value": "\"artifact_extractions\".\"status\" in ('pending', 'running', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_paper_metadata": {
+      "name": "artifact_paper_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliations": {
+          "name": "affiliations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal": {
+          "name": "journal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_status": {
+          "name": "oa_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_status": {
+          "name": "pdf_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_paper_metadata_by_owner_artifact": {
+          "name": "artifact_paper_metadata_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_paper_metadata_by_owner_workspace_updated": {
+          "name": "artifact_paper_metadata_by_owner_workspace_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_paper_metadata_by_owner_doi": {
+          "name": "artifact_paper_metadata_by_owner_doi",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_paper_metadata_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_paper_metadata_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_paper_metadata_artifact_id_artifacts_id_fk": {
+          "name": "artifact_paper_metadata_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_paper_metadata_workspace_id_workspaces_id_fk": {
+          "name": "artifact_paper_metadata_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_paper_metadata_metadata_source_check": {
+          "name": "artifact_paper_metadata_metadata_source_check",
+          "value": "\"artifact_paper_metadata\".\"metadata_source\" in ('crossref', 'openalex', 'arxiv', 'datacite', 'semantic_scholar', 'manual', 'llm')"
+        },
+        "artifact_paper_metadata_pdf_status_check": {
+          "name": "artifact_paper_metadata_pdf_status_check",
+          "value": "\"artifact_paper_metadata\".\"pdf_status\" is null or \"artifact_paper_metadata\".\"pdf_status\" in ('downloaded', 'no_oa_available')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_urls": {
+      "name": "artifact_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_text": {
+          "name": "readable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_text": {
+          "name": "context_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_text_r2_key": {
+          "name": "readable_text_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_urls_by_owner_workspace_normalized_url": {
+          "name": "artifact_urls_by_owner_workspace_normalized_url",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_urls_by_owner_artifact": {
+          "name": "artifact_urls_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_urls_by_owner_workspace_status_updated": {
+          "name": "artifact_urls_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_urls_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_urls_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_urls_workspace_id_workspaces_id_fk": {
+          "name": "artifact_urls_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_urls_artifact_id_artifacts_id_fk": {
+          "name": "artifact_urls_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_urls_status_check": {
+          "name": "artifact_urls_status_check",
+          "value": "\"artifact_urls\".\"status\" in ('pending', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_embeddings": {
+      "name": "artifact_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_embeddings_by_owner_artifact": {
+          "name": "artifact_embeddings_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_embeddings_embedding_hnsw": {
+          "name": "artifact_embeddings_embedding_hnsw",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_embeddings_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_embeddings_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_embeddings_artifact_id_artifacts_id_fk": {
+          "name": "artifact_embeddings_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_embeddings_workspace_id_workspaces_id_fk": {
+          "name": "artifact_embeddings_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_status": {
+          "name": "title_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lite'"
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continuation_token": {
+          "name": "continuation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_user_message": {
+          "name": "pending_user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_user_message_created_at": {
+          "name": "pending_user_message_created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_threads_by_owner_activity": {
+          "name": "chat_threads_by_owner_activity",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_threads_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_threads_status_check": {
+          "name": "chat_threads_status_check",
+          "value": "\"chat_threads\".\"status\" in ('idle', 'streaming', 'failed')"
+        },
+        "chat_threads_title_status_check": {
+          "name": "chat_threads_title_status_check",
+          "value": "\"chat_threads\".\"title_status\" is null or \"chat_threads\".\"title_status\" in ('generating', 'ready')"
+        },
+        "chat_threads_agent_kind_check": {
+          "name": "chat_threads_agent_kind_check",
+          "value": "\"chat_threads\".\"agent_kind\" in ('lite', 'pro')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_by_thread_created": {
+          "name": "chat_messages_by_thread_created",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_messages_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_messages_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_messages_role_check": {
+          "name": "chat_messages_role_check",
+          "value": "\"chat_messages\".\"role\" in ('user', 'assistant', 'system')"
+        },
+        "chat_messages_status_check": {
+          "name": "chat_messages_status_check",
+          "value": "\"chat_messages\".\"status\" in ('streaming', 'complete', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_events": {
+      "name": "chat_thread_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_index": {
+          "name": "event_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_thread_events_thread_event_index": {
+          "name": "chat_thread_events_thread_event_index",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_events_thread_type_step": {
+          "name": "chat_thread_events_thread_type_step",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_events_thread_id_chat_threads_id_fk": {
+          "name": "chat_thread_events_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_thread_events",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_thread_events_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_thread_events_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_thread_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.research_sources": {
+      "name": "research_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citation_number": {
+          "name": "citation_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_strength": {
+          "name": "evidence_strength",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovery_query": {
+          "name": "discovery_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "research_sources_by_thread": {
+          "name": "research_sources_by_thread",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "research_sources_thread_turn_locator": {
+          "name": "research_sources_thread_turn_locator",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "research_sources_thread_id_chat_threads_id_fk": {
+          "name": "research_sources_thread_id_chat_threads_id_fk",
+          "tableFrom": "research_sources",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "research_sources_owner_user_id_users_owner_user_id_fk": {
+          "name": "research_sources_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "research_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "research_sources_origin_check": {
+          "name": "research_sources_origin_check",
+          "value": "\"research_sources\".\"origin\" in ('web', 'arxiv', 'doi')"
+        },
+        "research_sources_evidence_strength_check": {
+          "name": "research_sources_evidence_strength_check",
+          "value": "\"research_sources\".\"evidence_strength\" in ('strong', 'medium', 'weak')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.explore_papers": {
+      "name": "explore_papers",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openalex_id": {
+          "name": "openalex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_access": {
+          "name": "is_open_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "explore_papers_by_doi": {
+          "name": "explore_papers_by_doi",
+          "columns": [
+            {
+              "expression": "doi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "explore_papers_provider_check": {
+          "name": "explore_papers_provider_check",
+          "value": "\"explore_papers\".\"provider\" in ('OpenAlex', 'arXiv', 'Exa', 'Jina', 'Crossref')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tldr": {
+          "name": "tldr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tldr_id": {
+          "name": "tldr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_id": {
+          "name": "title_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_url": {
+          "name": "resolved_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_text": {
+          "name": "article_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrich_attempts": {
+          "name": "enrich_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_key": {
+          "name": "paper_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_access": {
+          "name": "is_open_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "trend_score": {
+          "name": "trend_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retraction_status": {
+          "name": "retraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_claim": {
+          "name": "primary_claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance_supporting": {
+          "name": "stance_supporting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance_contrasting": {
+          "name": "stance_contrasting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sparkline": {
+          "name": "sparkline",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_at": {
+          "name": "order_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "feed_items_by_dedupe_key": {
+          "name": "feed_items_by_dedupe_key",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_kind_trend": {
+          "name": "feed_items_by_kind_trend",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trend_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_kind_published": {
+          "name": "feed_items_by_kind_published",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_order": {
+          "name": "feed_items_by_order",
+          "columns": [
+            {
+              "expression": "order_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_paper_key": {
+          "name": "feed_items_by_paper_key",
+          "columns": [
+            {
+              "expression": "paper_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_search_gin": {
+          "name": "feed_items_search_gin",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_items_kind_check": {
+          "name": "feed_items_kind_check",
+          "value": "\"feed_items\".\"kind\" in ('paper', 'news', 'claim', 'topic', 'idea')"
+        },
+        "feed_items_provider_check": {
+          "name": "feed_items_provider_check",
+          "value": "\"feed_items\".\"provider\" in ('openalex', 'exa_news', 'google_news', 'gdelt', 'google_factcheck', 'turnbackhoax')"
+        },
+        "feed_items_retraction_status_check": {
+          "name": "feed_items_retraction_status_check",
+          "value": "\"feed_items\".\"retraction_status\" is null or \"feed_items\".\"retraction_status\" in ('none', 'concern', 'retracted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_sources": {
+      "name": "feed_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cadence_minutes": {
+          "name": "cadence_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_params_json": {
+          "name": "query_params_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feed_sources_by_provider": {
+          "name": "feed_sources_by_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_sources_provider_check": {
+          "name": "feed_sources_provider_check",
+          "value": "\"feed_sources\".\"provider\" in ('openalex', 'exa_news', 'google_news', 'gdelt', 'google_factcheck', 'turnbackhoax')"
+        },
+        "feed_sources_last_status_check": {
+          "name": "feed_sources_last_status_check",
+          "value": "\"feed_sources\".\"last_status\" is null or \"feed_sources\".\"last_status\" in ('ready', 'empty', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_feed_items": {
+      "name": "saved_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "saved_feed_items_by_owner_item": {
+          "name": "saved_feed_items_by_owner_item",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_feed_items_by_owner_created": {
+          "name": "saved_feed_items_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_feed_items_owner_user_id_users_owner_user_id_fk": {
+          "name": "saved_feed_items_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "saved_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "saved_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "saved_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hidden_feed_items": {
+      "name": "hidden_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "hidden_feed_items_by_owner_item": {
+          "name": "hidden_feed_items_by_owner_item",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hidden_feed_items_by_owner_created": {
+          "name": "hidden_feed_items_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hidden_feed_items_owner_user_id_users_owner_user_id_fk": {
+          "name": "hidden_feed_items_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "hidden_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hidden_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "hidden_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "hidden_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_interactions": {
+      "name": "feed_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feed_interactions_by_owner_item_kind": {
+          "name": "feed_interactions_by_owner_item_kind",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_by_owner_created": {
+          "name": "feed_interactions_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_interactions_owner_user_id_users_owner_user_id_fk": {
+          "name": "feed_interactions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "feed_interactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_interactions_feed_item_id_feed_items_id_fk": {
+          "name": "feed_interactions_feed_item_id_feed_items_id_fk",
+          "tableFrom": "feed_interactions",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_interactions_kind_check": {
+          "name": "feed_interactions_kind_check",
+          "value": "\"feed_interactions\".\"kind\" in ('save', 'hide', 'research', 'open_evidence')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.domain_reliability": {
+      "name": "domain_reliability",
+      "schema": "",
+      "columns": {
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unreliable": {
+          "name": "unreliable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "domain_reliability_by_unreliable": {
+          "name": "domain_reliability_by_unreliable",
+          "columns": [
+            {
+              "expression": "unreliable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_subscriptions": {
+      "name": "billing_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_product_id": {
+          "name": "provider_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_subscriptions_by_provider": {
+          "name": "billing_subscriptions_by_provider",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_subscriptions_by_owner_updated": {
+          "name": "billing_subscriptions_by_owner_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscriptions_owner_user_id_users_owner_user_id_fk": {
+          "name": "billing_subscriptions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "billing_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_subscriptions_plan_check": {
+          "name": "billing_subscriptions_plan_check",
+          "value": "\"billing_subscriptions\".\"plan_key\" in ('starter', 'plus', 'ultra')"
+        },
+        "billing_subscriptions_interval_check": {
+          "name": "billing_subscriptions_interval_check",
+          "value": "\"billing_subscriptions\".\"billing_interval\" in ('month', 'year')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_pending_webhooks": {
+      "name": "billing_pending_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_entitlements": {
+      "name": "admin_entitlements",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_entitlements_owner_user_id_users_owner_user_id_fk": {
+          "name": "admin_entitlements_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "admin_entitlements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_credit_periods": {
+      "name": "billing_credit_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_limit": {
+          "name": "credits_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spend_ceiling_cents": {
+          "name": "spend_ceiling_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_credit_periods_by_owner_period": {
+          "name": "billing_credit_periods_by_owner_period",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_credit_periods_owner_user_id_users_owner_user_id_fk": {
+          "name": "billing_credit_periods_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "billing_credit_periods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_usage_ledger": {
+      "name": "provider_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "provider_usage_ledger_by_owner_idempotency_key": {
+          "name": "provider_usage_ledger_by_owner_idempotency_key",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_usage_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_usage_ledger_by_owner_feature_created": {
+          "name": "provider_usage_ledger_by_owner_feature_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_usage_ledger_owner_user_id_users_owner_user_id_fk": {
+          "name": "provider_usage_ledger_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "provider_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_usage_ledger_feature_check": {
+          "name": "provider_usage_ledger_feature_check",
+          "value": "\"provider_usage_ledger\".\"feature\" in ('normal_chat', 'pro_chat', 'cited_answer', 'deep_research', 'external_search', 'sandbox_compute', 'citation_verify')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_daily_rollup": {
+      "name": "usage_daily_rollup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "feature_counts": {
+          "name": "feature_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "usage_daily_rollup_by_owner_date": {
+          "name": "usage_daily_rollup_by_owner_date",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_daily_rollup_owner_user_id_users_owner_user_id_fk": {
+          "name": "usage_daily_rollup_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "usage_daily_rollup",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0014_snapshot.json
+++ b/packages/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,4191 @@
+{
+  "id": "66887c5f-ee39-4a5b-81d8-033cf83fc244",
+  "prevId": "e2637f6b-918b-4329-a16d-25fd79401524",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_completed_at": {
+          "name": "deletion_completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_status": {
+          "name": "deletion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "users_by_email": {
+          "name": "users_by_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_deletion_status_check": {
+          "name": "users_deletion_status_check",
+          "value": "\"users\".\"deletion_status\" in ('active', 'deleting', 'deleted', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workspaces_by_owner_status_updated": {
+          "name": "workspaces_by_owner_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_by_owner_updated": {
+          "name": "workspaces_by_owner_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_users_owner_user_id_fk": {
+          "name": "workspaces_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspaces_status_check": {
+          "name": "workspaces_status_check",
+          "value": "\"workspaces\".\"status\" in ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_folders": {
+      "name": "workspace_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_folders_by_owner_workspace_status_updated": {
+          "name": "workspace_folders_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_folders_by_owner_workspace_name": {
+          "name": "workspace_folders_by_owner_workspace_name",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_folders_owner_user_id_users_owner_user_id_fk": {
+          "name": "workspace_folders_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "workspace_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_folders_workspace_id_workspaces_id_fk": {
+          "name": "workspace_folders_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_folders",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_folders_status_check": {
+          "name": "workspace_folders_status_check",
+          "value": "\"workspace_folders\".\"status\" in ('active', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_about_source": {
+          "name": "heard_about_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_about_other": {
+          "name": "heard_about_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_onboarding_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_onboarding_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feed_interests": {
+      "name": "user_feed_interests",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feed_interests_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_feed_interests_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_feed_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_feed_interests_owner_user_id_topic_pk": {
+          "name": "user_feed_interests_owner_user_id_topic_pk",
+          "columns": [
+            "owner_user_id",
+            "topic"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_family": {
+          "name": "artifact_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexing_status": {
+          "name": "indexing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_indexed'"
+        },
+        "indexing_failure_reason": {
+          "name": "indexing_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_document_kind": {
+          "name": "detected_document_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_r2_key": {
+          "name": "storage_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rag_entry_id": {
+          "name": "rag_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text_preview": {
+          "name": "plain_text_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifacts_by_owner_status_updated": {
+          "name": "artifacts_by_owner_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_workspace_status_updated": {
+          "name": "artifacts_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_workspace_folder_status_updated": {
+          "name": "artifacts_by_owner_workspace_folder_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_thread_created": {
+          "name": "artifacts_by_owner_thread_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_thread_source_status_created": {
+          "name": "artifacts_by_owner_thread_source_status_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifacts_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_workspace_id_workspaces_id_fk": {
+          "name": "artifacts_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifacts_folder_id_workspace_folders_id_fk": {
+          "name": "artifacts_folder_id_workspace_folders_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "workspace_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifacts_artifact_type_check": {
+          "name": "artifacts_artifact_type_check",
+          "value": "\"artifacts\".\"artifact_type\" in ('markdown', 'plain_text', 'pdf', 'docx', 'html', 'svg', 'mermaid', 'json', 'csv', 'code', 'url')"
+        },
+        "artifacts_artifact_family_check": {
+          "name": "artifacts_artifact_family_check",
+          "value": "\"artifacts\".\"artifact_family\" in ('text', 'file', 'interactive', 'visual', 'data', 'link')"
+        },
+        "artifacts_source_check": {
+          "name": "artifacts_source_check",
+          "value": "\"artifacts\".\"source\" in ('manual', 'upload', 'agent', 'url')"
+        },
+        "artifacts_indexing_status_check": {
+          "name": "artifacts_indexing_status_check",
+          "value": "\"artifacts\".\"indexing_status\" in ('not_indexed', 'pending', 'ready', 'failed')"
+        },
+        "artifacts_detected_document_kind_check": {
+          "name": "artifacts_detected_document_kind_check",
+          "value": "\"artifacts\".\"detected_document_kind\" is null or \"artifacts\".\"detected_document_kind\" in ('generic', 'scholarly_paper')"
+        },
+        "artifacts_status_check": {
+          "name": "artifacts_status_check",
+          "value": "\"artifacts\".\"status\" in ('active', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_contents": {
+      "name": "artifact_contents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks_json": {
+          "name": "blocks_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text": {
+          "name": "plain_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_text": {
+          "name": "context_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text_r2_key": {
+          "name": "plain_text_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocks_json_r2_key": {
+          "name": "blocks_json_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown_r2_key": {
+          "name": "markdown_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_contents_by_owner_artifact": {
+          "name": "artifact_contents_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_contents_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_contents_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_contents_workspace_id_workspaces_id_fk": {
+          "name": "artifact_contents_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_contents_artifact_id_artifacts_id_fk": {
+          "name": "artifact_contents_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_extractions": {
+      "name": "artifact_extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractor": {
+          "name": "extractor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_extractions_by_owner_artifact_extractor": {
+          "name": "artifact_extractions_by_owner_artifact_extractor",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extractor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_extractions_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_extractions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_extractions_artifact_id_artifacts_id_fk": {
+          "name": "artifact_extractions_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_extractions_workspace_id_workspaces_id_fk": {
+          "name": "artifact_extractions_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_extractions_extractor_check": {
+          "name": "artifact_extractions_extractor_check",
+          "value": "\"artifact_extractions\".\"extractor\" in ('pdf_text', 'docx_text', 'url_reader')"
+        },
+        "artifact_extractions_status_check": {
+          "name": "artifact_extractions_status_check",
+          "value": "\"artifact_extractions\".\"status\" in ('pending', 'running', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_paper_metadata": {
+      "name": "artifact_paper_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliations": {
+          "name": "affiliations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal": {
+          "name": "journal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_status": {
+          "name": "oa_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_status": {
+          "name": "pdf_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_paper_metadata_by_owner_artifact": {
+          "name": "artifact_paper_metadata_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_paper_metadata_by_owner_workspace_updated": {
+          "name": "artifact_paper_metadata_by_owner_workspace_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_paper_metadata_by_owner_doi": {
+          "name": "artifact_paper_metadata_by_owner_doi",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_paper_metadata_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_paper_metadata_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_paper_metadata_artifact_id_artifacts_id_fk": {
+          "name": "artifact_paper_metadata_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_paper_metadata_workspace_id_workspaces_id_fk": {
+          "name": "artifact_paper_metadata_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_paper_metadata_metadata_source_check": {
+          "name": "artifact_paper_metadata_metadata_source_check",
+          "value": "\"artifact_paper_metadata\".\"metadata_source\" in ('crossref', 'openalex', 'arxiv', 'datacite', 'semantic_scholar', 'manual', 'llm')"
+        },
+        "artifact_paper_metadata_pdf_status_check": {
+          "name": "artifact_paper_metadata_pdf_status_check",
+          "value": "\"artifact_paper_metadata\".\"pdf_status\" is null or \"artifact_paper_metadata\".\"pdf_status\" in ('downloaded', 'no_oa_available')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_urls": {
+      "name": "artifact_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_text": {
+          "name": "readable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_text": {
+          "name": "context_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_text_r2_key": {
+          "name": "readable_text_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_urls_by_owner_workspace_normalized_url": {
+          "name": "artifact_urls_by_owner_workspace_normalized_url",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_urls_by_owner_artifact": {
+          "name": "artifact_urls_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_urls_by_owner_workspace_status_updated": {
+          "name": "artifact_urls_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_urls_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_urls_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_urls_workspace_id_workspaces_id_fk": {
+          "name": "artifact_urls_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_urls_artifact_id_artifacts_id_fk": {
+          "name": "artifact_urls_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_urls_status_check": {
+          "name": "artifact_urls_status_check",
+          "value": "\"artifact_urls\".\"status\" in ('pending', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_embeddings": {
+      "name": "artifact_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_embeddings_by_owner_artifact": {
+          "name": "artifact_embeddings_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_embeddings_embedding_hnsw": {
+          "name": "artifact_embeddings_embedding_hnsw",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_embeddings_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_embeddings_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_embeddings_artifact_id_artifacts_id_fk": {
+          "name": "artifact_embeddings_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_embeddings_workspace_id_workspaces_id_fk": {
+          "name": "artifact_embeddings_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_status": {
+          "name": "title_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lite'"
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continuation_token": {
+          "name": "continuation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_user_message": {
+          "name": "pending_user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_user_message_created_at": {
+          "name": "pending_user_message_created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_threads_by_owner_activity": {
+          "name": "chat_threads_by_owner_activity",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_threads_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_threads_status_check": {
+          "name": "chat_threads_status_check",
+          "value": "\"chat_threads\".\"status\" in ('idle', 'streaming', 'failed')"
+        },
+        "chat_threads_title_status_check": {
+          "name": "chat_threads_title_status_check",
+          "value": "\"chat_threads\".\"title_status\" is null or \"chat_threads\".\"title_status\" in ('generating', 'ready')"
+        },
+        "chat_threads_agent_kind_check": {
+          "name": "chat_threads_agent_kind_check",
+          "value": "\"chat_threads\".\"agent_kind\" in ('lite', 'pro')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_by_thread_created": {
+          "name": "chat_messages_by_thread_created",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_messages_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_messages_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_messages_role_check": {
+          "name": "chat_messages_role_check",
+          "value": "\"chat_messages\".\"role\" in ('user', 'assistant', 'system')"
+        },
+        "chat_messages_status_check": {
+          "name": "chat_messages_status_check",
+          "value": "\"chat_messages\".\"status\" in ('streaming', 'complete', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_events": {
+      "name": "chat_thread_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_index": {
+          "name": "event_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_thread_events_thread_event_index": {
+          "name": "chat_thread_events_thread_event_index",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_events_thread_type_step": {
+          "name": "chat_thread_events_thread_type_step",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_events_thread_id_chat_threads_id_fk": {
+          "name": "chat_thread_events_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_thread_events",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_thread_events_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_thread_events_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_thread_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.research_sources": {
+      "name": "research_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citation_number": {
+          "name": "citation_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_strength": {
+          "name": "evidence_strength",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovery_query": {
+          "name": "discovery_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "research_sources_by_thread": {
+          "name": "research_sources_by_thread",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "research_sources_thread_turn_locator": {
+          "name": "research_sources_thread_turn_locator",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "research_sources_thread_id_chat_threads_id_fk": {
+          "name": "research_sources_thread_id_chat_threads_id_fk",
+          "tableFrom": "research_sources",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "research_sources_owner_user_id_users_owner_user_id_fk": {
+          "name": "research_sources_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "research_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "research_sources_origin_check": {
+          "name": "research_sources_origin_check",
+          "value": "\"research_sources\".\"origin\" in ('web', 'arxiv', 'doi')"
+        },
+        "research_sources_evidence_strength_check": {
+          "name": "research_sources_evidence_strength_check",
+          "value": "\"research_sources\".\"evidence_strength\" in ('strong', 'medium', 'weak')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.explore_papers": {
+      "name": "explore_papers",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openalex_id": {
+          "name": "openalex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_access": {
+          "name": "is_open_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "explore_papers_by_doi": {
+          "name": "explore_papers_by_doi",
+          "columns": [
+            {
+              "expression": "doi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "explore_papers_provider_check": {
+          "name": "explore_papers_provider_check",
+          "value": "\"explore_papers\".\"provider\" in ('OpenAlex', 'arXiv', 'Exa', 'Jina', 'Crossref')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tldr": {
+          "name": "tldr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tldr_id": {
+          "name": "tldr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_id": {
+          "name": "title_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_url": {
+          "name": "resolved_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_text": {
+          "name": "article_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrich_attempts": {
+          "name": "enrich_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_key": {
+          "name": "paper_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_access": {
+          "name": "is_open_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "trend_score": {
+          "name": "trend_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retraction_status": {
+          "name": "retraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_claim": {
+          "name": "primary_claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance_supporting": {
+          "name": "stance_supporting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance_contrasting": {
+          "name": "stance_contrasting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sparkline": {
+          "name": "sparkline",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_at": {
+          "name": "order_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "feed_items_by_dedupe_key": {
+          "name": "feed_items_by_dedupe_key",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_kind_trend": {
+          "name": "feed_items_by_kind_trend",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trend_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_kind_published": {
+          "name": "feed_items_by_kind_published",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_order": {
+          "name": "feed_items_by_order",
+          "columns": [
+            {
+              "expression": "order_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_paper_key": {
+          "name": "feed_items_by_paper_key",
+          "columns": [
+            {
+              "expression": "paper_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_search_gin": {
+          "name": "feed_items_search_gin",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_items_kind_check": {
+          "name": "feed_items_kind_check",
+          "value": "\"feed_items\".\"kind\" in ('paper', 'news', 'claim', 'topic', 'idea')"
+        },
+        "feed_items_provider_check": {
+          "name": "feed_items_provider_check",
+          "value": "\"feed_items\".\"provider\" in ('openalex', 'exa_news', 'google_news', 'gdelt', 'google_factcheck', 'turnbackhoax')"
+        },
+        "feed_items_retraction_status_check": {
+          "name": "feed_items_retraction_status_check",
+          "value": "\"feed_items\".\"retraction_status\" is null or \"feed_items\".\"retraction_status\" in ('none', 'concern', 'retracted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_sources": {
+      "name": "feed_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cadence_minutes": {
+          "name": "cadence_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_params_json": {
+          "name": "query_params_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feed_sources_by_provider": {
+          "name": "feed_sources_by_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_sources_provider_check": {
+          "name": "feed_sources_provider_check",
+          "value": "\"feed_sources\".\"provider\" in ('openalex', 'exa_news', 'google_news', 'gdelt', 'google_factcheck', 'turnbackhoax')"
+        },
+        "feed_sources_last_status_check": {
+          "name": "feed_sources_last_status_check",
+          "value": "\"feed_sources\".\"last_status\" is null or \"feed_sources\".\"last_status\" in ('ready', 'empty', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_feed_items": {
+      "name": "saved_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "saved_feed_items_by_owner_item": {
+          "name": "saved_feed_items_by_owner_item",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_feed_items_by_owner_created": {
+          "name": "saved_feed_items_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_feed_items_owner_user_id_users_owner_user_id_fk": {
+          "name": "saved_feed_items_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "saved_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "saved_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "saved_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hidden_feed_items": {
+      "name": "hidden_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "hidden_feed_items_by_owner_item": {
+          "name": "hidden_feed_items_by_owner_item",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hidden_feed_items_by_owner_created": {
+          "name": "hidden_feed_items_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hidden_feed_items_owner_user_id_users_owner_user_id_fk": {
+          "name": "hidden_feed_items_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "hidden_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hidden_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "hidden_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "hidden_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_interactions": {
+      "name": "feed_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feed_interactions_by_owner_item_kind": {
+          "name": "feed_interactions_by_owner_item_kind",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_by_owner_created": {
+          "name": "feed_interactions_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_interactions_owner_user_id_users_owner_user_id_fk": {
+          "name": "feed_interactions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "feed_interactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_interactions_feed_item_id_feed_items_id_fk": {
+          "name": "feed_interactions_feed_item_id_feed_items_id_fk",
+          "tableFrom": "feed_interactions",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_interactions_kind_check": {
+          "name": "feed_interactions_kind_check",
+          "value": "\"feed_interactions\".\"kind\" in ('save', 'hide', 'research', 'open_evidence')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.domain_reliability": {
+      "name": "domain_reliability",
+      "schema": "",
+      "columns": {
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unreliable": {
+          "name": "unreliable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "domain_reliability_by_unreliable": {
+          "name": "domain_reliability_by_unreliable",
+          "columns": [
+            {
+              "expression": "unreliable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_subscriptions": {
+      "name": "billing_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_product_id": {
+          "name": "provider_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_subscriptions_by_provider": {
+          "name": "billing_subscriptions_by_provider",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_subscriptions_by_owner_updated": {
+          "name": "billing_subscriptions_by_owner_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscriptions_owner_user_id_users_owner_user_id_fk": {
+          "name": "billing_subscriptions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "billing_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_subscriptions_plan_check": {
+          "name": "billing_subscriptions_plan_check",
+          "value": "\"billing_subscriptions\".\"plan_key\" in ('starter', 'plus', 'ultra')"
+        },
+        "billing_subscriptions_interval_check": {
+          "name": "billing_subscriptions_interval_check",
+          "value": "\"billing_subscriptions\".\"billing_interval\" in ('month', 'year')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_pending_webhooks": {
+      "name": "billing_pending_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_entitlements": {
+      "name": "admin_entitlements",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_entitlements_owner_user_id_users_owner_user_id_fk": {
+          "name": "admin_entitlements_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "admin_entitlements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_credit_periods": {
+      "name": "billing_credit_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_limit": {
+          "name": "credits_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spend_ceiling_cents": {
+          "name": "spend_ceiling_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_credit_periods_by_owner_period": {
+          "name": "billing_credit_periods_by_owner_period",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_credit_periods_owner_user_id_users_owner_user_id_fk": {
+          "name": "billing_credit_periods_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "billing_credit_periods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_usage_ledger": {
+      "name": "provider_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "provider_usage_ledger_by_owner_idempotency_key": {
+          "name": "provider_usage_ledger_by_owner_idempotency_key",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_usage_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_usage_ledger_by_owner_feature_created": {
+          "name": "provider_usage_ledger_by_owner_feature_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_usage_ledger_owner_user_id_users_owner_user_id_fk": {
+          "name": "provider_usage_ledger_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "provider_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_usage_ledger_feature_check": {
+          "name": "provider_usage_ledger_feature_check",
+          "value": "\"provider_usage_ledger\".\"feature\" in ('normal_chat', 'pro_chat', 'cited_answer', 'deep_research', 'external_search', 'sandbox_compute', 'citation_verify')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_daily_rollup": {
+      "name": "usage_daily_rollup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "feature_counts": {
+          "name": "feature_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "usage_daily_rollup_by_owner_date": {
+          "name": "usage_daily_rollup_by_owner_date",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_daily_rollup_owner_user_id_users_owner_user_id_fk": {
+          "name": "usage_daily_rollup_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "usage_daily_rollup",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -92,6 +92,20 @@
       "when": 1782361846134,
       "tag": "0012_mayar_billing",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1782461857929,
+      "tag": "0013_romantic_stature",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1782462735970,
+      "tag": "0014_bstrip_superseded_deltas",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/chatThreadEventRepo.ts
+++ b/packages/db/src/repositories/chatThreadEventRepo.ts
@@ -15,6 +15,11 @@ export const ChatThreadEventRepo = {
    * menentukan hasil. Query ini membuang delta yang sudah disusul → payload kecil, cursor tetap
    * benar (delta tail per langkah ikut → `max(event_index)` ≈ posisi stream eve sebenarnya).
    * Token-level realtime tetap via resume stream eve (`/eve/v1/.../stream`).
+   *
+   * GROUP BY kolom `step_index` (Phase 3, fix C), BUKAN ekspresi `payload->'data'->>'stepIndex'`
+   * yang memaksa DETOAST seluruh payload (32MB) tiap panggil hanya untuk membaca satu int →
+   * cold-load ~2 dtk. Kolom + index `(thread_id, type, step_index)` → grouping tanpa detoast;
+   * payload hanya di-detoast untuk ~84 baris final yang benar-benar di-SELECT.
    */
   async listByThread(
     db: DbOrTx,
@@ -23,7 +28,7 @@ export const ChatThreadEventRepo = {
   ): Promise<ChatThreadEvent[]> {
     const filters = [eq(chatThreadEvents.threadId, threadId)];
     if (afterIndex !== undefined) filters.push(gt(chatThreadEvents.eventIndex, afterIndex));
-    // Semua event NON-delta + hanya delta TERAKHIR per (type, turn_id, stepIndex).
+    // Semua event NON-delta + hanya delta TERAKHIR per (type, turn_id, step_index).
     filters.push(sql`(
       ${chatThreadEvents.type} not in ('message.appended', 'reasoning.appended')
       or ${chatThreadEvents.eventIndex} in (
@@ -31,7 +36,7 @@ export const ChatThreadEventRepo = {
         from chat_thread_events
         where thread_id = ${threadId}
           and type in ('message.appended', 'reasoning.appended')
-        group by type, turn_id, (payload -> 'data' ->> 'stepIndex')
+        group by type, turn_id, step_index
       )
     )`);
     return db
@@ -39,5 +44,36 @@ export const ChatThreadEventRepo = {
       .from(chatThreadEvents)
       .where(and(...filters))
       .orderBy(asc(chatThreadEvents.eventIndex));
+  },
+
+  /**
+   * Append event terminal SINTETIK (reconciler zombie, Phase 5, fix E). Turn yang crash mid-stream
+   * tak menulis event terminal → event terakhir non-terminal → klien `isStreamActive(base)` true
+   * selamanya (composer terkunci). Sisipkan `turn.failed` (∈ `SETTLED_OR_PARKED_LAST` klien) di
+   * `event_index = max+1` → `isStreamActive` false → composer unlock saat reload. `event_index` via
+   * subquery (sama pola `store.ts`); `onConflictDoNothing` defensif (idempoten bila dijalankan ulang).
+   * Payload = event eve minimal valid; reducer memperlakukan `turn.failed` sbg no-op (gate UI via
+   * status='failed' + isStreamActive), jadi turnId tak wajib.
+   */
+  async appendTerminal(
+    db: DbOrTx,
+    input: { threadId: string; ownerUserId: string; type: string },
+  ): Promise<void> {
+    const now = Date.now();
+    await db
+      .insert(chatThreadEvents)
+      .values({
+        threadId: input.threadId,
+        ownerUserId: input.ownerUserId,
+        eventIndex: sql`(select coalesce(max(event_index), -1) + 1 from chat_thread_events where thread_id = ${input.threadId})`,
+        type: input.type,
+        turnId: null,
+        stepIndex: null,
+        payload: { type: input.type, data: { reason: "reconciled_stale" } },
+        createdAt: now,
+      })
+      .onConflictDoNothing({
+        target: [chatThreadEvents.threadId, chatThreadEvents.eventIndex],
+      });
   },
 };

--- a/packages/db/src/repositories/chatThreadEventRepo.ts
+++ b/packages/db/src/repositories/chatThreadEventRepo.ts
@@ -1,15 +1,43 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, gt, sql } from "drizzle-orm";
 import { type ChatThreadEvent, chatThreadEvents } from "../schema/chatThreadEvents";
 import type { DbOrTx } from "../types";
 
 /** Repo chat_thread_events — BACA saja (tulis via raw SQL di PROSES eve). */
 export const ChatThreadEventRepo = {
-  /** Event stream thread, urut `event_index` ASC (= posisi stream eve; cursor resume klien). */
-  async listByThread(db: DbOrTx, threadId: string): Promise<ChatThreadEvent[]> {
+  /**
+   * Event stream thread, urut `event_index` ASC (= posisi stream eve; cursor resume klien).
+   * `afterIndex` (opsional) = fetch INCREMENTAL hanya delta `event_index > afterIndex`.
+   *
+   * COMPACTION (krusial untuk performa): `message.appended`/`reasoning.appended` membawa
+   * `messageSoFar`/`reasoningSoFar` KUMULATIF, jadi log mentah O(n²) byte (terukur 18MB untuk
+   * satu `/deep`) → menarik dari Postgres VPS lambat berdetik-detik tiap cold-load. Reducer eve
+   * me-REPLACE part teks tiap delta, jadi HANYA delta terakhir per (type, turn, step) yang
+   * menentukan hasil. Query ini membuang delta yang sudah disusul → payload kecil, cursor tetap
+   * benar (delta tail per langkah ikut → `max(event_index)` ≈ posisi stream eve sebenarnya).
+   * Token-level realtime tetap via resume stream eve (`/eve/v1/.../stream`).
+   */
+  async listByThread(
+    db: DbOrTx,
+    threadId: string,
+    afterIndex?: number,
+  ): Promise<ChatThreadEvent[]> {
+    const filters = [eq(chatThreadEvents.threadId, threadId)];
+    if (afterIndex !== undefined) filters.push(gt(chatThreadEvents.eventIndex, afterIndex));
+    // Semua event NON-delta + hanya delta TERAKHIR per (type, turn_id, stepIndex).
+    filters.push(sql`(
+      ${chatThreadEvents.type} not in ('message.appended', 'reasoning.appended')
+      or ${chatThreadEvents.eventIndex} in (
+        select max(event_index)
+        from chat_thread_events
+        where thread_id = ${threadId}
+          and type in ('message.appended', 'reasoning.appended')
+        group by type, turn_id, (payload -> 'data' ->> 'stepIndex')
+      )
+    )`);
     return db
       .select()
       .from(chatThreadEvents)
-      .where(eq(chatThreadEvents.threadId, threadId))
+      .where(and(...filters))
       .orderBy(asc(chatThreadEvents.eventIndex));
   },
 };

--- a/packages/db/src/repositories/chatThreadRepo.ts
+++ b/packages/db/src/repositories/chatThreadRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
+import { and, desc, eq, gte, isNull, lt, or } from "drizzle-orm";
 import { type ChatThread, chatThreads, type NewChatThread } from "../schema/chatThreads";
 import { type KeysetCursor, encodeKeysetCursor } from "../cursor";
 import type { DbOrTx } from "../types";
@@ -7,6 +7,33 @@ import type { DbOrTx } from "../types";
 export const ChatThreadRepo = {
   async findById(db: DbOrTx, id: string): Promise<ChatThread | null> {
     const rows = await db.select().from(chatThreads).where(eq(chatThreads.id, id)).limit(1);
+    return rows[0] ?? null;
+  },
+
+  /**
+   * Thread `streaming` TERMUDA milik owner (DESC `lastActivityAt`). Dipakai klien untuk
+   * menemukan sessionId turn PERTAMA segera setelah `send()` — `useEveAgent` baru surface
+   * sessionId di akhir turn (`onSessionChange`), jadi tanpa ini refresh saat menyusun plan
+   * mendarat di halaman kosong. Karena composer serial (satu turn aktif per user), thread
+   * streaming termuda == yang baru dibuat hook `session.started`.
+   *
+   * `since` (opsional, epoch ms) menyaring `lastActivityAt >= since` supaya thread `streaming`
+   * BASI lama (turn mati tanpa settle) tak salah dikira thread baru → klien teruskan timestamp
+   * SEBELUM `send()`.
+   */
+  async findRecentActiveByOwner(
+    db: DbOrTx,
+    ownerUserId: string,
+    since?: number,
+  ): Promise<ChatThread | null> {
+    const filters = [eq(chatThreads.ownerUserId, ownerUserId), eq(chatThreads.status, "streaming")];
+    if (since !== undefined) filters.push(gte(chatThreads.lastActivityAt, since));
+    const rows = await db
+      .select()
+      .from(chatThreads)
+      .where(and(...filters))
+      .orderBy(desc(chatThreads.lastActivityAt), desc(chatThreads.id))
+      .limit(1);
     return rows[0] ?? null;
   },
 

--- a/packages/db/src/repositories/chatThreadRepo.ts
+++ b/packages/db/src/repositories/chatThreadRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, isNull, lt, or } from "drizzle-orm";
+import { and, desc, eq, gte, isNull, lt, or, sql } from "drizzle-orm";
 import { type ChatThread, chatThreads, type NewChatThread } from "../schema/chatThreads";
 import { type KeysetCursor, encodeKeysetCursor } from "../cursor";
 import type { DbOrTx } from "../types";
@@ -55,6 +55,38 @@ export const ChatThreadRepo = {
   },
 
   /**
+   * Upsert continuation token RACE-PROOF (Phase 2 proxy-tee). Respons create-POST eve (202)
+   * mendahului hook `session.started` yang membuat row, jadi row bisa BELUM ada → insert-if-absent
+   * (row minimal milik caller; owner = Clerk sub = eve principalId). Bila row sudah ada → update
+   * token saja, `setWhere owner` mencegah caller lain menimpa token thread bukan miliknya
+   * (id = ULID tak-bisa-ditebak; defensif). TIDAK menyentuh `status` saat update (jangan timpa
+   * lifecycle turn). Idempoten + tanpa assertOwner (row mungkin belum ada).
+   */
+  async upsertContinuationToken(
+    db: DbOrTx,
+    input: { id: string; ownerUserId: string; continuationToken: string },
+  ): Promise<void> {
+    const now = Date.now();
+    await db
+      .insert(chatThreads)
+      .values({
+        id: input.id,
+        ownerUserId: input.ownerUserId,
+        status: "streaming",
+        agentKind: "lite",
+        continuationToken: input.continuationToken,
+        lastActivityAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: chatThreads.id,
+        set: { continuationToken: input.continuationToken, updatedAt: now },
+        setWhere: eq(chatThreads.ownerUserId, input.ownerUserId),
+      });
+  },
+
+  /**
    * Klaim atomik generasi auto-title (Slice 6.8). `title_status: null → 'generating'`
    * via guard `where title_status IS NULL` → `RETURNING` → hanya satu pemanggil yang
    * "menang". `true` ⇒ klaim baru: turn pertama (status masih null) DAN belum di-rename
@@ -85,6 +117,31 @@ export const ChatThreadRepo = {
 
   async deleteById(db: DbOrTx, id: string): Promise<void> {
     await db.delete(chatThreads).where(eq(chatThreads.id, id));
+  },
+
+  /**
+   * Thread "zombie" (Phase 5, fix E): `status='streaming'` yang turn-nya MATI mid-stream (crash /
+   * ENOSPC / dev restart) tanpa menulis event terminal → klien `isStreamActive` true selamanya
+   * (composer terkunci, refresh tak menolong). Kandidat = `streaming` + `last_activity_at < cutoff`
+   * (plan: ambang 30 mnt > gap subagent sah ~5,7 mnt).
+   *
+   * Guard `not exists (event >= cutoff)`: cegah FALSE-POSITIVE — `last_activity_at` hanya di-bump
+   * oleh message.completed, jadi turn yang masih hidup tapi sedang stream token (delta `*.appended`
+   * tiap ~330ms) atau tool/subagent bisa terlihat "basi" oleh last_activity_at saja. Event-recency
+   * memastikan kita hanya reconcile turn yang BENAR-BENAR diam (tak ada event apa pun sejak cutoff)
+   * — reconcile turn hidup = data loss (turn mahal ter-corrupt), jadi guard ini wajib.
+   */
+  async findStaleStreaming(db: DbOrTx, cutoff: number): Promise<ChatThread[]> {
+    return db
+      .select()
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.status, "streaming"),
+          lt(chatThreads.lastActivityAt, cutoff),
+          sql`not exists (select 1 from chat_thread_events e where e.thread_id = ${chatThreads.id} and e.created_at >= ${cutoff})`,
+        ),
+      );
   },
 
   /** List keyset milik owner, DESC `(lastActivityAt, id)`. `{ items, nextCursor }`. */

--- a/packages/db/src/schema/chatThreadEvents.ts
+++ b/packages/db/src/schema/chatThreadEvents.ts
@@ -1,4 +1,13 @@
-import { bigint, bigserial, integer, jsonb, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core";
+import {
+  bigint,
+  bigserial,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
 import { chatThreads } from "./chatThreads";
 import { users } from "./users";
 
@@ -42,11 +51,20 @@ export const chatThreadEvents = pgTable(
     eventIndex: integer("event_index").notNull(),
     type: text("type").notNull(),
     turnId: text("turn_id"),
+    // `payload.data.stepIndex` di-lift ke kolom (Phase 3): compaction jalur-baca (`listByThread`)
+    // GROUP BY kolom ini, bukan ekspresi JSON `payload->'data'->>'stepIndex'` yang men-DETOAST
+    // SELURUH payload (32MB) tiap panggil hanya untuk membaca satu int → cold-load ~2 dtk. Nullable
+    // (event non-step / event lama pra-backfill).
+    stepIndex: integer("step_index"),
     payload: jsonb("payload").$type<unknown>().notNull(),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
   },
-  // UNIQUE (thread_id, event_index) sekaligus melayani lookup + ordering replay per thread.
-  (t) => [uniqueIndex("chat_thread_events_thread_event_index").on(t.threadId, t.eventIndex)],
+  (t) => [
+    // UNIQUE (thread_id, event_index) sekaligus melayani lookup + ordering replay per thread.
+    uniqueIndex("chat_thread_events_thread_event_index").on(t.threadId, t.eventIndex),
+    // Mendukung GROUP BY compaction delta (`listByThread`) tanpa detoast payload (Phase 3).
+    index("chat_thread_events_thread_type_step").on(t.threadId, t.type, t.stepIndex),
+  ],
 );
 
 export type ChatThreadEvent = typeof chatThreadEvents.$inferSelect;

--- a/packages/db/src/schema/chatThreads.ts
+++ b/packages/db/src/schema/chatThreads.ts
@@ -29,9 +29,12 @@ export const chatThreads = pgTable(
     status: text("status").notNull().default("idle"),
     agentKind: text("agent_kind").notNull().default("lite"),
     lastMessagePreview: text("last_message_preview"),
-    // Resume handle eve (Slice fix): dipersist tiap `session.waiting` oleh channel agent.
-    // Follow-up di thread yang di-reload WAJIB continuationToken (eve menolak tanpa-token);
-    // di-rehydrate ke `initialSession` saat ThreadView mount. Null sampai turn pertama parkir.
+    // Resume handle eve = continuation token ber-namespace TUNGGAL (`eve:<uuid>`). Ditangkap
+    // SERVER-SIDE oleh proxy-tee respons create/continue eve (`app/eve/v1/[...path]/route.ts`
+    // → upsert race-proof api-v2), BUKAN oleh channel agent (`channel.continuationToken` =
+    // double-namespace `eve:eve:…` → `deliver` gagal). Follow-up + jawab HITL di thread yang
+    // di-reload WAJIB token ini (eve menolak tanpa-token); di-rehydrate ke `initialSession`
+    // saat ThreadView mount. Null sampai create-POST turn pertama ter-tee.
     continuationToken: text("continuation_token"),
     // Recovery pesan terkirim yang turn-nya belum settle (baseline template eve-chat). Ditulis
     // klien sebelum `agent.send()`; di-null-kan saat ada event settled setelah `_created_at`

--- a/packages/services/src/chat/event.service.ts
+++ b/packages/services/src/chat/event.service.ts
@@ -7,8 +7,16 @@ import { type ChatThreadEvent, ChatThreadEventRepo, type DbOrTx } from "@aqsha/d
  * turn jalan). Path TULIS hidup di PROSES eve (`apps/agent-v2/agent/lib/store.ts`, raw SQL).
  */
 export const EventService = {
-  /** Event stream thread (urut `event_index`). UNGATED — route memanggil `ThreadService.assertOwner` dulu. */
-  async listByThread(db: DbOrTx, threadId: string): Promise<ChatThreadEvent[]> {
-    return ChatThreadEventRepo.listByThread(db, threadId);
+  /**
+   * Event stream thread (urut `event_index`). UNGATED — route memanggil `ThreadService.assertOwner` dulu.
+   * `afterIndex` (opsional) = fetch INCREMENTAL hanya delta `> afterIndex` (reconciliation klien,
+   * hindari re-fetch seluruh log).
+   */
+  async listByThread(
+    db: DbOrTx,
+    threadId: string,
+    afterIndex?: number,
+  ): Promise<ChatThreadEvent[]> {
+    return ChatThreadEventRepo.listByThread(db, threadId, afterIndex);
   },
 };

--- a/packages/services/src/chat/thread.service.ts
+++ b/packages/services/src/chat/thread.service.ts
@@ -33,6 +33,20 @@ export const ThreadService = {
     return thread;
   },
 
+  /**
+   * Thread `streaming` termuda milik caller — klien memakai ini untuk menemukan sessionId
+   * turn PERTAMA segera setelah `send()` (lihat `ChatThreadRepo.findRecentActiveByOwner`),
+   * lalu bump URL → refresh saat menyusun plan tak lagi kehilangan thread. `null` bila
+   * belum ada (klien retry singkat sampai hook `session.started` membuat thread).
+   */
+  async recentActive(
+    db: DbOrTx,
+    ownerUserId: string,
+    since?: number,
+  ): Promise<ChatThread | null> {
+    return ChatThreadRepo.findRecentActiveByOwner(db, ownerUserId, since);
+  },
+
   /** Assert kepemilikan (rename/delete/messages). Missing/not-owned → 404. */
   async assertOwner(db: DbOrTx, ownerUserId: string, threadId: string): Promise<ChatThread> {
     const thread = await ChatThreadRepo.findById(db, threadId);

--- a/packages/services/src/chat/thread.service.ts
+++ b/packages/services/src/chat/thread.service.ts
@@ -1,6 +1,7 @@
 import {
   type ChatThread,
   ChatMessageRepo,
+  ChatThreadEventRepo,
   ChatThreadRepo,
   type Db,
   type DbOrTx,
@@ -14,6 +15,7 @@ const DEFAULT_LIST_LIMIT = 30;
 const MAX_LIST_LIMIT = 100;
 const TITLE_MAX = 120;
 const ARCHIVE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // >1 hari sejak aktivitas terakhir → "older"
+const STALE_STREAMING_THRESHOLD_MS = 30 * 60_000; // 30 mnt > gap subagent sah (~5,7 mnt); tunable
 
 /** Bucket aktivitas thread untuk pengelompokan sidebar — dihitung server-side (BE). */
 export type ThreadBucket = "recent" | "older";
@@ -135,20 +137,23 @@ export const ThreadService = {
   },
 
   /**
-   * Persist handle-resume eve (`continuationToken`) dari KLIEN (`onSessionChange`). WAJIB
-   * pakai token KLIEN, bukan `channel.continuationToken` server: yang server ter-namespace
-   * GANDA (`eve:eve:…`) → `createSendFn` menamespace lagi saat dikirim balik → `deliver`
-   * gagal (approval HITL `inputResponses` TAK punya fallback → "Cannot deliver"). Token klien
-   * = nilai yang dipakai live (ter-namespace sekali) → cocok sesudah reload.
+   * Upsert handle-resume eve (`continuationToken`) RACE-PROOF — dipanggil proxy-tee respons
+   * create/continue eve (Phase 2), BUKAN klien. Token dari respons create-POST = ber-namespace
+   * TUNGGAL (`eve:<uuid>`, nilai yang dipakai live) → approval HITL `inputResponses` + follow-up
+   * lintas-reload bisa di-`deliver`. JANGAN pakai `channel.continuationToken` server (ganda
+   * `eve:eve:…` → `createSendFn` menamespace lagi → `deliver` gagal "Cannot deliver").
+   *
+   * TANPA assertOwner: respons create (202) bisa mendahului hook `session.started` yang membuat
+   * row → repo insert-if-absent (owner-guard di `setWhere`). Idempoten.
    */
-  async saveContinuation(
+  async upsertContinuationToken(
     db: DbOrTx,
     input: { ownerUserId: string; threadId: string; continuationToken: string },
   ): Promise<{ ok: true }> {
-    await this.assertOwner(db, input.ownerUserId, input.threadId);
-    await ChatThreadRepo.update(db, input.threadId, {
+    await ChatThreadRepo.upsertContinuationToken(db, {
+      id: input.threadId,
+      ownerUserId: input.ownerUserId,
       continuationToken: input.continuationToken,
-      updatedAt: Date.now(),
     });
     return { ok: true };
   },
@@ -166,6 +171,34 @@ export const ThreadService = {
       await ChatThreadRepo.deleteById(tx, input.threadId);
     });
     return { ok: true };
+  },
+
+  /**
+   * Reconciler thread "zombie" (Phase 5, fix E) — dipanggil cron worker `reconcile-stale-threads`.
+   * Turn crash (ENOSPC / restart / dev) meninggalkan `status='streaming'` TANPA event terminal →
+   * composer terkunci selamanya (klien tebak status dari event terakhir, refresh tak menolong).
+   * Untuk tiap thread basi (`findStaleStreaming`: streaming + last_activity basi + tanpa event sejak
+   * cutoff): (1) append event terminal sintetik `turn.failed` → `isStreamActive(base)` false (klien
+   * unlock composer), (2) `status='failed'` → DB & heuristik klien selaras. KEDUANYA wajib — status
+   * saja → heuristik event-terakhir klien & DB divergen (plan Traps). Per-thread satu tx (idempoten).
+   */
+  async reconcileStaleStreaming(
+    db: Db,
+    opts?: { thresholdMs?: number },
+  ): Promise<{ reconciled: number }> {
+    const cutoff = Date.now() - (opts?.thresholdMs ?? STALE_STREAMING_THRESHOLD_MS);
+    const stale = await ChatThreadRepo.findStaleStreaming(db, cutoff);
+    for (const thread of stale) {
+      await db.transaction(async (tx) => {
+        await ChatThreadEventRepo.appendTerminal(tx, {
+          threadId: thread.id,
+          ownerUserId: thread.ownerUserId,
+          type: "turn.failed",
+        });
+        await ChatThreadRepo.update(tx, thread.id, { status: "failed", updatedAt: Date.now() });
+      });
+    }
+    return { reconciled: stale.length };
   },
 };
 

--- a/packages/services/src/clients/queue.ts
+++ b/packages/services/src/clients/queue.ts
@@ -19,9 +19,10 @@ export const FEED_QUEUES = {
   feedHydration: "feed-hydration",
 } as const;
 
-/** Queue chat (P6) — auto-title async thread (Slice 6.8). */
+/** Queue chat (P6) — auto-title async thread (Slice 6.8) + reconciler zombie (Phase 5). */
 export const CHAT_QUEUES = {
   threadTitle: "thread-title",
+  reconcileStale: "reconcile-stale-threads",
 } as const;
 
 /** Queue account (P9) — cascade hard-delete data owner async (blob sweep + DELETE users). */


### PR DESCRIPTION
## Apa ini

Streaming/HITL big-bang (§9): mengganti jalur live berbasis polling dengan **resume event terpersist** sebagai satu-satunya mekanisme live, plus pengerasan storage & reliabilitas untuk surface chat Astra.

### Perubahan inti
- **Resume** — klien membuka ulang durable stream eve dari `max(event_index)+1` lalu reduce lewat reducer yang sama → streaming token-level lintas refresh.
- **Persistence** — event disimpan 1:1 dengan `event_index` monoton + `step_index`; proxy nge-*tee* respons create/continue eve untuk menyimpan `continuationToken` server-side (tanpa client-mint).
- **Storage** — B-strip delta tergantikan saat tulis (payload dikosongkan, baris dipertahankan) alih-alih di-drop; kompaksi read-path menyisakan delta terakhir per `(type, turn_id, step_index)`. Migrasi **0013 + 0014**.
- **Reliabilitas** — worker `reconcile-stale` menandai turn streaming zombie sebagai `failed` (ambang 30 mnt, dijaga cek event terbaru).
- **UI** — label elapsed subagent, satu timeline terurut, kartu HITL input-request.

### Perbaikan dari review (`/code-review high` + `/simplify`)
- **use-astra-agent** — lepas guard discovery turn-pertama di `finally` supaya ronde gagal (hook `session.started` lambat) bisa retry, bukan mematikan discovery permanen untuk mount itu.
- **chat-surface** — munculkan kegagalan `agent.send()` (jawaban HITL / kirim) lewat notice `sendError`, tidak lagi ditelan sunyi.
- **eve-timeline/chat-surface** — reduce event log **sekali** per perubahan `base`, dipakai bersama timeline + scan HITL (sebelumnya ter-reduce dua kali).

### Review: temuan yang TIDAK diubah
- **Resume reconnect-lock** (turn mati → composer terkunci s/d 10 mnt) sengaja **dibiarkan**: ini knob tuning yang sama dengan false-abort subagent /deep yang lambat — memendekkan timeout memperbaiki yang satu tapi memperburuk yang lain, dan tak ada sinyal client-side yang membedakan "mati" vs "diam mengerjakan". Fix sebenarnya = sinyal turn-dead otoritatif dari server (fitur terpisah).

## Aksi owner sebelum/sesudah merge
- [ ] Apply migrasi **0013** + **0014**
- [ ] Redeploy **agent-v2 / api-v2 / web-v2** atomik
- [ ] E2E streaming + HITL + resume lintas-refresh
- [ ] (opsional) Tinjau temuan **React Doctor** pada changeset (`react-doctor --staged --fail-on warning`)

## Gates
- web-v2 `tsc --noEmit` bersih; `eve-timeline.test.ts` 29 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
