### PR TITLE
fix(deploy): eve agent start command + onboarding completion bounce

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -15,7 +15,9 @@ ENV NODE_ENV=production
 ENV PORT=4317
 COPY --from=build /app /app
 EXPOSE 4317
-# ponytail: eve bin is hoisted to the root node_modules; run it under Node from the agent
-# project dir. `--port 4317` mirrors the dev script. `.workflow-data` (eve durable state)
-# MUST be a persistent volume in compose. Validate flags with `eve --help` on first build.
-CMD ["node", "/app/node_modules/.bin/eve", "start", "--port", "4317"]
+# eve is a dep of @aqsha/agent only, so bun keeps it workspace-local (NOT hoisted to root).
+# Run its entry directly under Node. `--host 0.0.0.0` is REQUIRED for non-Vercel container
+# deploys (eve deployment docs §8) — without it eve binds loopback and the web container's
+# `http://agent:4317/eve/v1/*` proxy hits connection-refused. `.workflow-data` (eve durable
+# state) MUST be a persistent volume in compose.
+CMD ["node", "/app/apps/agent/node_modules/eve/bin/eve.js", "start", "--host", "0.0.0.0", "--port", "4317"]

--- a/apps/web/features/onboarding/lib/use-onboarding-flow.ts
+++ b/apps/web/features/onboarding/lib/use-onboarding-flow.ts
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { readableApiErrorMessage } from "@/lib/api-error";
 import { useApi } from "@/lib/api-client";
-import { unwrap } from "@/lib/api-query";
+import { queryKeys, unwrap } from "@/lib/api-query";
 import { MIN_INTERESTS, SOURCE_OTHER } from "./onboarding-options";
 
 const ONBOARDING_STEPS = ["welcome", "background", "interests", "source", "finish"] as const;
@@ -21,6 +21,7 @@ export type OnboardingAnswers = {
 
 export function useOnboardingFlow() {
   const api = useApi();
+  const queryClient = useQueryClient();
   const [step, setStep] = useState<OnboardingStep>("welcome");
   const [answers, setAnswers] = useState<OnboardingAnswers>({
     background: null,
@@ -40,6 +41,12 @@ export function useOnboardingFlow() {
             answers.source === SOURCE_OTHER.id ? answers.sourceOther.trim() : undefined,
         }),
       ),
+    // Tandai cache status=completed segera (sinkron, tanpa window refetch). Tanpa ini
+    // OnboardingGate masih baca `{completed:false}` lama → `router.replace("/app/explore")`
+    // dari step finish dipantul balik ke /onboarding → wizard remount ke step 1.
+    onSuccess: () => {
+      queryClient.setQueryData(queryKeys.onboarding.status(), { completed: true });
+    },
   });
 
   const setBackground = (id: string) => setAnswers((a) => ({ ...a, background: id }));

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,14 +1,6 @@
 import type { NextConfig } from "next";
 import path from "node:path";
 
-// Agent Astra (eve) = app TERPISAH `@aqsha/agent` (`eve dev`/`eve start`). web = pure
-// consumer: proxy same-origin `/eve/v1/*` → origin agent supaya `useEveAgent` tetap
-// same-origin (TANPA CORS; eve tak punya CORS bawaan) dan bearer Clerk diteruskan apa adanya.
-//
-// Proxy `/eve/v1/*` ADA DI Route Handler streaming (`app/eve/v1/[...path]/route.ts`), BUKAN
-// `rewrites()`: rewrites menahan stream long-lived (turn in-flight) → progres beku, boundary
-// `session.waiting` tak sampai (token resume hilang → HITL tak bisa dijawab), resume nav-balik macet.
-
 const nextConfig: NextConfig = {
   output: "standalone",
   outputFileTracingRoot: path.resolve(__dirname, "../.."),


### PR DESCRIPTION
## Ringkas
Dua fix produksi yang ditemukan saat deploy via Dokploy.

## Perubahan
- **`apps/agent/Dockerfile`** — `eve` adalah dep `@aqsha/agent` saja, jadi bun menaruhnya workspace-local (BUKAN di-hoist ke root). CMD diarahkan ke `apps/agent/node_modules/eve/bin/eve.js` dan ditambah `--host 0.0.0.0` (wajib untuk deploy container non-Vercel per eve deployment docs §8). Tanpa `--host 0.0.0.0`, eve bind ke loopback → proxy web `http://agent:4317/eve/v1/*` kena connection-refused.
- **`apps/web/.../use-onboarding-flow.ts`** — `setQueryData(onboarding.status, {completed:true})` saat onboarding sukses, supaya `OnboardingGate` tak memantul `/app/explore` balik ke `/onboarding` (yang me-remount wizard ke step 1).
- **`apps/web/next.config.ts`** — hapus komentar usang soal proxy eve (proxy hidup di Route Handler streaming, bukan `rewrites()`).

## Catatan deploy
`.workflow-data` (durable state eve) HARUS persistent volume di compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)