### PR TITLE
feat(agent,web): /deep durable — rencana structuredOutput + audit Bagian 2 (A1-A3, B1-B5) + palette mobile

### DIFF
--- a/apps/agent/scripts/smoke-deep-task.ts
+++ b/apps/agent/scripts/smoke-deep-task.ts
@@ -3,12 +3,23 @@
  * (1) dispatch task baru → executor jalan → hasil terpersist; (2) pemanggilan ULANG dengan
  * `toolCallId` sama me-REUSE hasil dari storage (cepat, tanpa model call kedua) — properti yang
  * membuat `run.restart()` (DUR-5) tidak re-debit search.
+ * (3) B5: attempt ber-suffix `:r<N>:<ts>` yang completed ikut ter-reuse oleh lookup ber-base
+ * (dulu tak terlihat → sub-Q diriset + didebit ulang saat restart).
+ * (4) B4: abortSignal yang sudah aborted → throw SEBELUM dispatch (tanpa task baru).
  *
  *   bun run scripts/smoke-deep-task.ts
  */
+import { createBackgroundTask } from "@mastra/core/background-tasks";
 import { mastra } from "../src/mastra";
 import { AQSHA_AGENT_KIND_KEY } from "../src/mastra/lib/tool-context";
-import { runDeepSubagentTask } from "../src/mastra/workflows/deep-tasks";
+import { DEEP_TASK_TOOL_NAME, runDeepSubagentTask } from "../src/mastra/workflows/deep-tasks";
+
+const KATA_ARGS = (kata: string) => ({
+  agentId: "deep-writer" as const,
+  prompt: `Balas persis satu kata: ${kata}`,
+  requestContext: [[AQSHA_AGENT_KIND_KEY, "lite"]] as [string, unknown][],
+  toolChoice: "none" as const,
+});
 
 async function main() {
   // Paritas server production: deployer memanggil `startWorkers()` saat boot — tanpa ini event
@@ -16,6 +27,8 @@ async function main() {
   await mastra.startWorkers();
   const manager = mastra.backgroundTaskManager;
   if (!manager) throw new Error("backgroundTaskManager tidak aktif — cek konfigurasi Mastra");
+
+  // ── Skenario 1: dispatch baru + reuse by toolCallId base ─────────────────────────────────
   const runId = `smoke-deep-task-${Date.now()}`;
   const base = {
     mastra,
@@ -23,12 +36,7 @@ async function main() {
     threadId: `smoke-thread-${Date.now()}`,
     timeoutMs: 120_000,
     toolCallId: `${runId}:synthesize`,
-    args: {
-      agentId: "deep-writer" as const,
-      prompt: "Balas persis satu kata: siap",
-      requestContext: [[AQSHA_AGENT_KIND_KEY, "lite"]] as [string, unknown][],
-      toolChoice: "none" as const,
-    },
+    args: KATA_ARGS("siap"),
   };
 
   const t0 = Date.now();
@@ -47,12 +55,80 @@ async function main() {
     JSON.stringify(tasks.map((t) => ({ status: t.status, toolCallId: t.toolCallId }))),
   );
 
-  const ok =
+  const ok1 =
     first.text.trim().length > 0 &&
     second.text === first.text &&
     secondMs < Math.max(2000, firstMs / 4) &&
     tasks.length === 1 &&
     tasks[0]?.status === "completed";
+  console.log(ok1 ? "[smoke] skenario 1 PASS" : "[smoke] skenario 1 FAIL");
+
+  // ── Skenario 2 (B5): attempt ber-suffix completed ter-reuse oleh lookup base ─────────────
+  // Seed: task SUFFIX `:r1:<ts>` (persis format attempt retry) dijalankan sampai completed,
+  // lalu panggil runDeepSubagentTask dgn toolCallId BASE → wajib reuse (tanpa dispatch baru).
+  const runId2 = `smoke-deep-b5-${Date.now()}`;
+  const base2 = `${runId2}:synthesize`;
+  const seedHandle = createBackgroundTask(manager, {
+    runId: runId2,
+    toolName: DEEP_TASK_TOOL_NAME,
+    toolCallId: `${base2}:r1:${Date.now()}`,
+    args: KATA_ARGS("pulih") as unknown as Record<string, unknown>,
+    agentId: "deep-writer",
+    threadId: `smoke-thread-b5-${Date.now()}`,
+    timeoutMs: 120_000,
+    context: {
+      executor: { execute: () => Promise.resolve({ text: "pulih" }) },
+    },
+  });
+  await seedHandle.dispatch();
+  const seeded = await seedHandle.waitForCompletion({ timeoutMs: 30_000 });
+  const t2 = Date.now();
+  const reused = await runDeepSubagentTask({
+    mastra,
+    runId: runId2,
+    threadId: `smoke-thread-b5-${Date.now()}`,
+    timeoutMs: 120_000,
+    toolCallId: base2,
+    args: KATA_ARGS("pulih"),
+  });
+  const reusedMs = Date.now() - t2;
+  const { tasks: tasks2 } = await manager.listTasks({ runId: runId2 });
+  console.log(
+    "[smoke] b5 reuse:",
+    JSON.stringify(reused.text.slice(0, 60)),
+    `${reusedMs}ms`,
+    JSON.stringify(tasks2.map((t) => ({ status: t.status, toolCallId: t.toolCallId }))),
+  );
+  const ok2 =
+    seeded.status === "completed" &&
+    reused.text === "pulih" &&
+    reusedMs < 2000 &&
+    tasks2.length === 1; // TIDAK lahir task base baru — inti fix B5
+  console.log(ok2 ? "[smoke] skenario 2 (B5) PASS" : "[smoke] skenario 2 (B5) FAIL");
+
+  // ── Skenario 3 (B4): abortSignal sudah aborted → throw sebelum dispatch ──────────────────
+  const runId3 = `smoke-deep-b4-${Date.now()}`;
+  const aborted = new AbortController();
+  aborted.abort();
+  let threw = false;
+  try {
+    await runDeepSubagentTask({
+      mastra,
+      runId: runId3,
+      threadId: `smoke-thread-b4-${Date.now()}`,
+      timeoutMs: 120_000,
+      toolCallId: `${runId3}:synthesize`,
+      args: KATA_ARGS("batal"),
+      abortSignal: aborted.signal,
+    });
+  } catch {
+    threw = true;
+  }
+  const { tasks: tasks3 } = await manager.listTasks({ runId: runId3 });
+  const ok3 = threw && tasks3.length === 0; // tak ada task lahir untuk run yang dibatalkan
+  console.log(ok3 ? "[smoke] skenario 3 (B4) PASS" : "[smoke] skenario 3 (B4) FAIL");
+
+  const ok = ok1 && ok2 && ok3;
   console.log(ok ? "[smoke] PASS" : "[smoke] FAIL");
   process.exit(ok ? 0 : 1);
 }

--- a/apps/agent/scripts/smoke-structured-plan.ts
+++ b/apps/agent/scripts/smoke-structured-plan.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke `structuredOutput` jalur rencana `/deep` (audit 2026-07-03): panggil `deepWriter.generate`
+ * persis seperti step `draft-plan` (toolChoice none + PlanOutputSchema strict) lalu pastikan
+ * `out.object` valid — plan prosa non-kosong, 3-6 sub-pertanyaan, domain enum. Jalankan dari
+ * `apps/agent` (Bun auto-load `.env`): `bun run scripts/smoke-structured-plan.ts`.
+ */
+import { RequestContext } from "@mastra/core/request-context";
+import { z } from "zod";
+import { deepWriter } from "../src/mastra/agents/deep-writer";
+import { AQSHA_AGENT_KIND_KEY } from "../src/mastra/lib/tool-context";
+
+const PlanOutputSchema = z.object({
+  plan: z.string().describe("Rencana riset lengkap sebagai prosa mengalir (bukan daftar bernomor, bukan form)."),
+  subQuestions: z.array(z.string()).describe("3-6 sub-pertanyaan riset spesifik yang diturunkan dari rencana."),
+  domain: z
+    .enum(["medicine", "cs-ml", "education", "general"])
+    .describe("Domain-pack metodologi paling cocok dengan topik."),
+});
+
+const prompt =
+  "Pertanyaan riset:\nBagaimana dampak penggunaan media sosial terhadap kualitas tidur remaja Indonesia?\n\n" +
+  "Susun rencana riset mendalam sebagai PROSA mengalir (bukan daftar bernomor, bukan form): jelaskan apa yang akan " +
+  "diselidiki, sub-arah utama yang ditelusuri terpisah, jenis sumber yang dicari, dan cara verifikasi. " +
+  "Lalu turunkan 3-6 sub-pertanyaan riset spesifik dari rencana itu.";
+
+const out = await deepWriter.generate(prompt, {
+  requestContext: new RequestContext([[AQSHA_AGENT_KIND_KEY, "lite"]]),
+  toolChoice: "none",
+  structuredOutput: { schema: PlanOutputSchema, errorStrategy: "strict" },
+});
+
+const obj = out.object;
+const ok =
+  obj &&
+  typeof obj.plan === "string" &&
+  obj.plan.trim().length > 100 &&
+  Array.isArray(obj.subQuestions) &&
+  obj.subQuestions.length >= 3 &&
+  obj.subQuestions.length <= 6 &&
+  ["medicine", "cs-ml", "education", "general"].includes(obj.domain);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: Boolean(ok),
+      planHead: obj?.plan?.slice(0, 140),
+      planHasFence: obj?.plan?.includes("```") ?? null,
+      planHasNameJunk: obj?.plan?.includes('{"name"') ?? null,
+      subQuestionCount: obj?.subQuestions?.length ?? 0,
+      domain: obj?.domain ?? null,
+    },
+    null,
+    2,
+  ),
+);
+process.exit(ok ? 0 : 1);

--- a/apps/agent/src/mastra/agents/deep-writer.ts
+++ b/apps/agent/src/mastra/agents/deep-writer.ts
@@ -1,6 +1,5 @@
 import { Agent } from "@mastra/core/agent";
 import { modelForRequestContext } from "../model";
-import { inlineSkills } from "../skills";
 import { deepWriterTools } from "../tools";
 
 /**
@@ -50,5 +49,8 @@ export const deepWriter = new Agent({
   // bila deep-writer dipakai di jalur ber-tool di masa depan.
   defaultOptions: { maxSteps: 12 },
   tools: deepWriterTools,
-  skills: inlineSkills,
+  // TANPA `skills` (audit 2026-07-03): semua pemanggilan `toolChoice:"none"` → tool skill tak
+  // pernah bisa jalan, tapi keberadaannya memancing model MENULIS `{"name": "..."}` sebagai teks
+  // di awal output (junk yang merusak rencana di prod). Panduan metodologi di-inline via
+  // `synthesisGuidance` (CFG-2), bukan lewat skill tool.
 });

--- a/apps/agent/src/mastra/index.ts
+++ b/apps/agent/src/mastra/index.ts
@@ -1,6 +1,7 @@
 import { assertEmbeddingEnabled } from "@aqsha/services/rag";
 import { Mastra } from "@mastra/core/mastra";
 import { MASTRA_THREAD_ID_KEY } from "@mastra/core/request-context";
+import type { Middleware } from "@mastra/core/server";
 import { MastraStorageExporter, Observability } from "@mastra/observability";
 import { astraLite, astraPro } from "./agents/astra-lite";
 import { createClerkAuth } from "./auth";
@@ -18,6 +19,15 @@ import { registerDeepTaskExecutors } from "./workflows/deep-tasks";
 // Fail-fast (D1): tool `search_thread_documents` butuh embedding aktif. Konsisten dengan throw
 // `DATABASE_URL` di `./storage` — kredensial wajib digagalkan saat boot, bukan degradasi senyap.
 assertEmbeddingEnabled();
+
+// Sweep A1 hanya boleh jalan SEKALI per proses — flag di-set sinkron sebelum panggilan async
+// supaya request paralel pertama tak memicu sweep ganda. Impl `sweepFrozenDeepRunsOnce` di bawah
+// instance `mastra` (butuh instance-nya); deklarasi function di-hoist, aman dirujuk dari sini.
+let deepBootSweepStarted = false;
+const bootSweepMiddleware: Middleware = async (_c, next) => {
+  sweepFrozenDeepRunsOnce();
+  await next();
+};
 
 /**
  * Instance Mastra runtime Astra (Fase 0 spike).
@@ -83,9 +93,35 @@ export const mastra = new Mastra({
     host: process.env.HOST ?? "0.0.0.0",
     auth: createClerkAuth(),
     // userContextMiddleware: ekstrak email Clerk → RequestContext (gate admin billing).
-    middleware: [userContextMiddleware],
+    // bootSweepMiddleware: sweep A1 run beku, terpicu request pertama (lihat komentar di bawah).
+    middleware: [userContextMiddleware, bootSweepMiddleware],
   },
 });
+
+/**
+ * A1 (audit 2026-07-03): sweep run `deep-research` yang beku karena proses mati (deploy Dokploy =
+ * restart container; Mastra 1.47 tak me-resume run `running` sendiri). Hanya menyapu
+ * `running`+`waiting` (bukan `suspended` — run parkir di gerbang HITL sehat, di-resume user);
+ * step yang re-run me-reuse task selesai by `toolCallId` (DUR-7) → tanpa re-debit. Fire-and-forget:
+ * kegagalan sweep (mis. storage belum siap) tak boleh mematikan server; error per-run ditangkap
+ * internal. Scoped per-workflow (bukan facade `mastra.*`) supaya workflow internal Mastra
+ * (`__mastra_notification_dispatcher`) tak ikut tersapu.
+ *
+ * Dipicu REQUEST HTTP PERTAMA (middleware), BUKAN import module: modul ini juga di-import smoke
+ * scripts / build / test yang menunjuk DB sama — sweep dari proses sekali-jalan me-restart run
+ * milik user lalu mati di tengah (membekukan ulang, bisa dobel-dispatch task). Hanya proses yang
+ * benar-benar melayani HTTP yang boleh men-sweep; saat request pertama tiba, `startWorkers()`
+ * deployer juga sudah jalan (urutan boot), jadi task hasil restart tak menganggur di antrean.
+ * Run beku selalu tersentuh: FE poll re-attach memukul server begitu ada user membuka thread-nya.
+ */
+function sweepFrozenDeepRunsOnce(): void {
+  if (deepBootSweepStarted) return;
+  deepBootSweepStarted = true;
+  void mastra
+    .getWorkflow("deep-research")
+    .restartAllActiveWorkflowRuns()
+    .catch((err) => console.error("[deep-research] boot sweep restart gagal", err));
+}
 
 // Executor static task `/deep` WAJIB di-register saat boot: task `running`/`pending` yang dipulihkan
 // `recoverStaleTasks` (proses sebelumnya mati) hanya bisa dieksekusi ulang lewat registry ini —

--- a/apps/agent/src/mastra/workflows/deep-research.ts
+++ b/apps/agent/src/mastra/workflows/deep-research.ts
@@ -48,7 +48,7 @@ import { effectiveBilledTier, liteProviderOptions, proProviderOptions } from "..
  *
  *   draftClarify (kuota + nilai klarifikasi) → clarify (HITL ask_questions, opsional) → draftPlan
  *   → approvePlan (HITL suspend/resume + gerbang billing) → searchLiterature → counterEvidence
- *   → verifyCitations → synthesize
+ *   → verifyCitations → synthesize → persistReport
  *
  * Keputusan desain (deviasi sah dari §7 plan, dicatat):
  * - **Fan-out di dalam `searchStep`** (Promise.all per sub-pertanyaan) alih-alih builder
@@ -147,6 +147,27 @@ const CitedSchema = CounteredSchema.extend({
     .describe("Referensi terstruktur per [n] unik → verify-citations panggil CitationService langsung (IMP-5)."),
 });
 const VerifiedSchema = CitedSchema.extend({ verification: z.string() });
+/**
+ * Hasil sintesis → step `persist-report` (failure domain persist terpisah, B2). SUBSET yang
+ * dikonsumsi persist-report + FE saja — korpus bukti (evidence/verifyRefs/question/context) sudah
+ * tersimpan di output step-step sebelumnya; mengangkutnya lagi hanya menggemukkan snapshot dan
+ * chunk `workflow-step-result` yang dikirim ke browser tepat saat user menunggu laporan.
+ */
+const SynthesizedSchema = VerifiedSchema.pick({
+  threadId: true,
+  agentKind: true,
+  plan: true,
+  subQuestions: true,
+  counter: true,
+  verification: true,
+  numberedInventory: true,
+  numberedSources: true,
+}).extend({
+  report: z.string().min(1).describe("Laporan tercitasi hasil penulis sintesis."),
+  reasoning: z
+    .string()
+    .describe("Ringkasan penalaran penulis (kosong bila provider tak mengembalikan)."),
+});
 
 const OutputSchema = z.object({
   status: z.enum(["completed", "cancelled", "blocked"]),
@@ -407,7 +428,14 @@ async function ensureDeepThread(
  * Persist laporan akhir (assistant) ke memory thread chat (`mastra_messages`) lewat agent `astra-lite`.
  * Disimpan VERBATIM (fidelitas sitasi `[n]`) + `metadata.deepRunId = runId` agar FE memetakan Sumber
  * per-turn (G4). Pertanyaan user sudah dipersist di `ensureDeepThread` (plan-gate) → JANGAN ulang di sini
- * (anti bubble kembar). Preview thread diperbarui ke laporan. Best-effort.
+ * (anti bubble kembar). Preview thread diperbarui ke laporan.
+ *
+ * THROW saat persist gagal (audit B2): laporan yang tak tersimpan = produk berbayar LENYAP saat
+ * refresh (history dibaca dari `mastra_messages`) — bukan side-effect opsional yang boleh ditelan.
+ * Pemanggil = step `persist-report` ber-`retries`; id pesan deterministik `deep-report:<runId>`
+ * membuat retry/time-travel meng-upsert baris yang SAMA (tak pernah bubble laporan kembar). Guard
+ * `!mastra`/`!memory` tetap return diam — absennya memory = constraint environment (unit test),
+ * bukan kegagalan persist.
  */
 async function persistDeepReport(
   mastra: Mastra | undefined,
@@ -424,43 +452,117 @@ async function persistDeepReport(
   },
 ): Promise<void> {
   if (!mastra) return;
+  const agent = mastra.getAgent("astra-lite");
+  const memory = await agent.getMemory({ requestContext });
+  if (!memory) return;
+  const resourceId = ownerFromRequestContext(requestContext).id ?? undefined;
+  if (resourceId) {
+    try {
+      await ThreadService.ensureProjected(getServiceDb(), {
+        threadId: args.threadId,
+        ownerUserId: resourceId,
+        agentKind: args.agentKind,
+        preview: messagePreview(args.report),
+      });
+    } catch (err) {
+      // Proyeksi `chat_threads` = kosmetik sidebar/preview (best-effort, paritas `ensureDeepThread`)
+      // — BUKAN bagian dari "laporan tersimpan". Gagal deterministik di sini (mis. constraint) tak
+      // boleh mengunci run di loop retry/time-travel padahal `saveMessages` sendiri akan sukses.
+      console.error("[deep-research] thread projection failed", err);
+    }
+    // Idempoten: thread memory biasanya sudah dibuat di `ensureDeepThread` (plan-gate); jaga-jaga.
+    // TETAP throw — `saveMessages` butuh baris `mastra_threads` (kegagalan nyata domain persist).
+    await ensureMemoryThread(memory, { threadId: args.threadId, resourceId, title: args.report });
+  }
+  await memory.saveMessages({
+    messages: [
+      buildMastraMessage({
+        role: "assistant",
+        text: args.report,
+        threadId: args.threadId,
+        resourceId,
+        // Id deterministik per run (paritas `deep-user:<runId>`) → upsert idempoten lintas retry.
+        id: `deep-report:${args.runId}`,
+        ...(args.reasoning ? { reasoning: args.reasoning } : {}),
+        metadata: {
+          deepRunId: args.runId,
+          ...(args.deepProcess ? { deepProcess: args.deepProcess } : {}),
+        },
+      }),
+    ],
+  });
+}
+
+/**
+ * B3(b): persist alasan bail `blocked` sebagai pesan assistant — id deterministik
+ * `deep-bail:<runId>` (paritas `deep-report:<runId>`) → upsert idempoten, tak mungkin kembar.
+ * Tanpa ini alasan hanya hidup di kartu notice sesi FE; refresh membaca history dari
+ * `mastra_messages` dan kehilangan konteks kenapa run berhenti. BEST-EFFORT keseluruhan (beda
+ * dgn `persistDeepReport` yang throw): bail = jalur keluar run, kegagalan persist tak boleh
+ * mengubah hasil bail.
+ */
+async function persistDeepNotice(
+  mastra: Mastra | undefined,
+  requestContext: RequestContext,
+  args: { threadId: string; runId: string; reason: string },
+): Promise<void> {
+  if (!mastra) return;
   try {
     const agent = mastra.getAgent("astra-lite");
     const memory = await agent.getMemory({ requestContext });
     if (!memory) return;
     const resourceId = ownerFromRequestContext(requestContext).id ?? undefined;
-    if (resourceId) {
-      try {
-        await ThreadService.ensureProjected(getServiceDb(), {
-          threadId: args.threadId,
-          ownerUserId: resourceId,
-          agentKind: args.agentKind,
-          preview: messagePreview(args.report),
-        });
-        // Idempoten: thread memory biasanya sudah dibuat di `ensureDeepThread` (plan-gate); jaga-jaga.
-        await ensureMemoryThread(memory, { threadId: args.threadId, resourceId, title: args.report });
-      } catch (err) {
-        console.error("[deep-research] thread projection failed", err);
-      }
-    }
+    if (!resourceId) return;
+    // Idempoten — biasanya sudah dibuat `ensureDeepThread` barusan; jaga-jaga bila itu gagal parsial.
+    await ensureMemoryThread(memory, { threadId: args.threadId, resourceId, title: args.reason });
     await memory.saveMessages({
       messages: [
         buildMastraMessage({
           role: "assistant",
-          text: args.report,
+          text: `Riset mendalam dihentikan: ${args.reason}`,
           threadId: args.threadId,
           resourceId,
-          ...(args.reasoning ? { reasoning: args.reasoning } : {}),
-          metadata: {
-            deepRunId: args.runId,
-            ...(args.deepProcess ? { deepProcess: args.deepProcess } : {}),
-          },
+          id: `deep-bail:${args.runId}`,
+          metadata: { deepRunId: args.runId },
         }),
       ],
     });
   } catch (err) {
-    console.error("[deep-research] persistReport failed", err);
+    console.error("[deep-research] persistDeepNotice failed", err);
   }
+}
+
+/**
+ * B3(b): efek durable SEBELUM bail `blocked` (kuota/akses) — satu helper untuk ketiga site.
+ * (1) `ensureDeepThread` (idempoten `deep-user:<runId>`) — site draft-clarify bisa bail sebelum
+ * gerbang HITL mana pun memproyeksikan thread → tanpa ini refresh = thread kosong; (2)
+ * `persistDeepNotice` — alasannya ikut tersimpan. Site `cancelled` (user menolak rencana)
+ * SENGAJA tidak lewat sini: settle senyap adalah keputusan user.
+ */
+async function persistBlockedBail(
+  mastra: Mastra | undefined,
+  requestContext: RequestContext,
+  args: {
+    threadId: string;
+    question: string;
+    displayQuestion?: string;
+    agentKind: AgentKind;
+    runId: string;
+    reason: string;
+  },
+): Promise<void> {
+  await ensureDeepThread(mastra, requestContext, {
+    threadId: args.threadId,
+    question: args.question,
+    displayQuestion: args.displayQuestion,
+    agentKind: args.agentKind,
+    runId: args.runId,
+  });
+  await persistDeepNotice(mastra, requestContext, {
+    threadId: args.threadId,
+    runId: args.runId,
+    reason: args.reason,
+  });
 }
 
 /** Jumlah sitasi unik `[n]` di inventory bernomor (baris bisa berbagi nomor karena dedupe). */
@@ -662,7 +764,7 @@ const draftClarifyStep = createStep({
   id: "draft-clarify",
   inputSchema: InputSchema,
   outputSchema: ClarifiedSchema,
-  execute: async ({ inputData, requestContext, bail, runId }) => {
+  execute: async ({ inputData, requestContext, bail, runId, mastra }) => {
     const { id: ownerUserId, email: ownerEmail } = ownerFromRequestContext(requestContext);
     if (ownerUserId) {
       const quota = await SendQuotaService.check(getServiceDb(), {
@@ -671,10 +773,11 @@ const draftClarifyStep = createStep({
         feature: "deep_research",
       });
       if (!quota.ok) {
-        return bail({
-          status: "blocked" as const,
-          reason: `Kuota deep research tidak tersedia (${quota.reason}).`,
-        });
+        // B3: bail PALING DINI — belum ada gerbang HITL yang memproyeksikan thread, jadi efek
+        // durable (bubble user + alasan) wajib dari sini.
+        const reason = `Kuota deep research tidak tersedia (${quota.reason}).`;
+        await persistBlockedBail(mastra, requestContext, { ...inputData, runId, reason });
+        return bail({ status: "blocked" as const, reason });
       }
     }
     let clarifyQuestions: AskQuestion[] = [];
@@ -804,7 +907,9 @@ const approvePlanStep = createStep({
         requiredPlan,
       });
       if (!gate.ok) {
-        return bail({ status: "blocked" as const, reason: `Akses deep research ditolak (${gate.reason}).` });
+        const reason = `Akses deep research ditolak (${gate.reason}).`;
+        await persistBlockedBail(mastra, requestContext, { ...inputData, runId, reason });
+        return bail({ status: "blocked" as const, reason });
       }
       const debit = await BillingService.consumeCredits(db, {
         ownerUserId,
@@ -817,7 +922,9 @@ const approvePlanStep = createStep({
         idempotencyKey: `${runId}:deep`,
       });
       if (!debit.ok) {
-        return bail({ status: "blocked" as const, reason: `Kuota deep research habis (${debit.reason}).` });
+        const reason = `Kuota deep research habis (${debit.reason}).`;
+        await persistBlockedBail(mastra, requestContext, { ...inputData, runId, reason });
+        return bail({ status: "blocked" as const, reason });
       }
     }
     if (!resumeData.edits) return inputData;
@@ -859,7 +966,7 @@ const searchStep = createStep({
   // TANPA `retries`: re-run step = re-debit `external_search` per tool-call baru. Isolasi
   // per-sub-Q di bawah sudah membuat step ini tak melempar. (Pasca-DUR-7 restart step justru
   // AMAN: task selesai di-reuse by `toolCallId`, tak menjalankan ulang subagent.)
-  execute: async ({ inputData, mastra, requestContext, runId, writer }) => {
+  execute: async ({ inputData, mastra, requestContext, runId, writer, abortSignal }) => {
     // Tanam thread+run di rc induk dulu → entries() yang DI-CLONE per sub-Q sudah membawanya.
     withDeepRun(requestContext, inputData.threadId, runId, inputData.agentKind);
     const owner = ownerFromRequestContext(requestContext);
@@ -873,12 +980,14 @@ const searchStep = createStep({
         await emitDetail(writer, { kind: "search-sub", subIndex, subQuestion, status: "searching" });
         // DUR-7: subagent jalan sebagai background task persisten — `toolCallId` deterministik
         // per (run, sub-Q) → restart run me-reuse hasil task selesai (tanpa re-debit search).
+        // B4: `abortSignal` ikut — Stop user menutup task run ini, bukan membiarkannya jalan terus.
         const taskBase = {
           mastra,
           runId,
           threadId: inputData.threadId,
           ...(owner.id ? { resourceId: owner.id } : {}),
           timeoutMs: 600_000,
+          abortSignal,
         };
         let findings = "";
         try {
@@ -894,8 +1003,9 @@ const searchStep = createStep({
           findings = out.text.trim();
           // Guard turn-senyap subagent (CTX-7): selesai pas di tool-call → teks kosong. Retry SEKALI
           // dengan pengingat eksplisit; masih kosong → catat gap jujur (jangan biarkan bucket kosong
-          // mengalir senyap ke sintesis).
-          if (!findings) {
+          // mengalir senyap ke sintesis). B4: jangan dispatch empty-retry untuk run yang sedang
+          // dibatalkan (catch CFG-4 di bawah menelan abort-error attempt pertama).
+          if (!findings && !abortSignal.aborted) {
             const retry = await runDeepSubagentTask({
               ...taskBase,
               toolCallId: `${runId}:search:${subIndex}:empty-retry`,
@@ -936,7 +1046,7 @@ const counterEvidenceStep = createStep({
   inputSchema: SearchedSchema,
   outputSchema: CounteredSchema,
   retries: 1,
-  execute: async ({ inputData, mastra, requestContext, runId, writer }) => {
+  execute: async ({ inputData, mastra, requestContext, runId, writer, abortSignal }) => {
     // IMP-9: emit di AWAL step → body panel proses terisi jujur selama fase lambat berjalan
     // (ditimpa teks final di akhir step; paritas pola `search-sub` status "searching").
     await emitDetail(writer, {
@@ -952,6 +1062,7 @@ const counterEvidenceStep = createStep({
       threadId: inputData.threadId,
       ...(owner.id ? { resourceId: owner.id } : {}),
       timeoutMs: 600_000,
+      abortSignal,
       toolCallId: `${runId}:counter`,
       args: {
         agentId: "counter-evidence",
@@ -971,11 +1082,15 @@ const counterEvidenceStep = createStep({
 /**
  * 5. assignCitations — nomori `research_sources` run ini (turnId=runId) → `citation_number` 1..N
  * (dedupe by DOI/arXiv/locator) lalu susun inventory bernomor GLOBAL untuk verify + synthesis (G4).
+ * `retries: 1` (audit B1): step pasca-billing murni DB dan idempoten (`assignCitationNumbers`
+ * menghitung ulang penomoran deterministik lalu overwrite) — blip DB satu kali tak boleh
+ * mematikan run yang kreditnya sudah didebit.
  */
 const assignCitationsStep = createStep({
   id: "assign-citations",
   inputSchema: CounteredSchema,
   outputSchema: CitedSchema,
+  retries: 1,
   execute: async ({ inputData, runId, writer }) => {
     const items = await ResearchService.assignCitationNumbers(getServiceDb(), {
       threadId: inputData.threadId,
@@ -1085,13 +1200,13 @@ const citationVerifyStep = createStep({
   },
 });
 
-/** 7. synthesize — penulis akhir (deepWriter, "root") merangkai jawaban tercitasi + persist. */
+/** 7. synthesize — penulis akhir (deepWriter, "root") merangkai jawaban tercitasi. */
 const synthesizeStep = createStep({
   id: "synthesize",
   inputSchema: VerifiedSchema,
-  outputSchema: OutputSchema,
+  outputSchema: SynthesizedSchema,
   retries: 1,
-  execute: async ({ inputData, requestContext, mastra, runId, writer }) => {
+  execute: async ({ inputData, requestContext, mastra, runId, writer, abortSignal }) => {
     // `toolChoice: "none"`: seluruh bukti sudah ada di prompt; paksa penulis MENULIS teks
     // (bukan berhenti di tool-call kosong) — jaminan `out.text` terisi pada model gateway.
     // DUR-7: background task persisten — restart run me-reuse laporan task selesai.
@@ -1103,6 +1218,7 @@ const synthesizeStep = createStep({
       threadId: inputData.threadId,
       ...(owner.id ? { resourceId: owner.id } : {}),
       timeoutMs: 900_000,
+      abortSignal,
       toolCallId: `${runId}:synthesize`,
       args: {
         agentId: "deep-writer",
@@ -1116,14 +1232,60 @@ const synthesizeStep = createStep({
     // token-level (aman thd durable refresh) → emit live + dipersist di pesan untuk rehydrate.
     const reasoning = (out.reasoningText ?? "").trim();
     if (reasoning) await emitDetail(writer, { kind: "reasoning", text: reasoning });
-    // Persist verbatim ke memory thread chat → muncul di history + rehydrate saat refresh (G1/G2).
-    // (Pertanyaan user sudah dipersist di `ensureDeepThread` pada plan-gate.) `deepProcess` =
-    // jejak proses agar FE bangun ulang langkah + detail tanpa runId (riwayat/refresh, G7). Teks
-    // counter/verify dipersist PENUH (tanpa clamp) → panel detail menampilkan narasi utuh.
+    // Laporan kosong (blip gateway / turn senyap penulis) HARUS gagal DI step ini: lolos ke
+    // `persist-report` = gagal di validasi input `min(1)` di sana, dan time-travel ke persist
+    // selalu me-replay laporan kosong yang sama dari snapshot — buntu. Gagal di sini →
+    // retry/time-travel synthesize menulis ulang; deep-tasks TIDAK me-reuse completed kosong
+    // (completedWithText) → retry itu benar-benar men-dispatch attempt penulis baru, bukan
+    // memutar hasil kosong yang sama selamanya.
+    const report = (out.text ?? "").trim();
+    if (!report) throw new Error("deep-research: penulis sintesis mengembalikan teks kosong");
+    // Persist ke memory = step `persist-report` TERPISAH (B2) — kegagalan simpan tak lagi menelan
+    // laporan senyap, dan retry/time-travel persist tak menyentuh jalur LLM/task sama sekali.
+    return {
+      threadId: inputData.threadId,
+      agentKind: inputData.agentKind,
+      plan: inputData.plan,
+      subQuestions: inputData.subQuestions,
+      counter: inputData.counter,
+      verification: inputData.verification,
+      numberedInventory: inputData.numberedInventory,
+      numberedSources: inputData.numberedSources,
+      report,
+      reasoning,
+    };
+  },
+});
+
+/**
+ * 8. persistReport — simpan laporan ke memory thread sebagai step tersendiri (audit B2). Failure
+ * domain terpisah dari `synthesize`: persist murni DB, idempoten (id pesan `deep-report:<runId>`),
+ * jadi boleh `retries: 2` + di-time-travel TANPA menyentuh jalur LLM/task. Dulu best-effort di
+ * dalam synthesize → gagal = run tetap `success` tapi laporan LENYAP saat refresh (history dibaca
+ * dari `mastra_messages`) padahal user bayar penuh. `deepProcess` = jejak proses agar FE bangun
+ * ulang langkah + detail tanpa runId (riwayat/refresh, G7); teks counter/verify dipersist PENUH
+ * (tanpa clamp) → panel detail menampilkan narasi utuh.
+ */
+const persistReportStep = createStep({
+  id: "persist-report",
+  inputSchema: SynthesizedSchema,
+  outputSchema: OutputSchema,
+  retries: 2,
+  execute: async ({ inputData, requestContext, mastra, runId }) => {
+    // TEMP-TEST E2E B1/B2 (HAPUS SETELAH UJI): HANYA saat env `AQSHA_E2E_FAIL_PERSIST=1` — gagal
+    // selama file flag ada (toggle mid-run tanpa restart proses); hapus flag lalu "Coba lagi"
+    // (time-travel) harus memulihkan tanpa debit baru. Tanpa env (prod) = nol I/O fs, dan file
+    // /tmp nyasar di host TIDAK bisa mematikan persist semua user.
+    if (process.env.AQSHA_E2E_FAIL_PERSIST === "1") {
+      const { existsSync } = await import("node:fs");
+      if (existsSync("/tmp/aqsha-fail-persist")) {
+        throw new Error("uji E2E: persist digagalkan via flag /tmp/aqsha-fail-persist");
+      }
+    }
     await persistDeepReport(mastra, requestContext, {
       threadId: inputData.threadId,
-      report: out.text,
-      reasoning,
+      report: inputData.report,
+      reasoning: inputData.reasoning,
       runId,
       agentKind: inputData.agentKind,
       deepProcess: {
@@ -1139,17 +1301,17 @@ const synthesizeStep = createStep({
     });
     return {
       status: "completed" as const,
-      report: out.text,
+      report: inputData.report,
       plan: inputData.plan,
       subQuestions: inputData.subQuestions,
-      ...(reasoning ? { reasoning } : {}),
+      ...(inputData.reasoning ? { reasoning: inputData.reasoning } : {}),
     };
   },
 });
 
 export const deepResearch = createWorkflow({
   id: "deep-research",
-  description: "Riset mendalam tercitasi: klarifikasi (HITL, opsional) → plan-gate (HITL) → cari literatur → bukti tandingan → verifikasi sitasi → sintesis.",
+  description: "Riset mendalam tercitasi: klarifikasi (HITL, opsional) → plan-gate (HITL) → cari literatur → bukti tandingan → verifikasi sitasi → sintesis → persist laporan.",
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
 })
@@ -1162,4 +1324,5 @@ export const deepResearch = createWorkflow({
   .then(assignCitationsStep)
   .then(citationVerifyStep)
   .then(synthesizeStep)
+  .then(persistReportStep)
   .commit();

--- a/apps/agent/src/mastra/workflows/deep-research.ts
+++ b/apps/agent/src/mastra/workflows/deep-research.ts
@@ -474,12 +474,64 @@ function parseCitationCount(numberedInventory: string): number {
 
 // ── Prompt builders ────────────────────────────────────────────────────────────────────
 
-/** Ekor kontrak JSON rencana — dipakai `planPrompt` DAN `replanPrompt` (satu sumber format). */
-const PLAN_JSON_CONTRACT = `AKHIRI responsmu dengan TEPAT SATU blok kode JSON valid (tanpa teks setelahnya) berbentuk:\n\`\`\`json\n{"plan": "<rencana prosa lengkap di sini>", "subQuestions": ["<sub-pertanyaan 1>", "<sub-pertanyaan 2>", "..."], "domain": "<medicine|cs-ml|education|general>"}\n\`\`\`\nField \`domain\` = domain-pack metodologi yang paling cocok dengan topik (kesehatan/biomedis → medicine; CS/ML → cs-ml; pendidikan/pembelajaran → education; selain itu → general).`;
+/**
+ * Skema WIRE rencana untuk `structuredOutput` native (audit prod 2026-07-03: parser fence manual
+ * gagal SENYAP — fence tak tertutup + junk `{"name":…}` → riset jalan dgn 1 sub-question fallback).
+ * Sengaja TANPA constraint numerik (`minItems`/`minLength`): dukungan keyword itu tak seragam pada
+ * gateway OpenAI-compatible mode strict; kardinalitas ditegakkan `ensurePlanOutput` di kode.
+ */
+const PlanOutputSchema = z.object({
+  plan: z
+    .string()
+    .describe("Rencana riset lengkap sebagai prosa mengalir (bukan daftar bernomor, bukan form)."),
+  subQuestions: z
+    .array(z.string())
+    .describe("3-6 sub-pertanyaan riset spesifik yang diturunkan dari rencana."),
+  domain: ResearchDomainSchema.describe(
+    "Domain-pack metodologi paling cocok dengan topik: kesehatan/biomedis → medicine; CS/ML → cs-ml; pendidikan/pembelajaran → education; selain itu → general.",
+  ),
+});
+
+/**
+ * Escape-hatch gateway tanpa `response_format` native: set `AQSHA_STRUCTURED_OUTPUT_INJECTION=1`
+ * → Mastra memaksa JSON lewat injeksi prompt sistem alih-alih response_format json_schema.
+ */
+const STRUCTURED_OUTPUT_INJECTION = process.env.AQSHA_STRUCTURED_OUTPUT_INJECTION === "1";
+
+/** Opsi `structuredOutput` baku langkah `/deep`: strict (gagal validasi = throw, TANPA degradasi senyap). */
+function structuredOutputOpts<T extends z.ZodType>(schema: T) {
+  return {
+    schema,
+    errorStrategy: "strict" as const,
+    ...(STRUCTURED_OUTPUT_INJECTION ? { jsonPromptInjection: true } : {}),
+  };
+}
+
+/**
+ * Gerbang kualitas hasil `PlanOutputSchema`: rapikan whitespace + tegakkan kardinalitas yang tak
+ * dibawa skema wire. Throw (bukan fallback) → ditangani `retries` step / try-catch pemanggil;
+ * JANGAN pernah menurunkan diam-diam ke 1 sub-question — itu bug prod yang memicu migrasi ini.
+ */
+function ensurePlanOutput(output: z.infer<typeof PlanOutputSchema> | undefined): {
+  plan: string;
+  subQuestions: string[];
+  domain: ResearchDomain;
+} {
+  const plan = output?.plan.trim() ?? "";
+  const subQuestions = (output?.subQuestions ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (!output || plan.length === 0 || subQuestions.length < 2) {
+    throw new Error(
+      `deep-research: rencana terstruktur tidak memadai (plan ${plan.length} char, ${subQuestions.length} sub-pertanyaan)`,
+    );
+  }
+  return { plan, subQuestions: subQuestions.slice(0, 8), domain: output.domain };
+}
 
 function planPrompt(input: z.infer<typeof InputSchema>): string {
   const ctx = input.context ? `\n\nKonteks tambahan dari pengguna:\n${input.context}` : "";
-  return `Pertanyaan riset:\n${input.question}${ctx}\n\nSusun rencana riset mendalam sebagai PROSA mengalir (bukan daftar bernomor, bukan form): jelaskan apa yang akan diselidiki, sub-arah utama yang ditelusuri terpisah, jenis sumber yang dicari, dan cara verifikasi. Lalu turunkan 3-6 sub-pertanyaan riset spesifik dari rencana itu.\n\n${PLAN_JSON_CONTRACT}`;
+  return `Pertanyaan riset:\n${input.question}${ctx}\n\nSusun rencana riset mendalam sebagai PROSA mengalir (bukan daftar bernomor, bukan form): jelaskan apa yang akan diselidiki, sub-arah utama yang ditelusuri terpisah, jenis sumber yang dicari, dan cara verifikasi. Lalu turunkan 3-6 sub-pertanyaan riset spesifik dari rencana itu.`;
 }
 
 /**
@@ -488,71 +540,38 @@ function planPrompt(input: z.infer<typeof InputSchema>): string {
  */
 function replanPrompt(input: Planned, edits: string): string {
   const subs = input.subQuestions.map((s, i) => `${i + 1}. ${s}`).join("\n");
-  return `Rencana riset untuk pertanyaan:\n${input.question}\n\nRencana saat ini:\n${input.plan}\n\nSub-pertanyaan saat ini:\n${subs}\n\nPengguna meminta penyesuaian berikut SEBELUM riset dijalankan:\n${edits}\n\nTulis ulang rencana sebagai PROSA mengalir yang menghormati penyesuaian itu, lalu turunkan ulang 3-6 sub-pertanyaan (buang/ubah/tambah sub-pertanyaan sesuai permintaan pengguna; pertahankan yang tidak disinggung).\n\n${PLAN_JSON_CONTRACT}`;
+  return `Rencana riset untuk pertanyaan:\n${input.question}\n\nRencana saat ini:\n${input.plan}\n\nSub-pertanyaan saat ini:\n${subs}\n\nPengguna meminta penyesuaian berikut SEBELUM riset dijalankan:\n${edits}\n\nTulis ulang rencana sebagai PROSA mengalir yang menghormati penyesuaian itu, lalu turunkan ulang 3-6 sub-pertanyaan (buang/ubah/tambah sub-pertanyaan sesuai permintaan pengguna; pertahankan yang tidak disinggung).`;
 }
 
 /**
- * Ekstrak `{plan, subQuestions}` dari output model. Andalkan blok \`\`\`json di akhir (model
- * gateway kerap membungkus JSON dalam markdown); fallback ke objek {...} pertama yang valid.
- * Lebih tahan-banting dari `structuredOutput` native pada model OpenAI-compatible (gateway).
+ * Skema WIRE klarifikasi pra-rencana untuk `structuredOutput`. Longgar by-design: hasil parse
+ * TETAP melewati `normalizeAskQuestions` (SSOT normalisasi id/opsi/freeform/lipat "Lainnya" yang
+ * sama dipakai reducer FE) — skema hanya menjamin bentuk, bukan semantik.
  */
-function parsePlan(
-  text: string,
-): { plan: string; subQuestions: string[]; domain: ResearchDomain } | null {
-  const fenced = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)].map((m) => m[1]);
-  for (const chunk of [...fenced.reverse(), text]) {
-    const start = chunk.indexOf("{");
-    const end = chunk.lastIndexOf("}");
-    if (start === -1 || end <= start) continue;
-    try {
-      const obj = JSON.parse(chunk.slice(start, end + 1));
-      if (obj && typeof obj.plan === "string" && Array.isArray(obj.subQuestions)) {
-        const subQuestions = obj.subQuestions.filter(
-          (s: unknown): s is string => typeof s === "string" && s.trim().length > 0,
-        );
-        const domainParsed = ResearchDomainSchema.safeParse(obj.domain);
-        return {
-          plan: obj.plan,
-          subQuestions,
-          domain: domainParsed.success ? domainParsed.data : "general",
-        };
-      }
-    } catch {
-      // coba kandidat berikutnya
-    }
-  }
-  return null;
-}
+const ClarifyOutputSchema = z.object({
+  questions: z
+    .array(
+      z.object({
+        id: z.string().describe("Id singkat pertanyaan, mis. `scope`."),
+        prompt: z.string().describe("Teks pertanyaan klarifikasi."),
+        kind: z.enum(["single", "multi"]).describe("`single` pilih satu; `multi` pilih beberapa."),
+        options: z
+          .array(z.object({ label: z.string() }))
+          .describe("2-4 opsi jawaban ringkas."),
+        allowOther: z.boolean().describe("true bila jawaban bebas relevan."),
+      }),
+    )
+    .describe("MAKSIMAL 3 pertanyaan; KOSONG bila pertanyaan riset sudah cukup spesifik."),
+});
 
 /**
  * Prompt penilaian klarifikasi pra-rencana: minta model menilai apakah pertanyaan sudah cukup
- * spesifik; bila tidak, mengembalikan 0-3 pertanyaan klarifikasi TERSTRUKTUR (JSON) — bukan prosa.
+ * spesifik; bila tidak, mengembalikan 0-3 pertanyaan klarifikasi terstruktur — bukan prosa.
  * Sengaja konservatif (kembalikan kosong bila sudah jelas) agar `/deep` yang sudah spesifik tak
  * terpotong gerbang tambahan.
  */
 function clarifyPrompt(input: z.infer<typeof InputSchema>): string {
-  return `Pertanyaan riset dari pengguna:\n${input.question}\n\nNilai apakah pertanyaan ini SUDAH cukup spesifik untuk langsung diriset mendalam, atau ada AMBIGUITAS PENTING yang bila diklarifikasi akan sangat mengubah arah/kualitas riset (mis. ruang lingkup, populasi/konteks, rentang waktu, sudut pandang, atau format keluaran).\n\nBila sudah cukup spesifik, kembalikan daftar KOSONG. Bila perlu, ajukan MAKSIMAL 3 pertanyaan klarifikasi yang paling menentukan — ringkas, tiap pertanyaan \`single\` (pilih satu) atau \`multi\` (pilih beberapa) dengan 2-4 opsi; set \`allowOther: true\` bila jawaban bebas relevan.\n\nAKHIRI dengan TEPAT SATU blok kode JSON valid (tanpa teks setelahnya):\n\`\`\`json\n{"questions": [{"id": "scope", "prompt": "...", "kind": "single", "options": [{"label": "..."}], "allowOther": true}]}\n\`\`\`\nKembalikan {"questions": []} bila tak perlu klarifikasi.`;
-}
-
-/**
- * Ekstrak `AskQuestion[]` dari output model (blok ```json` di akhir; fallback objek {...} pertama).
- * Normalisasi item mentah (id/opsi/freeform/lipat "Lainnya") = `normalizeAskQuestions` — SSOT yang
- * sama dipakai reducer FE; di sini dibatasi `max: 3` (klarifikasi pra-rencana ringkas).
- */
-function parseClarifyQuestions(text: string): AskQuestion[] {
-  const fenced = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)].map((m) => m[1] ?? "");
-  for (const chunk of [...fenced.reverse(), text]) {
-    const start = chunk.indexOf("{");
-    const end = chunk.lastIndexOf("}");
-    if (start === -1 || end <= start) continue;
-    try {
-      const obj = JSON.parse(chunk.slice(start, end + 1));
-      if (obj && Array.isArray(obj.questions)) return normalizeAskQuestions(obj.questions, { max: 3 });
-    } catch {
-      // coba kandidat berikutnya
-    }
-  }
-  return [];
+  return `Pertanyaan riset dari pengguna:\n${input.question}\n\nNilai apakah pertanyaan ini SUDAH cukup spesifik untuk langsung diriset mendalam, atau ada AMBIGUITAS PENTING yang bila diklarifikasi akan sangat mengubah arah/kualitas riset (mis. ruang lingkup, populasi/konteks, rentang waktu, sudut pandang, atau format keluaran).\n\nBila sudah cukup spesifik, kembalikan daftar \`questions\` KOSONG. Bila perlu, ajukan MAKSIMAL 3 pertanyaan klarifikasi yang paling menentukan — ringkas, tiap pertanyaan \`single\` (pilih satu) atau \`multi\` (pilih beberapa) dengan 2-4 opsi; set \`allowOther: true\` bila jawaban bebas relevan.`;
 }
 
 function searcherPrompt(subQuestion: string, input: Planned): string {
@@ -663,8 +682,9 @@ const draftClarifyStep = createStep({
       const out = await deepWriter.generate(clarifyPrompt(inputData), {
         ...deepGenOptions(requestContext, inputData, runId),
         toolChoice: "none",
+        structuredOutput: structuredOutputOpts(ClarifyOutputSchema),
       });
-      clarifyQuestions = parseClarifyQuestions(out.text);
+      clarifyQuestions = normalizeAskQuestions(out.object?.questions ?? [], { max: 3 });
     } catch (err) {
       console.error("[deep-research] draftClarify failed", err);
     }
@@ -708,11 +728,12 @@ const clarifyGateStep = createStep({
 });
 
 /**
- * 1. draftPlan — susun rencana prosa + sub-pertanyaan terstruktur via `deepWriter`. Precheck kuota
- * dipindah ke `draft-clarify` (gerbang paling awal) → step ini fokus menyusun rencana.
+ * 1. draftPlan — susun rencana prosa + sub-pertanyaan terstruktur via `deepWriter` dengan
+ * `structuredOutput` strict (audit 2026-07-03: fallback parse-manual yang senyap DIHAPUS — gagal
+ * validasi → throw → `retries: 1` → run failed SEBELUM gerbang billing, user tak kehilangan kredit).
  * `toolChoice:"none"` (CFG-5): step ini berjalan SEBELUM gerbang billing `approve-plan`, jadi tool
  * berbayar (`search_*`) tak boleh bisa jalan di sini; `delete_artifact` (approval-suspend) juga
- * dilarang dalam workflow-generate (lihat `tools/index.ts`). Murni menulis JSON rencana.
+ * dilarang dalam workflow-generate (lihat `tools/index.ts`). Murni menulis rencana terstruktur.
  */
 const draftPlanStep = createStep({
   id: "draft-plan",
@@ -723,12 +744,9 @@ const draftPlanStep = createStep({
     const out = await deepWriter.generate(planPrompt(inputData), {
       ...deepGenOptions(requestContext, inputData, runId),
       toolChoice: "none",
+      structuredOutput: structuredOutputOpts(PlanOutputSchema),
     });
-    const parsed = parsePlan(out.text);
-    const plan = parsed?.plan ?? out.text;
-    const subQuestions =
-      parsed && parsed.subQuestions.length > 0 ? parsed.subQuestions : [inputData.question];
-    const domain = parsed?.domain ?? "general";
+    const { plan, subQuestions, domain } = ensurePlanOutput(out.object);
     await emitDetail(writer, { kind: "plan", plan, subQuestions });
     return { ...inputData, plan, subQuestions, domain };
   },
@@ -805,26 +823,17 @@ const approvePlanStep = createStep({
     if (!resumeData.edits) return inputData;
     // CFG-3: edit user harus sampai ke `subQuestions` yang benar-benar diriset fan-out — bukan
     // hanya ditempel sebagai prosa yang baru dibaca writer akhir. Re-derive rencana+sub-pertanyaan
-    // dengan satu pass murah (`toolChoice:"none"`); gagal → fallback perilaku lama (append prosa).
+    // dengan satu pass murah (`toolChoice:"none"` + structuredOutput strict); gagal → fallback
+    // perilaku lama (append prosa) — di titik ini debit SUDAH terjadi, run tak boleh mati.
     try {
       const out = await deepWriter.generate(replanPrompt(inputData, resumeData.edits), {
         ...deepGenOptions(requestContext, inputData, runId),
         toolChoice: "none",
+        structuredOutput: structuredOutputOpts(PlanOutputSchema),
       });
-      const parsed = parsePlan(out.text);
-      if (parsed && parsed.subQuestions.length > 0) {
-        await emitDetail(writer, {
-          kind: "plan",
-          plan: parsed.plan,
-          subQuestions: parsed.subQuestions,
-        });
-        return {
-          ...inputData,
-          plan: parsed.plan,
-          subQuestions: parsed.subQuestions,
-          domain: parsed.domain,
-        };
-      }
+      const { plan, subQuestions, domain } = ensurePlanOutput(out.object);
+      await emitDetail(writer, { kind: "plan", plan, subQuestions });
+      return { ...inputData, plan, subQuestions, domain };
     } catch (err) {
       console.error("[deep-research] replan after edits failed", err);
     }

--- a/apps/agent/src/mastra/workflows/deep-tasks.ts
+++ b/apps/agent/src/mastra/workflows/deep-tasks.ts
@@ -100,14 +100,56 @@ function normalizeResult(result: unknown): DeepTaskResult {
   };
 }
 
-/** Poll sampai task terminal (getTask baca storage — andal juga untuk task yang dipulihkan). */
+/** Margin di atas timeout task sendiri — beri waktu engine menandai `timed_out` lebih dulu. */
+const STALE_WAIT_MARGIN_MS = 30_000;
+
+/**
+ * A2: batas tunggu untuk task LAMA = sisa umur task itu sendiri (`startedAt ?? createdAt` +
+ * `task.timeoutMs` + margin) — BUKAN full timeout baru. Task stale (eksekutor proses lama mati,
+ * recovery tak menyentuh) punya deadline di masa lalu → loop wait langsung keluar → dispatch
+ * attempt baru segera, alih-alih klik "Mulai ulang" terasa hang ~10 menit. Catatan: record
+ * `BackgroundTask` TIDAK punya `updatedAt` (rekomendasi audit dikoreksi di sini). Tetap di-cap
+ * timeout step pemanggil.
+ */
+function existingTaskDeadline(task: BackgroundTask, callerTimeoutMs: number): number {
+  const anchor = new Date(task.startedAt ?? task.createdAt).getTime();
+  return Math.min(anchor + task.timeoutMs + STALE_WAIT_MARGIN_MS, Date.now() + callerTimeoutMs);
+}
+
+/**
+ * B5: attempt yang satu identitas logis dgn `base` = base persis ATAU suffix retry `:r<N>:<ts>`.
+ * BUKAN prefix polos: `:empty-retry` adalah kunci logis BERBEDA (retry teks-kosong CTX-7), dan
+ * `search:1` tak boleh mencocokkan `search:10`.
+ */
+function isAttemptOf(toolCallId: string, base: string): boolean {
+  return toolCallId === base || toolCallId.startsWith(`${base}:r`);
+}
+
+/**
+ * Hasil `completed` layak reuse hanya bila MEMBAWA TEKS. Task completed ber-`text:""` (turn senyap
+ * CTX-7 / result malformed yang dipaksa kosong `normalizeResult`) yang di-reuse membuat synthesize
+ * gagal PERMANEN: throw laporan-kosong → retry/time-travel menemukan task "completed" yang sama →
+ * tak pernah dispatch attempt baru — kredit run hangus tanpa jalur pulih. Empty completed
+ * diperlakukan seperti terminal non-completed → attempt baru ber-suffix (untuk search ini berarti
+ * re-riset sub-Q yang hasilnya memang kosong/tak berguna — debit ulang yang membeli jawaban nyata).
+ */
+function completedWithText(task: BackgroundTask): boolean {
+  return normalizeResult(task.result).text.trim().length > 0;
+}
+
+/** Poll sampai task terminal (getTask baca storage — andal juga untuk task yang dipulihkan).
+ *  Deadline ABSOLUT (epoch ms, A2); abort run (B4) → tutup task lalu lempar. */
 async function waitUntilTerminal(
   manager: BackgroundTaskManager,
   taskId: string,
-  timeoutMs: number,
+  deadlineMs: number,
+  abortSignal?: AbortSignal,
 ): Promise<BackgroundTask | null> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  while (Date.now() < deadlineMs) {
+    if (abortSignal?.aborted) {
+      await manager.cancel(taskId).catch(() => {});
+      throw new Error("deep task dibatalkan: run di-cancel");
+    }
     const task = await manager.getTask(taskId);
     if (!task) return null;
     if (TERMINAL_STATUSES.has(task.status)) return task;
@@ -121,9 +163,11 @@ async function waitUntilTerminal(
  *
  * - Manager tak tersedia (backgroundTasks off / unit test) → fallback FOREGROUND (perilaku
  *   pra-DUR-7, tanpa persist).
- * - Task lama dgn `toolCallId` sama: `completed` → reuse hasil (no re-run/no re-debit);
- *   `pending/running/suspended` → register ulang executor + tunggu; `failed/timed_out/cancelled`
- *   → dispatch BARU dgn suffix percobaan (`:r<N>`).
+ * - Task lama satu identitas logis (base ATAU attempt ber-suffix `:r<N>:<ts>`, B5): `completed`
+ *   BER-TEKS → reuse hasil (no re-run/no re-debit); `pending/running/suspended` → register ulang
+ *   executor + tunggu maksimal sisa umur task itu (A2; melewati deadline → di-cancel supaya tak
+ *   jalan dobel); semua terminal non-completed (atau completed kosong) → dispatch BARU dgn suffix
+ *   percobaan berikutnya.
  * - Throw hanya bila task baru berakhir non-completed — pemanggil (step) yang memutuskan isolasi
  *   (searchStep menangkap per sub-Q; step ber-`retries` biarkan workflow yang mengulang).
  */
@@ -135,33 +179,65 @@ export async function runDeepSubagentTask(params: {
   threadId: string;
   resourceId?: string;
   timeoutMs: number;
+  /** B4: abortSignal step (dipicu `run.cancel()`) — tutup task run ini alih-alih jalan terus. */
+  abortSignal?: AbortSignal;
 }): Promise<DeepTaskResult> {
   const manager = params.mastra?.backgroundTaskManager;
   if (!manager) return executeDeepGenerate(params.args);
+  if (params.abortSignal?.aborted) throw new Error("deep task dibatalkan: run di-cancel");
 
   let toolCallId = params.toolCallId;
   try {
+    // B5: list per-RUN (bukan exact `toolCallId` — filter storage exact-match) supaya attempt
+    // ber-suffix `:r<N>:<ts>` yang BERHASIL ikut ditemukan saat restart; dulu attempt sukses itu
+    // tak terlihat → sub-Q diriset (dan didebit `external_search`) ulang.
     const { tasks } = await manager.listTasks({
-      toolCallId: params.toolCallId,
       runId: params.runId,
-      perPage: 10,
+      orderBy: "createdAt",
+      orderDirection: "desc",
+      // Fan-out satu run: ≤8 sub-Q × (base + empty-retry + suffix retry) + counter + synthesize.
+      perPage: 100,
     });
-    // Bisa >1 (percobaan ber-suffix listTasks by toolCallId dasar tak ikut) — ambil terbaru.
-    const existing = tasks[0];
-    if (existing) {
-      if (existing.status === "completed") return normalizeResult(existing.result);
-      if (!TERMINAL_STATUSES.has(existing.status)) {
-        manager.registerTaskContext(existing.id, { executor: deepTaskExecutor });
-        const done = await waitUntilTerminal(manager, existing.id, params.timeoutMs);
-        if (done?.status === "completed") return normalizeResult(done.result);
-        // Gagal/timeout/hilang → jatuh ke dispatch percobaan baru di bawah.
+    const attempts = tasks.filter((t) => isAttemptOf(t.toolCallId, params.toolCallId));
+    // Prioritas: (1) completed BER-TEKS terbaru → reuse hasil (no re-run / no re-debit);
+    const completed = attempts.find((t) => t.status === "completed" && completedWithText(t));
+    if (completed) return normalizeResult(completed.result);
+    // (2) non-terminal TERBARU → register ulang executor + tunggu ber-deadline umur task (A2);
+    const active = attempts.find((t) => !TERMINAL_STATUSES.has(t.status));
+    if (active) {
+      manager.registerTaskContext(active.id, { executor: deepTaskExecutor });
+      const done = await waitUntilTerminal(
+        manager,
+        active.id,
+        existingTaskDeadline(active, params.timeoutMs),
+        params.abortSignal,
+      );
+      if (done?.status === "completed" && completedWithText(done)) return normalizeResult(done.result);
+      // Stale melewati deadline / hilang dari storage → CANCEL dulu sebelum attempt baru: record
+      // `cancelled` membuat antrean melewatinya (engine hanya skip task cancelled saat dispatch).
+      // Tanpa ini task lama yang ternyata masih hidup (pending antrean backlog / re-dispatch
+      // `recoverStaleTasks` ber-`startedAt` kosong) ikut jalan → subagent DOBEL + debit dobel.
+      // Kooperatif: eksekusi yang sudah in-flight bisa tuntas internal (hasil dibuang).
+      if (!done || !TERMINAL_STATUSES.has(done.status)) {
+        await manager.cancel(active.id).catch(() => {});
       }
-      toolCallId = `${params.toolCallId}:r${existing.retryCount + 1}:${Date.now()}`;
+      // Gagal/timeout/stale/hilang → jatuh ke dispatch percobaan baru di bawah.
+    }
+    // (3) semua attempt terminal non-completed (atau completed tanpa teks) → attempt baru ber-suffix.
+    if (attempts.length > 0) {
+      toolCallId = `${params.toolCallId}:r${(attempts[0]?.retryCount ?? 0) + 1}:${Date.now()}`;
     }
   } catch (err) {
+    // Abort ≠ blip lookup — jangan lanjut dispatch attempt baru untuk run yang dibatalkan.
+    if (params.abortSignal?.aborted) throw err;
     // Dedupe best-effort — kegagalan lookup tak boleh mematikan step; lanjut dispatch baru.
     console.error("[deep-tasks] task lookup failed", err);
   }
+
+  // B4: abort bisa mendarat SELAMA lookup di atas (await panjang) — listener `abort` di bawah
+  // dipasang SETELAHNYA dan event pada signal yang sudah aborted tak pernah fire (spec WHATWG),
+  // jadi tanpa cek ulang ini task baru lahir + ditunggu full timeout untuk run yang dibatalkan.
+  if (params.abortSignal?.aborted) throw new Error("deep task dibatalkan: run di-cancel");
 
   const handle = createBackgroundTask(manager, {
     runId: params.runId,
@@ -174,15 +250,28 @@ export async function runDeepSubagentTask(params: {
     timeoutMs: params.timeoutMs,
     context: { executor: deepTaskExecutor },
   });
-  const { fallbackToSync } = await handle.dispatch();
-  if (fallbackToSync) return executeDeepGenerate(params.args);
-  const done = await handle.waitForCompletion({ timeoutMs: params.timeoutMs + 30_000 });
-  if (done.status !== "completed") {
-    throw new Error(
-      `deep background task ${params.args.agentId} berakhir ${done.status}${
-        done.error ? `: ${done.error.message}` : ""
-      }`,
-    );
+  // B4: run di-cancel → tutup task yang baru di-dispatch. KOOPERATIF & JUJUR: cancel menandai
+  // record `cancelled` + wait di bawah keluar dini via status terminal itu, tapi `agent.generate`
+  // in-flight TIDAK menerima signal (args task wajib JSON-serializable, tanpa closure) — panggilan
+  // LLM yang sudah jalan bisa tuntas internal lalu hasilnya dibuang. Kebocoran debit `search_*`
+  // mengecil (task antre/berikutnya tak pernah mulai), tidak nol.
+  const onAbort = () => void handle.cancel().catch(() => {});
+  params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+  // Tutup jendela race tersisa (abort mendarat di antara cek ulang di atas dan addEventListener).
+  if (params.abortSignal?.aborted) onAbort();
+  try {
+    const { fallbackToSync } = await handle.dispatch();
+    if (fallbackToSync) return executeDeepGenerate(params.args);
+    const done = await handle.waitForCompletion({ timeoutMs: params.timeoutMs + STALE_WAIT_MARGIN_MS });
+    if (done.status !== "completed") {
+      throw new Error(
+        `deep background task ${params.args.agentId} berakhir ${done.status}${
+          done.error ? `: ${done.error.message}` : ""
+        }`,
+      );
+    }
+    return normalizeResult(done.result);
+  } finally {
+    params.abortSignal?.removeEventListener("abort", onAbort);
   }
-  return normalizeResult(done.result);
 }

--- a/apps/web/components/home-banner-carousel.tsx
+++ b/apps/web/components/home-banner-carousel.tsx
@@ -207,7 +207,7 @@ function BannerSlideCard({
       </div>
       <div
         className={cn(
-          "relative h-14 w-24 shrink-0 overflow-hidden rounded-[8px]",
+          "relative h-12 w-20 shrink-0 overflow-hidden rounded-[8px] sm:h-14 sm:w-24",
           slide.imageBgClass,
         )}
       >
@@ -225,7 +225,7 @@ function BannerSlideCard({
     </>
   );
   const slideClass =
-    "flex w-full shrink-0 items-center gap-4 px-4 py-3 sm:px-5 focus-visible:outline-none";
+    "flex w-full shrink-0 items-center gap-3 px-4 py-3 sm:gap-4 sm:px-5 focus-visible:outline-none";
 
   // Slide non-aktif disembunyikan dari tab-order & a11y tree (masih di DOM demi animasi geser).
   if (slide.external) {

--- a/apps/web/features/thread-experience/components/explore-handwritten-cue.tsx
+++ b/apps/web/features/thread-experience/components/explore-handwritten-cue.tsx
@@ -9,7 +9,8 @@ const HOME_EASE_OUT = [0.23, 1, 0.32, 1] as const;
 /**
  * Cue tulisan tangan "scroll ke bawah, yuk" — duduk di kanan-atas landing /app,
  * diagonal di antara action buka panel Workspace dan hero title. Klik → gulir
- * mulus ke section Jelajahi yang ada di bawah fold.
+ * mulus ke section Jelajahi yang ada di bawah fold. Disembunyikan di bawah `sm`:
+ * di layar sempit tak ada celah antara header dan hero, cue menabrak keduanya.
  */
 export function ExploreHandwrittenCue({
   shouldReduceMotion,
@@ -28,7 +29,7 @@ export function ExploreHandwrittenCue({
       type="button"
       onClick={scrollToExplore}
       aria-label="Gulir ke section Jelajahi"
-      className="group absolute right-2 top-10 z-10 flex flex-row-reverse items-center gap-1.5 sm:right-8 sm:top-12"
+      className="group absolute right-8 top-12 z-10 hidden flex-row-reverse items-center gap-1.5 sm:flex"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5, ease: HOME_EASE_OUT, delay: 0.5 }}

--- a/apps/web/features/thread-experience/components/mastra-chat-thread-surface.tsx
+++ b/apps/web/features/thread-experience/components/mastra-chat-thread-surface.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@aqsha/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { m, useReducedMotion } from "motion/react";
-import { useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ChevronRightIcon, ClockIcon, RotateCcwIcon, XIcon } from "@aqsha/ui/icons";
 import { ConversationContent } from "@/components/ai-elements/conversation-content";
@@ -35,7 +35,7 @@ import {
 } from "@/features/threads/lib/mastra-client";
 import type { TimelineMessage } from "@/features/threads/lib/timeline-types";
 import { buildThreadPanelLookups } from "@/features/threads/lib/thread-panel-data";
-import { mastraMessagesToTimeline } from "@/features/threads/lib/mastra-timeline";
+import { mastraMessagesToTimeline, wfStepLabel } from "@/features/threads/lib/mastra-timeline";
 import { useMastraAgent } from "@/features/threads/lib/use-mastra-agent";
 import type { ResearchSource } from "@/features/threads/types";
 import { threadTitle } from "@/features/threads/types";
@@ -117,6 +117,38 @@ function deepBlockedMessage(status: ReturnType<typeof useSendStatus>["data"]): s
  * thread wajar — melewati ini butuh paginasi sungguhan.
  */
 const HISTORY_SEED_PER_PAGE = 400;
+
+/** Kartu notice run `/deep` (macet DUR-5 / gagal B1 / bail blocked B3) — satu shell agar styling
+ *  & a11y konsisten. `secondary` opsional (varian info-only B3 cukup satu aksi tutup); ikon primary
+ *  default panah-ulang (aksi restart/retry), override via `icon` bila aksinya bukan mengulang. */
+function DeepRunNoticeCard(props: {
+  body: ReactNode;
+  detail?: string | null;
+  primary: { label: string; onClick: () => void; disabled?: boolean; icon?: ReactNode };
+  secondary?: { label: string; onClick: () => void };
+}) {
+  return (
+    <div className={cn(threadTranscriptColumnClass)}>
+      <div className="rounded-xl border border-border bg-card p-4">
+        <p className="text-sm text-foreground">{props.body}</p>
+        {props.detail ? (
+          <p className="mt-1 text-muted-foreground text-xs">{props.detail}</p>
+        ) : null}
+        <div className="mt-3 flex gap-2">
+          <Button size="sm" onClick={props.primary.onClick} disabled={props.primary.disabled}>
+            {props.primary.icon ?? <RotateCcwIcon className="size-3.5" />}
+            {props.primary.label}
+          </Button>
+          {props.secondary ? (
+            <Button size="sm" variant="ghost" onClick={props.secondary.onClick}>
+              {props.secondary.label}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 /** Teks user terakhir di timeline (untuk regenerate). */
 function lastUserText(messages: readonly TimelineMessage[]): string | null {
@@ -496,23 +528,51 @@ function MastraChatInner({
   // DUR-5: run `/deep` tampak macet (snapshot tak maju beberapa menit — biasanya proses agent
   // sempat restart; run `running` tak resume sendiri) → tawarkan mulai ulang dari step terakhir.
   const stalledCard = agent.deepStalled ? (
-    <div className={cn(threadTranscriptColumnClass)}>
-      <div className="rounded-xl border border-border bg-card p-4">
-        <p className="text-sm text-foreground">
-          Riset mendalam tampak macet — tidak ada kemajuan beberapa menit terakhir.
-        </p>
-        <div className="mt-3 flex gap-2">
-          <Button size="sm" onClick={() => void agent.restartDeep()}>
-            <RotateCcwIcon className="size-3.5" />
-            Mulai ulang
-          </Button>
-          <Button size="sm" variant="ghost" onClick={agent.stop}>
-            Hentikan
-          </Button>
-        </div>
-      </div>
-    </div>
+    <DeepRunNoticeCard
+      body="Riset mendalam tampak macet — tidak ada kemajuan beberapa menit terakhir."
+      primary={{ label: "Mulai ulang", onClick: () => void agent.restartDeep() }}
+      secondary={{ label: "Hentikan", onClick: agent.stop }}
+    />
   ) : null;
+
+  // B1: run `/deep` gagal pasca-billing → jangan senyap. Kredit run sudah didebit (idempoten
+  // per-run), jadi tawarkan "Coba lagi" (time-travel dari langkah gagal — tanpa debit baru)
+  // alih-alih membiarkan user regenerate yang memotong kredit lagi. Tombol dinonaktifkan selagi
+  // turn lain streaming (retryDeep juga menolak) — retry mid-stream merusak timeline.
+  const failedCard = agent.deepFailed ? (
+    <DeepRunNoticeCard
+      body={
+        <>
+          Riset mendalam gagal
+          {agent.deepFailed.stepId
+            ? ` pada langkah "${wfStepLabel(agent.deepFailed.stepId).toLowerCase()}"`
+            : ""}
+          . Coba lagi akan melanjutkan dari langkah itu tanpa memotong kredit baru.
+        </>
+      }
+      detail={agent.deepFailed.message}
+      primary={{ label: "Coba lagi", onClick: () => void agent.retryDeep(), disabled: busy }}
+      secondary={{ label: "Buang", onClick: agent.dismissDeepFailure }}
+    />
+  ) : null;
+
+  // B3: run `/deep` berakhir bail `blocked` (kuota habis / akses ditolak — SEBELUM debit) → alasan
+  // harus terlihat, bukan settle senyap. Info-only: run sudah terminal, tak ada aksi pemulihan.
+  // Kartu DITEKAN bila bubble persisted `deep-bail:<runId>` (persistDeepNotice, best-effort) sudah
+  // ada di timeline — pasca-refresh history memuatnya, tanpa guard ini alasan yang sama tampil
+  // dua kali (bubble + kartu). Sesi live (bubble belum di-load) tetap dapat kartunya.
+  const deepNotice = agent.deepNotice;
+  const noticeCard =
+    deepNotice && !agent.messages.some((m) => m.id === `deep-bail:${deepNotice.runId}`) ? (
+      <DeepRunNoticeCard
+        body={<>Riset mendalam dihentikan: {deepNotice.reason}</>}
+        primary={{
+          label: "Tutup",
+          onClick: agent.dismissDeepNotice,
+          icon: <XIcon className="size-3.5" />,
+        }}
+      />
+    ) : null;
 
   if (isEmpty) {
     return (
@@ -564,6 +624,8 @@ function MastraChatInner({
         )}
       >
         {stalledCard}
+        {failedCard}
+        {noticeCard}
         {questionsCard}
         {planGateCard}
         {approvalCards}

--- a/apps/web/features/threads/components/composer.tsx
+++ b/apps/web/features/threads/components/composer.tsx
@@ -218,6 +218,8 @@ export function Composer({
   const [isSending, setIsSending] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Ref shell composer (kotak rounded penuh) — anchor palette slash/mention di mobile.
+  const composerShellRef = useRef<HTMLDivElement | null>(null);
 
   const secondsLeft = useSecondsLeft(notice?.retryAt);
   const agentSelection = useComposerAgentSelection(threadAgentKind);
@@ -521,6 +523,7 @@ export function Composer({
   return (
     <div className="flex w-full flex-col gap-8">
       <m.div
+        ref={composerShellRef}
         initial={false}
         layout
         className="@container/composer w-full overflow-hidden border border-border/85 bg-card/95 text-foreground"
@@ -626,6 +629,7 @@ export function Composer({
                     workspaceItems={workspaceItems}
                     workspaceItemsLoading={itemsQuery.isLoading}
                     onRequestWorkspaceItems={setDrillWorkspaceId}
+                    mobilePaletteAnchorRef={composerShellRef}
                   />
                 </div>
               </div>

--- a/apps/web/features/threads/components/elapsed-label.tsx
+++ b/apps/web/features/threads/components/elapsed-label.tsx
@@ -10,17 +10,20 @@ import { Shimmer } from "@/components/ai-elements/shimmer";
  * Terisolasi → hanya komponen ini yang re-render tiap detik.
  *
  * Dipakai blok "Proses" (`message-list`) DAN row subagent-call yang running (`tool-row`).
- * ponytail: hitung dari mount (`Date.now()`), bukan `createdAt` event aktif pertama — reset saat
- * refresh tapi tetap menunjukkan gerak; presisi lintas-reload = upgrade opsional.
+ * `startedAt` (epoch-ms durable: `steps[id].startedAt` snapshot `/deep` / `createdAt` pesan user)
+ * menjadikan timer selamat-refresh; tanpa itu fallback waktu mount. Boleh tiba TERLAMBAT (poll
+ * seed sesudah mount) → dihitung sebagai prop tiap render, bukan di-freeze useState. Clamp ≥0
+ * mengantisipasi skew jam client vs server.
  */
-export function ElapsedLabel({ base }: { base: string }) {
-  const [start] = useState(() => Date.now());
-  const [now, setNow] = useState(start);
+export function ElapsedLabel({ base, startedAt }: { base: string; startedAt?: number }) {
+  const [mountedAt] = useState(() => Date.now());
+  const [now, setNow] = useState(mountedAt);
   useEffect(() => {
     const timer = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(timer);
   }, []);
-  const secs = Math.floor((now - start) / 1000);
+  const start = startedAt && startedAt > 0 ? startedAt : mountedAt;
+  const secs = Math.max(0, Math.floor((now - start) / 1000));
   const m = Math.floor(secs / 60);
   const s = secs % 60;
   const label = secs < 10 ? `${base}…` : `${base}… ${m > 0 ? `${m}m ` : ""}${s}s`;

--- a/apps/web/features/threads/components/message-list.tsx
+++ b/apps/web/features/threads/components/message-list.tsx
@@ -102,7 +102,7 @@ export function MessageList({
   return (
     <MessageInteractionsProvider value={interactions}>
       <div className="flex flex-col gap-6">
-        {messages.map((m) =>
+        {messages.map((m, i) =>
           m.role === "user" ? (
             <UserBubble key={m.id} parts={m.parts} attachments={attachmentsByMessage?.get(m.id)} />
           ) : (
@@ -111,6 +111,7 @@ export function MessageList({
               message={m}
               sources={m.turnId ? sourcesByTurn?.get(m.turnId) : undefined}
               onRegenerate={!busy && m.id === lastAssistantId ? onRegenerate : undefined}
+              turnStartedAt={precedingUserCreatedAt(messages, i)}
             />
           ),
         )}
@@ -118,6 +119,19 @@ export function MessageList({
       </div>
     </MessageInteractionsProvider>
   );
+}
+
+/**
+ * `createdAt` pesan user terdekat SEBELUM pesan index `i` — anchor timer turn asisten yang
+ * selamat refresh (pesan user dipersist segera saat submit, jadi tersedia live maupun rehydrate).
+ * 0/absen → undefined (ElapsedLabel fallback ke waktu mount).
+ */
+function precedingUserCreatedAt(messages: TimelineMessage[], i: number): number | undefined {
+  for (let j = i - 1; j >= 0; j--) {
+    const m = messages[j];
+    if (m?.role === "user") return m.createdAt > 0 ? m.createdAt : undefined;
+  }
+  return undefined;
 }
 
 function UserBubble({
@@ -247,10 +261,13 @@ function AssistantMessage({
   message,
   sources,
   onRegenerate,
+  turnStartedAt,
 }: {
   message: TimelineMessage;
   sources?: ResearchSource[];
   onRegenerate?: () => void;
+  /** Epoch-ms pesan user pemicu turn — anchor timer "Sedang bekerja" yang selamat refresh. */
+  turnStartedAt?: number;
 }) {
   const { openSources } = useMessageInteractions();
   const streaming = Boolean(message.streaming);
@@ -267,6 +284,18 @@ function AssistantMessage({
     (p) => p.kind === "tool" || p.kind === "reasoning" || (p.kind === "text" && p.id !== answerId),
   );
   const toolSteps = processParts.filter((p) => p.kind === "tool").length;
+  // Anchor timer "Sedang bekerja": startedAt step Workflow yang SEDANG berjalan (snapshot `/deep`,
+  // durable lintas-refresh — sengaja bukan awal run supaya jeda menunggu plan-gate tak terhitung);
+  // fallback `createdAt` pesan user pemicu (chat normal), lalu waktu mount di ElapsedLabel.
+  let earliestRunningToolStart: number | undefined;
+  for (const p of processParts) {
+    if (p.kind !== "tool" || !p.model.isRunning) continue;
+    const startedAt = p.model.startedAt ?? 0;
+    if (startedAt > 0 && (earliestRunningToolStart === undefined || startedAt < earliestRunningToolStart)) {
+      earliestRunningToolStart = startedAt;
+    }
+  }
+  const workingSince = earliestRunningToolStart ?? turnStartedAt;
 
   // Sumber `/deep` dikelompokkan per `subQuestionIndex` → kartu sub-agen pencarian (step
   // search-literature). Hanya sumber bertanda sub-pertanyaan (chat biasa = null → dilewati).
@@ -311,6 +340,7 @@ function AssistantMessage({
           toolSteps={toolSteps}
           sourcesBySubQ={sourcesBySubQ}
           turnId={message.turnId}
+          workingSince={workingSince}
         />
       ) : null}
 
@@ -351,6 +381,7 @@ function ProcessBlock({
   toolSteps,
   sourcesBySubQ,
   turnId,
+  workingSince,
 }: {
   parts: TimelinePart[];
   streaming: boolean;
@@ -358,6 +389,8 @@ function ProcessBlock({
   sourcesBySubQ?: Map<number, ResearchSource[]>;
   /** Run id of this `/deep` turn — scopes the search/plan detail panels. */
   turnId?: string;
+  /** Epoch-ms anchor timer "Sedang bekerja" (durable lintas-refresh); kosong → waktu mount. */
+  workingSince?: number;
 }) {
   const [override, setOverride] = useState<boolean | null>(null);
   const prevStreaming = useRef(streaming);
@@ -376,7 +409,7 @@ function ProcessBlock({
             <Spinner className="size-3.5 shrink-0 text-primary" />
             {/* Riset mendalam menunggu subagent (task mode) bisa diam bermenit-menit tanpa
                 event; elapsed yang berdetak meyakinkan "masih bekerja", bukan beku. */}
-            <ElapsedLabel base="Sedang bekerja" />
+            <ElapsedLabel base="Sedang bekerja" startedAt={workingSince} />
           </>
         ) : (
           <span className="font-medium text-muted-foreground">{settledLabel}</span>

--- a/apps/web/features/threads/components/tokenized-prompt-input.tsx
+++ b/apps/web/features/threads/components/tokenized-prompt-input.tsx
@@ -11,8 +11,15 @@ import {
   MAX_CONTEXT_WORKSPACES,
   type PromptCommand,
 } from "@aqsha/chat-core";
-import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import {
   createCommandChipElement,
@@ -87,6 +94,7 @@ export function TokenizedPromptInput({
   workspaceItems,
   workspaceItemsLoading = false,
   onRequestWorkspaceItems,
+  mobilePaletteAnchorRef,
 }: {
   value: string;
   onValueChange: (value: string) => void;
@@ -106,8 +114,18 @@ export function TokenizedPromptInput({
   workspaceItems?: ContextItemOption[];
   workspaceItemsLoading?: boolean;
   onRequestWorkspaceItems?: (workspaceId: string | null) => void;
+  /**
+   * Anchor palette saat mobile: ref ke shell composer (kotak rounded penuh) supaya
+   * popover slash/mention selebar & center terhadap kotak input — bukan menjorok
+   * mengikuti wrapper editor yang offset oleh tombol upload/AgentSelector. Desktop
+   * tetap ter-anchor ke wrapper editor.
+   */
+  mobilePaletteAnchorRef?: RefObject<HTMLElement | null>;
 }) {
   const editorRef = useRef<HTMLDivElement | null>(null);
+  const editorWrapperRef = useRef<HTMLDivElement | null>(null);
+  const isMobile = useIsMobile();
+  const anchorToShell = isMobile && mobilePaletteAnchorRef != null;
   const paletteDismissalRef = useRef({ value, dismissed: false });
   const lastContextSignatureRef = useRef<string | null>(null);
   const isPaletteDismissed = () =>
@@ -558,70 +576,83 @@ export function TokenizedPromptInput({
 
   return (
     <Popover open={paletteOpen} modal={false}>
-      <PopoverAnchor asChild>
-        <div
-          className={cn(
-            "relative min-w-0 w-full text-[12.5px] text-foreground leading-[18px]",
-            isCollapsed && "flex min-h-8 items-center",
-            disabled && "opacity-100",
-            className,
-          )}
-        >
-          {showPlaceholder ? (
-            <span
-              className={cn(
-                "pointer-events-none absolute left-0 font-normal text-[12.5px] text-muted-foreground",
-                isCollapsed ? "inset-y-0 flex items-center" : "top-[3px]",
-              )}
-            >
-              {typeof placeholder === "string" ? (
-                placeholder
-              ) : (
-                <>
-                  {/* Container-query (bukan viewport): teks ringkas saat composer sempit
-                      (panel chat), teks penuh saat composer ≥ @lg (kolom thread lebar). */}
-                  <span className="@lg/composer:hidden">{placeholder.narrow}</span>
-                  <span className="hidden @lg/composer:inline">{placeholder.wide}</span>
-                </>
-              )}
-            </span>
-          ) : null}
-          <div
-            ref={editorRef}
-            contentEditable={!disabled}
-            role="textbox"
-            aria-label="Pesan"
-            aria-multiline="true"
-            aria-controls={
-              slashOpen
-                ? "composer-slash-commands"
-                : mentionOpen
-                  ? "composer-context-mentions"
-                  : undefined
-            }
+      {/* Anchor selalu virtual (render null) supaya wrapper editor tidak pernah
+          remount saat target anchor berpindah di breakpoint mobile↔desktop.
+          Cast: RefObject nullable React 19 tidak assignable ke RefObject<Measurable>
+          milik popper; runtime aman — popper hanya membaca .current. */}
+      <PopoverAnchor
+        virtualRef={
+          (anchorToShell ? mobilePaletteAnchorRef : editorWrapperRef) as RefObject<HTMLElement>
+        }
+      />
+      <div
+        ref={editorWrapperRef}
+        className={cn(
+          "relative min-w-0 w-full text-[12.5px] text-foreground leading-[18px]",
+          isCollapsed && "flex min-h-8 items-center",
+          disabled && "opacity-100",
+          className,
+        )}
+      >
+        {showPlaceholder ? (
+          <span
             className={cn(
-              "max-h-36 w-full overflow-y-auto whitespace-pre-wrap break-words text-foreground caret-primary outline-none disabled:opacity-100",
-              isCollapsed ? "min-h-8 py-[7px] leading-[18px]" : "min-h-6 py-1",
+              "pointer-events-none absolute left-0 font-normal text-[12.5px] text-muted-foreground",
+              isCollapsed ? "inset-y-0 flex items-center" : "top-[3px]",
             )}
-            onInput={updateEditorFromInput}
-            onBlur={syncEditorState}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            onClick={handleChipClick}
-            onMouseOver={handleChipHover}
-            onMouseLeave={() => setHoveredChip(null)}
-            onScroll={() => setHoveredChip(null)}
-            tabIndex={0}
-            suppressContentEditableWarning
-          />
-          {hoveredChip ? <ComposerChipTooltip chip={hoveredChip} /> : null}
-        </div>
-      </PopoverAnchor>
+          >
+            {typeof placeholder === "string" ? (
+              placeholder
+            ) : (
+              <>
+                {/* Container-query (bukan viewport): teks ringkas saat composer sempit
+                    (panel chat), teks penuh saat composer ≥ @lg (kolom thread lebar). */}
+                <span className="@lg/composer:hidden">{placeholder.narrow}</span>
+                <span className="hidden @lg/composer:inline">{placeholder.wide}</span>
+              </>
+            )}
+          </span>
+        ) : null}
+        <div
+          ref={editorRef}
+          contentEditable={!disabled}
+          role="textbox"
+          aria-label="Pesan"
+          aria-multiline="true"
+          aria-controls={
+            slashOpen
+              ? "composer-slash-commands"
+              : mentionOpen
+                ? "composer-context-mentions"
+                : undefined
+          }
+          className={cn(
+            "max-h-36 w-full overflow-y-auto whitespace-pre-wrap break-words text-foreground caret-primary outline-none disabled:opacity-100",
+            isCollapsed ? "min-h-8 py-[7px] leading-[18px]" : "min-h-6 py-1",
+          )}
+          onInput={updateEditorFromInput}
+          onBlur={syncEditorState}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onClick={handleChipClick}
+          onMouseOver={handleChipHover}
+          onMouseLeave={() => setHoveredChip(null)}
+          onScroll={() => setHoveredChip(null)}
+          tabIndex={0}
+          suppressContentEditableWarning
+        />
+        {hoveredChip ? <ComposerChipTooltip chip={hoveredChip} /> : null}
+      </div>
       <PopoverContent
-        align="start"
+        align={anchorToShell ? "center" : "start"}
         side="bottom"
         sideOffset={12}
-        className="w-[min(22.5rem,calc(100vw-2rem))] overflow-hidden rounded-xl p-0"
+        className={cn(
+          "overflow-hidden rounded-xl p-0",
+          anchorToShell
+            ? "w-[var(--radix-popover-trigger-width)]"
+            : "w-[min(22.5rem,calc(100vw-2rem))]",
+        )}
         onMouseDown={(event) => {
           event.preventDefault();
         }}

--- a/apps/web/features/threads/components/tool-row.tsx
+++ b/apps/web/features/threads/components/tool-row.tsx
@@ -215,7 +215,7 @@ export function ToolRow({
       />
       <span className="min-w-0">
         {isSubagentRunning ? (
-          <ElapsedLabel base={model.title} />
+          <ElapsedLabel base={model.title} startedAt={model.startedAt} />
         ) : model.isRunning ? (
           <Shimmer as="span">{model.title}</Shimmer>
         ) : (

--- a/apps/web/features/threads/lib/mastra-timeline.ts
+++ b/apps/web/features/threads/lib/mastra-timeline.ts
@@ -574,6 +574,31 @@ export function settleWorkflowTurn(
   };
 }
 
+/**
+ * B1: hidupkan lagi turn `/deep` yang failed SEBELUM retry time-travel. Chunk retry mengalir via
+ * `reduceWorkflowChunk` yang menyasar assistant STREAMING (`ensureActiveAssistant`) — turn failed
+ * sudah settle (`streaming: false`), jadi tanpa revive retry melahirkan bubble kembar. Turn
+ * ber-`turnId === runId` ditandai streaming lagi; tak ditemukan (mis. retry sebelum seed) →
+ * biarkan — `ensureActiveAssistant`/`seedWorkflowProgress` yang melahirkan placeholder.
+ */
+export function reviveWorkflowTurn(
+  state: MastraTimelineState,
+  runId: string,
+): MastraTimelineState {
+  return {
+    ...state,
+    status: "streaming",
+    runId,
+    activeRunId: runId,
+    // Paritas `startAssistantTurn`: aktivitas baru menghapus banner error basi (mis. pesan
+    // "Gagal mengulang" dari percobaan retry sebelumnya) selagi run retry streaming.
+    error: undefined,
+    messages: state.messages.map((m) =>
+      m.role === "assistant" && m.turnId === runId ? { ...m, streaming: true } : m,
+    ),
+  };
+}
+
 /** Set status streaming tanpa menyentuh pesan (dipakai sebelum menerapkan chunk konten). */
 function streaming(state: MastraTimelineState): MastraTimelineState {
   return state.status === "streaming" ? state : { ...state, status: "streaming" };
@@ -606,9 +631,11 @@ const WF_STEP_LABELS: Record<string, string> = {
   "assign-citations": "Menomori sumber",
   "verify-citations": "Memverifikasi sitasi",
   synthesize: "Menulis sintesis",
+  "persist-report": "Menyimpan laporan",
 };
 
-function wfStepLabel(stepId: string): string {
+/** Diekspor untuk kartu run gagal (B1) — label langkah yang sama dgn baris "Proses". */
+export function wfStepLabel(stepId: string): string {
   return WF_STEP_LABELS[stepId] ?? humanizeSlug(stepId);
 }
 
@@ -628,6 +655,7 @@ const WF_STEP_ORDER = [
   "assign-citations",
   "verify-citations",
   "synthesize",
+  "persist-report",
 ] as const;
 
 /** Status step Mastra (`runById().steps[id].status`) → `ToolStatus` baris "Proses". */
@@ -647,6 +675,16 @@ function wfStepStatusToTool(status: string): ToolStatus {
 }
 
 type WorkflowStepSnapshot = { status?: unknown; output?: unknown; startedAt?: unknown };
+
+/**
+ * Unwrap entry `runById().steps[id]`: wire type @mastra/core mengizinkan array-of-attempt —
+ * ambil attempt TERAKHIR (engine 1.47 chain `.then()` polos hari ini selalu menulis objek
+ * tunggal). Diekspor agar pembaca kembar (`deepFailureFromSteps` di use-mastra-agent) memakai
+ * normalisasi bentuk wire yang SATU dan sama.
+ */
+export function lastStepAttempt<T>(raw: T | T[] | undefined): T | undefined {
+  return Array.isArray(raw) ? raw[raw.length - 1] : raw;
+}
 
 /**
  * Seed progres Workflow `/deep` dari snapshot `runById().steps` saat re-attach refresh fase RUNNING.
@@ -678,7 +716,7 @@ export function seedWorkflowProgress(
   for (const stepId of WF_STEP_ORDER) {
     const raw = steps[stepId];
     if (!raw) continue;
-    const sr = Array.isArray(raw) ? raw[raw.length - 1] : raw;
+    const sr = lastStepAttempt(raw);
     const status = str(sr?.status);
     if (!status) continue;
     next = upsertWorkflowStep(next, idx, stepId, wfStepStatusToTool(status), num(sr?.startedAt) || undefined);
@@ -1056,7 +1094,7 @@ function runningSearchDetail(
 ): DeepStepDetail | null {
   for (const sourceStep of ["approve-plan", "draft-plan"] as const) {
     const raw = steps[sourceStep];
-    const sr = Array.isArray(raw) ? raw[raw.length - 1] : raw;
+    const sr = lastStepAttempt(raw);
     const subQuestions = strArray(asRecord(sr?.output).subQuestions);
     if (subQuestions.length > 0) {
       return {
@@ -1453,8 +1491,19 @@ function num(v: unknown): number {
 function asRecord(v: unknown): Record<string, unknown> {
   return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
 }
+/**
+ * Pesan error dari payload longgar (string / `{message}`) — `null` bila tak ada. Diekspor untuk
+ * kartu run gagal B1 (`deepFailed.message` dari `steps[id].error` snapshot) agar normalisasi
+ * bentuk error Mastra hidup di SATU tempat.
+ */
+export function errorMessageFrom(err: unknown): string | null {
+  if (typeof err === "string" && err) return err;
+  if (err && typeof err === "object" && "message" in err) {
+    const msg = String((err as { message: unknown }).message);
+    if (msg) return msg;
+  }
+  return null;
+}
 function extractError(err: unknown): string {
-  if (typeof err === "string") return err;
-  if (err && typeof err === "object" && "message" in err) return String((err as { message: unknown }).message);
-  return "Terjadi kesalahan saat memproses.";
+  return errorMessageFrom(err) ?? "Terjadi kesalahan saat memproses.";
 }

--- a/apps/web/features/threads/lib/mastra-timeline.ts
+++ b/apps/web/features/threads/lib/mastra-timeline.ts
@@ -646,7 +646,7 @@ function wfStepStatusToTool(status: string): ToolStatus {
   }
 }
 
-type WorkflowStepSnapshot = { status?: unknown; output?: unknown };
+type WorkflowStepSnapshot = { status?: unknown; output?: unknown; startedAt?: unknown };
 
 /**
  * Seed progres Workflow `/deep` dari snapshot `runById().steps` saat re-attach refresh fase RUNNING.
@@ -681,11 +681,17 @@ export function seedWorkflowProgress(
     const sr = Array.isArray(raw) ? raw[raw.length - 1] : raw;
     const status = str(sr?.status);
     if (!status) continue;
-    next = upsertWorkflowStep(next, idx, stepId, wfStepStatusToTool(status));
+    next = upsertWorkflowStep(next, idx, stepId, wfStepStatusToTool(status), num(sr?.startedAt) || undefined);
     // Rekonstruksi detail dari nilai return step (tersedia saat step selesai) → body expandable
     // tetap terisi setelah refresh fase RUNNING (rencana, kartu sub-agen, bukti tandingan, dll.).
     const detail = detailFromStepOutput(stepId, sr?.output);
     if (detail) next = setStepDetail(next, idx, stepId, detail);
+    else if (stepId === "search-literature" && status === "running") {
+      // Step search MASIH berjalan (output belum ada): jangan render body kosong yang terlihat
+      // "mulai dari nol" — kartu sub-agen di-seed dari rencana; hanya bila belum ada detail live.
+      const planned = runningSearchDetail(steps);
+      if (planned) next = setStepDetailWith(next, idx, stepId, (prev) => prev ?? planned);
+    }
     if (stepId === "synthesize" && status === "success") {
       const report = reportFromOutput(sr?.output);
       if (report) next = setReportText(next, idx, report);
@@ -804,12 +810,17 @@ export function reduceWorkflowChunk(
   }
 }
 
-/** Tool-row "Proses" untuk satu langkah Workflow (keyed `wf:<stepId>`). */
+/**
+ * Tool-row "Proses" untuk satu langkah Workflow (keyed `wf:<stepId>`). `startedAt` (epoch-ms dari
+ * snapshot `steps[id].startedAt`) menimpa saat tersedia — anchor timer yang selamat refresh; jalur
+ * live tanpa nilai ini biarkan apa adanya (timer fallback ke waktu mount).
+ */
 function upsertWorkflowStep(
   state: MastraTimelineState,
   msgIdx: number,
   stepId: string,
   status: ToolStatus,
+  startedAt?: number,
 ): MastraTimelineState {
   const toolCallId = `wf:${stepId}`;
   const isRunning = status === "running" || status === "pending";
@@ -825,11 +836,14 @@ function upsertWorkflowStep(
         isRunning,
         description: undefined,
         rows: [],
+        ...(startedAt ? { startedAt } : {}),
       };
       return [...parts, { kind: "tool", id: `tool:${toolCallId}`, model }];
     }
     return parts.map((p, j) =>
-      j === i && p.kind === "tool" ? { ...p, model: { ...p.model, status, isRunning } } : p,
+      j === i && p.kind === "tool"
+        ? { ...p, model: { ...p.model, status, isRunning, ...(startedAt ? { startedAt } : {}) } }
+        : p,
     );
   });
 }
@@ -1028,6 +1042,34 @@ function detailFromStepOutput(stepId: string, output: unknown): DeepStepDetail |
     default:
       return null;
   }
+}
+
+/**
+ * Detail sintetis step `search-literature` yang MASIH berjalan saat re-attach: output step belum
+ * ada, tapi daftar sub-pertanyaan sudah pasti dari rencana yang disetujui (`approve-plan`,
+ * fallback `draft-plan`) → kartu sub-agen ber-status running alih-alih body kosong yang terlihat
+ * seperti "mengulang dari nol". Sumber per-kartu terisi via join `research_sources`
+ * (`subQuestionIndex`) — rows dipersist DI TENGAH step oleh tool search, di-refresh saat re-attach.
+ */
+function runningSearchDetail(
+  steps: Record<string, WorkflowStepSnapshot | WorkflowStepSnapshot[]>,
+): DeepStepDetail | null {
+  for (const sourceStep of ["approve-plan", "draft-plan"] as const) {
+    const raw = steps[sourceStep];
+    const sr = Array.isArray(raw) ? raw[raw.length - 1] : raw;
+    const subQuestions = strArray(asRecord(sr?.output).subQuestions);
+    if (subQuestions.length > 0) {
+      return {
+        kind: "search",
+        subSearches: subQuestions.map((q, i) => ({
+          index: i,
+          subQuestion: q,
+          status: "running" as ToolStatus,
+        })),
+      };
+    }
+  }
+  return null;
 }
 
 /**

--- a/apps/web/features/threads/lib/timeline-types.ts
+++ b/apps/web/features/threads/lib/timeline-types.ts
@@ -69,6 +69,8 @@ export type ToolRowModel = {
   rows: ToolRow[];
   /** Detail proses `/deep` (rencana, kartu sub-agen pencarian, bukti tandingan, dll.). */
   detail?: DeepStepDetail;
+  /** Epoch-ms mulai step (snapshot Workflow `steps[id].startedAt`) — anchor timer lintas-refresh. */
+  startedAt?: number;
   /** Akumulasi teks JSON arg yang masih mengalir (`tool-call-delta`, IMP-11) — internal reducer. */
   argsTextRaw?: string;
 };

--- a/apps/web/features/threads/lib/use-mastra-agent.ts
+++ b/apps/web/features/threads/lib/use-mastra-agent.ts
@@ -16,9 +16,12 @@ import {
   type MastraPlanGate,
   type MastraTimelineState,
   dropLastTurn,
+  errorMessageFrom,
   initialMastraTimeline,
+  lastStepAttempt,
   reduceMastraChunk,
   reduceWorkflowChunk,
+  reviveWorkflowTurn,
   seedWorkflowProgress,
   settleAssistantTurn,
   settleWorkflowTurn,
@@ -42,6 +45,18 @@ export type QueuedSend = {
   serverRunId?: string;
 };
 
+/**
+ * Run `/deep` berakhir `failed` (audit B1) — kunci pemulihan DITAHAN untuk kartu "Coba lagi"
+ * (time-travel dari step gagal, tanpa debit baru), alih-alih settle senyap + regenerate berbayar.
+ */
+export type DeepFailure = {
+  runId: string;
+  /** Step yang gagal (target time-travel); null bila tak teridentifikasi dari snapshot. */
+  stepId: string | null;
+  /** Pesan error step (best-effort dari snapshot) untuk kartu. */
+  message: string | null;
+};
+
 export type MastraAgent = {
   status: MastraAgentStatus;
   messages: TimelineMessage[];
@@ -58,6 +73,16 @@ export type MastraAgent = {
   deepStalled: boolean;
   /** Mulai ulang run `/deep` yang macet dari step aktif terakhir (`run.restart()`). */
   restartDeep: () => Promise<void>;
+  /** Run `/deep` gagal pasca-billing → kartu "Coba lagi" (B1); `null` bila tak ada. */
+  deepFailed: DeepFailure | null;
+  /** Ulangi run `/deep` failed MULAI DARI step gagal (`timeTravelStream`) — debit/task lama di-reuse. */
+  retryDeep: () => Promise<void>;
+  /** Buang kartu gagal + lepaskan runId (run itu tak lagi bisa dipulihkan dari UI). */
+  dismissDeepFailure: () => void;
+  /** Run `/deep` berakhir bail `blocked` (kuota/akses) → kartu alasan (B3); `null` bila tak ada. */
+  deepNotice: DeepNotice | null;
+  /** Tutup kartu alasan bail — murni UI (run sudah terminal `success`, kunci sudah di-clear). */
+  dismissDeepNotice: () => void;
   send: (
     text: string,
     clientContext?: string[],
@@ -85,9 +110,10 @@ export type MastraAgent = {
 const DEEP_WORKFLOW_ID = "deep-research";
 
 /**
- * DUR-5: ambang "run macet" — status `running` tanpa SATU pun transisi status step selama ini.
- * Longgar (fase search-literature bisa sah 3-4 menit tanpa transisi); melewatinya hampir pasti
- * snapshot beku pasca-restart proses agent (run tak pernah resume sendiri di Mastra 1.47).
+ * DUR-5: ambang "run macet" — status non-terminal (`running`/`waiting`/`pending`, A3) tanpa SATU
+ * pun transisi status step selama ini. Longgar (fase search-literature bisa sah 3-4 menit tanpa
+ * transisi); melewatinya hampir pasti snapshot beku pasca-restart proses agent (run tak pernah
+ * resume sendiri di Mastra 1.47).
  */
 const DEEP_STALL_MS = 300_000;
 
@@ -108,7 +134,59 @@ type DeepRun = {
   /** Restart run dari step aktif terakhir (snapshot) — affordance run macet (DUR-5). Impl client-js
    *  membaca `params.requestContext` TANPA guard → argumen `{}` WAJIB (jangan panggil tanpa arg). */
   restart: (p: Record<string, unknown>) => Promise<unknown>;
+  /** Re-eksekusi MULAI DARI step target dgn stepResults lama dari snapshot — jalur pemulihan run
+   *  `failed` (B1). `restart()` MENOLAK snapshot non-aktif di Mastra 1.47 ("This workflow run was
+   *  not active"), time-travel hanya menolak snapshot `running`. */
+  timeTravelStream: (p: { step: string | string[] }) => Promise<ReadableStream<MastraChunk>>;
 };
+
+/** Bentuk `runById().steps[id]` yang dipakai re-attach + rekonsiliasi terminal (subset longgar). */
+type WorkflowStepsSnapshot = Record<
+  string,
+  { status?: unknown; output?: unknown; suspendPayload?: Record<string, unknown>; error?: unknown }
+>;
+
+/**
+ * Snapshot run `runById()` (subset yang dipakai FE) — SATU bentuk untuk poll re-attach,
+ * rekonsiliasi terminal, dan probe status, supaya penambahan field (spt `result` untuk B3)
+ * tak perlu diulang di tiap cast inline.
+ */
+type DeepRunSnapshot = {
+  status?: string;
+  steps?: WorkflowStepsSnapshot;
+  /** B3: payload `bail()` (run success) — sumber `reason` kartu notice. */
+  result?: Record<string, unknown>;
+};
+
+/**
+ * B3: notice terminal dari `result` run (payload `bail()` — engine mem-persist run bail sebagai
+ * `success` dgn payload di `result`). Hanya `status: "blocked"` (kuota/akses) yang dirender;
+ * `cancelled` (user menolak rencana) dan `completed` (laporan normal) tetap senyap by-design.
+ */
+export type DeepNotice = { runId: string; reason: string };
+
+function deepNoticeFromResult(runId: string, result: unknown): DeepNotice | null {
+  if (!result || typeof result !== "object") return null;
+  const r = result as { status?: unknown; reason?: unknown };
+  if (r.status !== "blocked") return null;
+  const reason =
+    typeof r.reason === "string" && r.reason ? r.reason : "Run dihentikan tanpa alasan terekam.";
+  return { runId, reason };
+}
+
+/** B1: temukan step failed (target time-travel) + pesannya dari snapshot run `failed`. */
+function deepFailureFromSteps(runId: string, steps: WorkflowStepsSnapshot): DeepFailure {
+  for (const [stepId, rawEntry] of Object.entries(steps)) {
+    // Wire type @mastra/core mengizinkan entry array-of-attempt — unwrap via helper yang sama
+    // dengan pembaca kembar `seedWorkflowProgress` (mastra-timeline).
+    const st = lastStepAttempt<WorkflowStepsSnapshot[string]>(
+      rawEntry as WorkflowStepsSnapshot[string] | WorkflowStepsSnapshot[string][],
+    );
+    if (String(st?.status ?? "") !== "failed") continue;
+    return { runId, stepId, message: errorMessageFrom(st?.error) };
+  }
+  return { runId, stepId: null, message: null };
+}
 
 /** Iterasi `ReadableStream` via reader (async-iterator ReadableStream belum universal di browser). */
 async function* iterateStream<T>(stream: ReadableStream<T>): AsyncGenerator<T> {
@@ -235,6 +313,25 @@ function lastTurnMessageIds(messages: readonly ServerMessageLike[]): string[] {
       lastAssistant = i;
       break;
     }
+  }
+  // Turn MENGGANTUNG: ada pesan setelah assistant terakhir (mis. `deep-user:<runId>` dari run
+  // `/deep` failed — jawaban tak pernah dipersist). Yang dibuang HANYA turn menggantung TERAKHIR
+  // (pesan user/signal terakhir di ekor + pesan sesudahnya) — regenerate hanya mengirim ulang
+  // pertanyaan terakhir, jadi turn menggantung yang lebih tua (multi-gagal beruntun) atau seluruh
+  // history saat thread belum punya assistant sama sekali (lastAssistant = -1 → ekor = SEMUA
+  // pesan) tidak boleh ikut terhapus permanen. `signal` = label input user durable-thread
+  // `sendMessage` (lihat doc di atas).
+  const tail = messages.slice(lastAssistant + 1);
+  if (tail.length > 0) {
+    let start = 0;
+    for (let i = tail.length - 1; i >= 0; i -= 1) {
+      const role = tail[i]!.role;
+      if (role === "user" || role === "signal") {
+        start = i;
+        break;
+      }
+    }
+    return tail.slice(start).map((m) => m.id);
   }
   if (lastAssistant < 0) return [];
   const ids: string[] = [messages[lastAssistant]!.id];
@@ -436,6 +533,12 @@ export function useMastraAgent(opts: {
   );
   // DUR-5: run `/deep` terdeteksi macet (snapshot tak maju) → banner affordance mulai ulang.
   const [deepStalled, setDeepStalled] = useState(false);
+  // B1: run `/deep` failed → TAHAN kunci pemulihan (runId localStorage sengaja TIDAK di-clear,
+  // affordance selamat refresh) + kartu "Coba lagi" (time-travel dari step gagal, tanpa debit baru).
+  const [deepFailed, setDeepFailed] = useState<DeepFailure | null>(null);
+  // B3: run `/deep` bail `blocked` (kuota/akses) → kartu alasan. Terminalnya `success` (semantik
+  // bail Mastra) jadi kunci runId tetap di-clear normal — kartu murni state UI sesi ini.
+  const [deepNotice, setDeepNotice] = useState<DeepNotice | null>(null);
 
   // IMP-10: batch delta frekuensi-tinggi (text/reasoning) per animation-frame. Tanpa ini tiap
   // delta = satu setState penuh (rebuild messages + memo turunannya) — jawaban panjang bisa
@@ -717,6 +820,76 @@ export function useMastraAgent(opts: {
 
   // ── `/deep` = Workflow `deep-research` (G2). Run terlepas dari koneksi; FE simpan runId untuk
   //    re-attach saat refresh. Plan-gate = suspend `approve-plan` → kartu → `resumeStream`. ──────
+
+  // Snapshot run `/deep` via `runById` — SATU titik fetch+cast (poll, rekonsiliasi, probe status);
+  // `null` bila tak terverifikasi — pemanggil yang memutuskan (jangan aksi destruktif atas `null`).
+  const fetchDeepRun = useCallback(async (runId: string): Promise<DeepRunSnapshot | null> => {
+    try {
+      return (await clientRef.current
+        .getWorkflow(DEEP_WORKFLOW_ID)
+        .runById(runId)) as DeepRunSnapshot;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Run `/deep` tuntas → lepaskan kunci + refresh data turunan: Sumber baru (citation_number) +
+  // judul/preview sidebar. SATU tempat — dipakai tail `applyDeepTerminal` dan jalur chunk-cacat
+  // `reconcileDeepTerminal`, supaya invalidasi baru tak bisa terpasang di satu sisi saja.
+  const clearDeepRunAndRefresh = useCallback(() => {
+    clearDeepRunId(opts.threadId);
+    void qc.invalidateQueries({ queryKey: queryKeys.threads.sources(opts.threadId) });
+    void qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+  }, [opts.threadId, qc]);
+
+  // B1: terapkan status terminal run `/deep` — handler TUNGGAL untuk jalur live (via
+  // `reconcileDeepTerminal`) + poll re-attach, agar semantiknya tak bisa drift. failed → TAHAN
+  // runId (kunci time-travel, selamat refresh) + kartu "Coba lagi"; success hasil bail `blocked`
+  // → kartu alasan (B3, dari `result` run); selainnya → clear + refresh Sumber/sidebar.
+  const applyDeepTerminal = useCallback(
+    (runId: string, status: string, steps: WorkflowStepsSnapshot, result?: unknown) => {
+      setDeepStalled(false);
+      deepRunRef.current = null;
+      // Seed ikon step dari snapshot (idempoten di jalur live yang sudah menerima chunk) +
+      // settle by runId (FE-7) — jangan positional, turn lain tak boleh ikut ter-settle.
+      setState((s) => settleWorkflowTurn(seedWorkflowProgress(s, runId, steps), runId));
+      if (status === "failed") {
+        setDeepFailed(deepFailureFromSteps(runId, steps));
+        return;
+      }
+      setDeepFailed(null);
+      // B3: `canceled` (Stop user) dan `cancelled` di payload (tolak rencana) tetap senyap —
+      // hanya bail `blocked` yang menghasilkan kartu.
+      if (status === "success") setDeepNotice(deepNoticeFromResult(runId, result));
+      clearDeepRunAndRefresh();
+    },
+    [clearDeepRunAndRefresh],
+  );
+
+  // B1: rekonsiliasi terminal jalur live. `workflow-finish` TIDAK membawa status (payload hanya
+  // `{runId}` — diverifikasi @mastra/core 1.47), jadi baca status otentik via `runById` SEKALI
+  // lalu delegasikan ke `applyDeepTerminal`. Fetch GAGAL → JANGAN clear: runId bisa milik run
+  // failed (satu-satunya kunci pemulihan B1 — discovery tak menjangkau run failed); serahkan ke
+  // poll re-attach yang toleran blip (retry 8×) via `bumpReattach`.
+  const reconcileDeepTerminal = useCallback(
+    async (runId: string | undefined) => {
+      if (!runId) {
+        // Tanpa runId (chunk cacat + runRef kosong) → jalur lama: clear + refresh.
+        deepRunRef.current = null;
+        clearDeepRunAndRefresh();
+        return;
+      }
+      const st = await fetchDeepRun(runId);
+      if (!st) {
+        deepRunRef.current = null;
+        bumpReattach();
+        return;
+      }
+      applyDeepTerminal(runId, st.status ?? "", st.steps ?? {}, st.result);
+    },
+    [fetchDeepRun, clearDeepRunAndRefresh, applyDeepTerminal],
+  );
+
   const consumeWorkflow = useCallback(
     async (stream: ReadableStream<MastraChunk>) => {
       // `closeOnSuspend` (default) menutup stream saat plan-gate dengan chunk terminal `workflow-finish`.
@@ -724,6 +897,7 @@ export function useMastraAgent(opts: {
       // sempat suspend di `approve-plan`, JANGAN bersihkan runId/runRef — kartu rencana + `resolvePlan`
       // (resume) + re-attach saat refresh (G2/G7) bergantung padanya.
       let suspended = false;
+      let terminalHandled = false;
       for await (const chunk of iterateStream(stream)) {
         setState((s) => reduceWorkflowChunk(s, chunk));
         const stepId = (chunk.payload as { id?: unknown } | undefined)?.id;
@@ -745,45 +919,53 @@ export function useMastraAgent(opts: {
         }
         if (
           !suspended &&
+          !terminalHandled &&
           (chunk.type === "workflow-finish" || chunk.type === "workflow-canceled")
         ) {
-          clearDeepRunId(opts.threadId);
-          deepRunRef.current = null;
-          // Sumber baru (citation_number) sudah dipersist → refresh panel Sumber + sidebar.
-          void qc.invalidateQueries({ queryKey: queryKeys.threads.sources(opts.threadId) });
-          void qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+          // Satu stream bisa membawa >1 chunk terminal (`workflow-canceled` LALU `workflow-finish`
+          // + finish sintetis saat close — @mastra/core 1.47) → rekonsiliasi cukup SEKALI.
+          terminalHandled = true;
+          await reconcileDeepTerminal(chunk.runId ?? deepRunRef.current?.runId);
         }
       }
     },
-    [opts.threadId, qc],
+    [opts.threadId, qc, reconcileDeepTerminal],
   );
 
   // FE-5: pemicu ulang effect poll re-attach `/deep` TANPA menunggu refresh manual — di-bump saat
   // stream putus tapi run masih hidup server-side (blip jaringan / proxy / agent hang sesaat).
   const [reattachNonce, bumpReattach] = useReducer((n: number) => n + 1, 0);
 
+  // Status run `/deep`; `""` bila tak terverifikasi — pemanggil yang memutuskan
+  // (jangan ambil aksi destruktif atas dasar `""`).
+  const deepRunStatus = useCallback(
+    async (runId: string): Promise<string> => (await fetchDeepRun(runId))?.status ?? "",
+    [fetchDeepRun],
+  );
+
   // Saat stream `/deep` gagal/putus: pertahankan runId bila run masih HIDUP server-side (running/
-  // suspended/waiting) → re-attach poll memulihkannya (return `true`). Hanya clear bila run tak
-  // jalan (terminal/pending) atau status tak bisa diverifikasi (default aman = clear, return `false`).
+  // suspended/waiting) → re-attach poll memulihkannya (return `true`). Clear HANYA bila status
+  // TERVERIFIKASI tak jalan (terminal non-failed / pending). PENGECUALIAN B1: `failed` TIDAK
+  // di-clear — runId run failed = kunci pemulihan time-travel (kartu "Coba lagi" lahir dari poll
+  // mount berikutnya); `""` (tak terverifikasi — blip yang sama bisa memutus stream DAN probe ini)
+  // juga TIDAK di-clear: runId bisa milik run yang berakhir failed, dan discovery tak menjangkau
+  // run failed — serahkan ke poll re-attach yang toleran blip (paritas `reconcileDeepTerminal` +
+  // catch `retryDeep`); `undefined` (run tak pernah dimulai) no-op agar kunci milik run failed
+  // lama tak ikut tersapu oleh error start run baru.
   const clearDeepRunIdUnlessAlive = useCallback(
     async (runId: string | undefined): Promise<boolean> => {
-      if (runId) {
-        try {
-          const st = (await clientRef.current.getWorkflow(DEEP_WORKFLOW_ID).runById(runId)) as unknown as {
-            status?: string;
-          };
-          if (st.status === "running" || st.status === "suspended" || st.status === "waiting") {
-            return true;
-          }
-        } catch {
-          /* tak bisa verifikasi → jatuh ke clear */
-        }
+      if (!runId) return false;
+      const status = await deepRunStatus(runId);
+      if (status === "running" || status === "suspended" || status === "waiting") {
+        return true;
       }
-      clearDeepRunId(opts.threadId);
       deepRunRef.current = null;
+      if (status === "") bumpReattach();
+      if (status === "" || status === "failed") return false;
+      clearDeepRunId(opts.threadId);
       return false;
     },
-    [opts.threadId],
+    [opts.threadId, deepRunStatus],
   );
 
   // FE-5: stream `/deep` selesai TANPA chunk terminal & TANPA gerbang HITL (blip jaringan/proxy
@@ -839,6 +1021,10 @@ export function useMastraAgent(opts: {
         const wf = clientRef.current.getWorkflow(DEEP_WORKFLOW_ID);
         const run = (await wf.createRun({ resourceId: userId })) as unknown as DeepRun;
         deepRunRef.current = run;
+        // Run baru MENGGANTIKAN run failed lama — kartu + kunci lama dibuang HANYA setelah run
+        // pengganti benar-benar lahir (createRun gagal → kartu & kunci pemulihan B1 tetap utuh).
+        setDeepFailed(null);
+        setDeepNotice(null);
         setDeepRunId(opts.threadId, run.runId);
         const inputData: Record<string, unknown> = { question, threadId: opts.threadId, agentKind };
         if (richText && richText !== question) inputData.displayQuestion = richText;
@@ -1049,22 +1235,15 @@ export function useMastraAgent(opts: {
       let sourcesSeeded = false;
       let sourcesRefreshed = false;
       // DUR-5: deteksi run macet — signature progres (status + status tiap step) yang tak berubah
-      // selama DEEP_STALL_MS pada status `running` = macet (mis. proses agent restart, snapshot beku
-      // `running` selamanya). Banner affordance mulai ulang; poll TETAP jalan (bisa pulih sendiri).
+      // selama DEEP_STALL_MS pada status non-terminal (`running`/`waiting`/`pending`, A3) = macet
+      // (mis. proses agent restart, snapshot beku selamanya). Banner affordance mulai ulang; poll
+      // TETAP jalan (bisa pulih sendiri).
       let progressSig = "";
       let progressAt = Date.now();
       while (!cancelled) {
-        let wfState: {
-          status?: string;
-          steps?: Record<
-            string,
-            { status?: unknown; output?: unknown; suspendPayload?: Record<string, unknown> }
-          >;
-        };
-        try {
-          wfState = (await wf.runById(rid)) as typeof wfState;
-        } catch {
-          if (cancelled) return;
+        const wfState = await fetchDeepRun(rid);
+        if (cancelled) return;
+        if (!wfState) {
           // Error transien (agent single-thread sempat hang saat fase berat / restart dev) → JANGAN
           // clear runId; coba lagi. Run tetap hidup server-side. Menyerah hanya setelah lama tak
           // responsif — TANPA clear runId, agar refresh berikutnya bisa re-attach lagi.
@@ -1077,7 +1256,6 @@ export function useMastraAgent(opts: {
           continue;
         }
         errors = 0;
-        if (cancelled) return;
         const status = wfState.status;
         const steps = wfState.steps ?? {};
         if (status === "suspended") {
@@ -1121,22 +1299,11 @@ export function useMastraAgent(opts: {
           }));
           return;
         }
-        if (status === "success") {
-          setDeepStalled(false);
-          // FE-7: settle by runId — jangan positional (turn lain tak boleh ikut ter-settle).
-          setState((s) => settleWorkflowTurn(seedWorkflowProgress(s, rid, steps), rid));
-          clearDeepRunId(opts.threadId);
-          deepRunRef.current = null;
-          // Sumber baru (citation_number) + judul/preview → refresh panel Sumber & sidebar.
-          void qc.invalidateQueries({ queryKey: queryKeys.threads.sources(opts.threadId) });
-          void qc.invalidateQueries({ queryKey: queryKeys.threads.all });
-          return;
-        }
-        if (status === "failed" || status === "canceled") {
-          setDeepStalled(false);
-          setState((s) => settleWorkflowTurn(seedWorkflowProgress(s, rid, steps), rid));
-          clearDeepRunId(opts.threadId);
-          deepRunRef.current = null;
+        if (status === "success" || status === "failed" || status === "canceled") {
+          // Terminal → handler TUNGGAL (paritas jalur live, B1): failed = TAHAN runId (kunci
+          // time-travel; kartu "Coba lagi" selamat refresh — mount berikutnya masuk sini lagi),
+          // success/canceled = clear + refresh Sumber/sidebar; semua settle by runId (FE-7).
+          applyDeepTerminal(rid, status, steps, wfState.result);
           return;
         }
         // running / waiting / pending → render progres terkini lalu poll lagi (step-level).
@@ -1153,7 +1320,12 @@ export function useMastraAgent(opts: {
           progressSig = sig;
           progressAt = Date.now();
           setDeepStalled(false);
-        } else if (status === "running" && Date.now() - progressAt >= DEEP_STALL_MS) {
+        } else if (
+          // A3: run bisa beku di `waiting`/`pending` juga (bukan cuma `running`) — snapshot
+          // non-terminal mana pun yang tak maju melewati ambang = macet.
+          (status === "running" || status === "waiting" || status === "pending") &&
+          Date.now() - progressAt >= DEEP_STALL_MS
+        ) {
           setDeepStalled(true);
         }
         // Refresh sumber DUA titik: (1) sekali begitu step search-literature MUNCUL di snapshot —
@@ -1176,12 +1348,27 @@ export function useMastraAgent(opts: {
     };
     // FE-5: `reattachNonce` di-bump saat stream `/deep` putus tapi run masih hidup → effect re-run,
     // poll mengambil alih progres live tanpa menunggu refresh manual.
-  }, [opts.threadId, userId, qc, reattachNonce]);
+  }, [opts.threadId, userId, qc, reattachNonce, applyDeepTerminal, fetchDeepRun]);
+
+  // B1: buang kartu gagal + LEPASKAN kunci pemulihan (run itu tak lagi bisa dipulihkan dari UI).
+  // Dideklarasikan sebelum `regenerate`/`retryDeep` yang memakainya.
+  const dismissDeepFailure = useCallback(() => {
+    setDeepFailed(null);
+    clearDeepRunId(opts.threadId);
+    deepRunRef.current = null;
+  }, [opts.threadId]);
+
+  // B3: tutup kartu alasan bail — murni UI; runId sudah di-clear `applyDeepTerminal` (run success).
+  const dismissDeepNotice = useCallback(() => setDeepNotice(null), []);
 
   const regenerate = useCallback(async () => {
     if (!userId || statusRef.current !== "ready") return;
     const text = lastUserText(stateRef.current.messages);
     if (!text) return;
+    // Regenerate = user MEMILIH debit baru → run failed lama tuntas urusannya. Tanpa ini kartu +
+    // kunci bertahan: kartu bangkit lagi tiap mount (poll membaca runId lama), dan "Coba lagi"
+    // sesudahnya menjalankan run lama sampai selesai → laporan kembar di bawah turn pengganti.
+    if (deepFailed) dismissDeepFailure();
     // FE-8: turn terakhir dikirim SESI INI (`lastSendRef`) → regen memakai konteks aslinya
     // (clientContext hydration @mention/slash + richText ber-pill) dan turn `/deep` di-regen sebagai
     // `/deep`. Teks bubble = `richText ?? text` turn asli, jadi kecocokan diperiksa terhadap itu.
@@ -1250,7 +1437,7 @@ export function useMastraAgent(opts: {
         error: readableApiErrorMessage(err, "Gagal membuat ulang jawaban."),
       }));
     }
-  }, [opts.threadId, userId, sendDeep]);
+  }, [opts.threadId, userId, sendDeep, deepFailed, dismissDeepFailure]);
 
   // DUR-5: mulai ulang run `/deep` macet dari step aktif terakhir (`POST .../restart`, snapshot-based).
   // Aman diulang: debit `deep_research` idempoten (`${runId}:deep`) dan subagent pasca-migrasi
@@ -1267,12 +1454,93 @@ export function useMastraAgent(opts: {
       await run.restart({});
       bumpReattach();
     } catch (err) {
+      // A3: run beku di `pending` tak pernah mulai — `restart()` pasti menolaknya ("This workflow
+      // run was not active" hanya menerima running/waiting). Arahkan user ke aksi yang benar
+      // alih-alih pesan gagal generik.
+      if ((await deepRunStatus(runId)) === "pending") {
+        setState((s) => ({
+          ...s,
+          error: "Run riset ini belum pernah mulai. Hentikan, lalu kirim ulang pertanyaannya.",
+        }));
+        return;
+      }
       setState((s) => ({
         ...s,
         error: readableApiErrorMessage(err, "Gagal memulai ulang riset mendalam."),
       }));
     }
-  }, [opts.threadId, userId]);
+  }, [opts.threadId, userId, deepRunStatus]);
+
+  // B1: ulangi run `/deep` failed MULAI DARI step gagal via time-travel — `restart()` MENOLAK
+  // snapshot `failed` di Mastra 1.47 ("This workflow run was not active"). stepResults lama
+  // dipertahankan dari snapshot → `approve-plan` tak pernah re-eksekusi (debit `${runId}:deep`
+  // tak tersentuh); search yang re-run me-reuse task selesai by `toolCallId` (DUR-7); persist
+  // idempoten via id `deep-report:<runId>`. Chunk retry mengalir ke `consumeWorkflow` (pipeline
+  // live yang sama); turn lama di-revive dulu supaya tak lahir bubble kembar.
+  const retryDeep = useCallback(async () => {
+    const failure = deepFailed;
+    if (!userId || !failure) return;
+    // Paritas send/sendDeep: jangan mulai stream kedua selagi turn lain streaming — chunk workflow
+    // menyasar assistant streaming TERAKHIR (`ensureActiveAssistant`), jadi retry mid-stream akan
+    // me-render step + laporan di dalam bubble chat yang sedang berjalan.
+    if (statusRef.current !== "ready") return;
+    const stepId = failure.stepId;
+    if (!stepId) {
+      // Tanpa target time-travel tak ada jalur pulih — snapshot run failed immutable, membaca ulang
+      // pasti null lagi. Jangan kembalikan kartu yang pasti gagal; buang + arahkan regenerate.
+      dismissDeepFailure();
+      setState((s) => ({
+        ...s,
+        error: "Tidak bisa menentukan langkah yang gagal. Coba buat ulang jawabannya.",
+      }));
+      return;
+    }
+    setDeepFailed(null);
+    const wf = clientRef.current.getWorkflow(DEEP_WORKFLOW_ID);
+    try {
+      const run = (await wf.createRun({
+        runId: failure.runId,
+        resourceId: userId,
+      })) as unknown as DeepRun;
+      deepRunRef.current = run;
+      setDeepRunId(opts.threadId, failure.runId);
+      setState((s) => reviveWorkflowTurn(s, failure.runId));
+      const stream = await run.timeTravelStream({ step: stepId });
+      await consumeWorkflow(stream);
+      maybeReattachAfterStreamClose(failure.runId);
+    } catch (err) {
+      // JANGAN `clearDeepRunIdUnlessAlive` di sini: run failed memang "tak hidup", tapi kuncinya =
+      // jaminan selamat-refresh B1 — error transien (timeTravelStream 502) tak boleh menyapunya.
+      const snap = await fetchDeepRun(failure.runId);
+      const status = snap?.status ?? "";
+      if (status === "running" || status === "suspended" || status === "waiting") {
+        // Masih hidup server-side (mis. retry dari tab lain menang duluan) → poll ambil alih.
+        bumpReattach();
+        return;
+      }
+      if (status === "success" || status === "canceled") {
+        // Dituntaskan dari tempat lain → rekonsiliasi normal (clear + refresh Sumber/sidebar);
+        // snapshot sudah di tangan — jangan fetch `runById` kedua via reconcile.
+        applyDeepTerminal(failure.runId, status, snap?.steps ?? {}, snap?.result);
+        return;
+      }
+      // failed / tak terverifikasi → kembalikan kartu; kunci pemulihan TETAP dipegang.
+      setDeepFailed(failure);
+      setState((s) => ({
+        ...settleWorkflowTurn(s, failure.runId),
+        error: readableApiErrorMessage(err, "Gagal mengulang riset mendalam."),
+      }));
+    }
+  }, [
+    deepFailed,
+    userId,
+    opts.threadId,
+    consumeWorkflow,
+    fetchDeepRun,
+    applyDeepTerminal,
+    dismissDeepFailure,
+    maybeReattachAfterStreamClose,
+  ]);
 
   const stop = useCallback(() => {
     // DUR-6: Stop = user menghentikan pipeline → antrean KLIEN ikut dibuang (auto-kirim setelah
@@ -1280,6 +1548,8 @@ export function useMastraAgent(opts: {
     // biarkan entry-nya; bubble tetap lahir saat runtime menjalankannya.
     setQueuedSends((q) => q.filter((i) => i.serverRunId !== undefined));
     setDeepStalled(false);
+    // Kartu gagal B1 SENGAJA tak disentuh: Stop atas run lain (chat) tak boleh membuang affordance
+    // pemulihan secara senyap — retry/sendDeep/regenerate/dismiss yang mengelolanya sendiri.
     const run = deepRunRef.current;
     if (run) {
       // FE-4: Stop saat `/deep` → cancel RUN WORKFLOW server-side. `subscription.abort()`
@@ -1308,6 +1578,11 @@ export function useMastraAgent(opts: {
     cancelQueued,
     deepStalled,
     restartDeep,
+    deepFailed,
+    retryDeep,
+    dismissDeepFailure,
+    deepNotice,
+    dismissDeepNotice,
     send,
     sendDeep,
     resolvePlan,

--- a/apps/web/features/threads/lib/use-mastra-agent.ts
+++ b/apps/web/features/threads/lib/use-mastra-agent.ts
@@ -1046,6 +1046,7 @@ export function useMastraAgent(opts: {
       // Binding `const` untuk closure di dalam loop (TS melebar `let runId` kembali ke nullable).
       const rid = runId;
       let errors = 0;
+      let sourcesSeeded = false;
       let sourcesRefreshed = false;
       // DUR-5: deteksi run macet — signature progres (status + status tiap step) yang tak berubah
       // selama DEEP_STALL_MS pada status `running` = macet (mis. proses agent restart, snapshot beku
@@ -1155,8 +1156,14 @@ export function useMastraAgent(opts: {
         } else if (status === "running" && Date.now() - progressAt >= DEEP_STALL_MS) {
           setDeepStalled(true);
         }
-        // Sekali, saat search-literature selesai: refresh sumber → kartu per sub-agen terisi
-        // (subQuestionIndex + OG image) walau run masih lanjut ke fase berikutnya.
+        // Refresh sumber DUA titik: (1) sekali begitu step search-literature MUNCUL di snapshot —
+        // rows `research_sources` dipersist DI TENGAH step oleh tool search, jadi kartu sub-agen
+        // hasil seed re-attach langsung terisi (bukan body kosong yang terlihat mengulang dari
+        // nol); (2) sekali lagi saat step selesai → set final (subQuestionIndex + OG image).
+        if (!sourcesSeeded && steps["search-literature"]) {
+          sourcesSeeded = true;
+          void qc.invalidateQueries({ queryKey: queryKeys.threads.sources(opts.threadId) });
+        }
         if (!sourcesRefreshed && steps["search-literature"]?.status === "success") {
           sourcesRefreshed = true;
           void qc.invalidateQueries({ queryKey: queryKeys.threads.sources(opts.threadId) });

--- a/docs/deep-research-audit-2026-07-03.md
+++ b/docs/deep-research-audit-2026-07-03.md
@@ -60,15 +60,15 @@ user pemicu (`precedingUserCreatedAt`).
 
 ---
 
-## Bagian 2 — Potensi stuck & bug step lain (STATUS: OPEN)
+## Bagian 2 — Potensi stuck & bug step lain (STATUS: SEMUA FIXED 2026-07-07, uncommitted, owner E2E)
 
 ### Kelas A — Run bisa macet
 
 | # | Temuan | Severity |
 |---|---|---|
-| A1 | Restart/deploy proses agent mid-run → run beku permanen | **Tinggi** |
-| A2 | Restart di atas task stale → hang tambahan sampai full timeout | Sedang |
-| A3 | Detektor stall buta terhadap status `waiting`/`pending` | Rendah |
+| A1 | Restart/deploy proses agent mid-run → run beku permanen | **Tinggi — FIXED 2026-07-07** |
+| A2 | Restart di atas task stale → hang tambahan sampai full timeout | Sedang — FIXED 2026-07-07 |
+| A3 | Detektor stall buta terhadap status `waiting`/`pending` | Rendah — FIXED 2026-07-07 |
 
 **A1 — Deploy membekukan semua run aktif.** Mastra 1.47 tidak me-resume run `running` setelah
 proses mati (`use-mastra-agent.ts:88` mengakuinya). Pemulihan satu-satunya = user melihat banner
@@ -78,42 +78,112 @@ pemulihan sudah ada (task di-recover saat boot + hasil reuse by `toolCallId`) ta
 tak ikut di-restart → hasil recovery menganggur.
 **Rekomendasi:** sweep saat boot agent — list run `deep-research` status `running` → `restart()`
 otomatis. Murah: step re-run me-reuse task selesai tanpa re-debit.
+**Fix (2026-07-07):** `mastra.getWorkflow("deep-research").restartAllActiveWorkflowRuns()`
+fire-and-forget + catch di `apps/agent/src/mastra/index.ts`. Scoped per-workflow (bukan facade)
+supaya workflow internal Mastra tak ikut tersapu; hanya menyapu `running`+`waiting` (bukan
+`suspended` — gerbang HITL sehat). REVISI pasca code-review: sweep dipicu REQUEST HTTP PERTAMA
+(middleware `bootSweepMiddleware`, once-guard per proses), BUKAN module scope — modul ini juga
+di-import smoke scripts/build/test yang menunjuk DB sama, dan sweep dari proses sekali-jalan
+me-restart run milik user lalu mati di tengah (membekukan ulang, bisa dobel-dispatch). Saat
+request pertama tiba, `registerDeepTaskExecutors` (module scope) + `startWorkers()` deployer
+sudah jalan; run beku selalu tersentuh karena FE poll re-attach memukul server.
 
 **A2 — `waitUntilTerminal` menunggu task stale sampai timeout penuh.** `deep-tasks.ts:153-158`:
 task lama non-terminal → tunggu full `timeoutMs` (600–900 dtk) sebelum dispatch attempt baru.
 Task stale (eksekutor mati, recovery tak menyentuh) membuat klik "mulai ulang" terasa hang
 ~10 menit lagi.
 **Rekomendasi:** cek `updatedAt` task; stale melewati ambang → langsung dispatch attempt baru.
+**Fix (2026-07-07, rekomendasi DIKOREKSI):** `BackgroundTask` TIDAK punya `updatedAt` — anchor
+yang benar = `startedAt ?? createdAt`. `waitUntilTerminal` kini menerima deadline ABSOLUT dari
+`existingTaskDeadline(task, callerTimeoutMs)` = `anchor + task.timeoutMs + margin 30s` (di-cap
+timeout step pemanggil); task stale ber-deadline lampau → wait langsung keluar → dispatch attempt
+baru segera. Hardening pasca code-review: task lama yang melewati deadline TANPA terminal
+di-`manager.cancel()` dulu sebelum attempt baru — task pending di antrean backlog / re-dispatch
+`recoverStaleTasks` (ber-`startedAt` kosong, timer `timed_out` engine baru jalan saat eksekusi
+mulai) bisa masih hidup, dan tanpa cancel keduanya jalan → subagent dobel + debit dobel.
 
 **A3 — Stall banner hanya untuk `running`.** `use-mastra-agent.ts:1156` — run beku di
 `waiting`/`pending` tak pernah memicu banner. Workflow ini tak memakai step waiting hari ini;
 fix gratis (tambahkan status ke kondisi).
+**Fix (2026-07-07):** kondisi stall diperluas ke `running|waiting|pending`; catch `restartDeep`
+kini membedakan run `pending` (`restart()` pasti menolaknya — "not active") → pesan arahan
+"Hentikan, lalu kirim ulang" alih-alih error generik.
 
 ### Kelas B — Bug senyap
 
 | # | Temuan | Severity |
 |---|---|---|
-| B1 | Kegagalan pasca-billing = kredit hangus tanpa jalur pulih | **Tinggi** |
-| B2 | `persistDeepReport` best-effort → laporan bisa hilang setelah refresh | **Tinggi** |
-| B3 | Hasil `bail` (blocked/cancelled) tak pernah sampai ke user | Sedang |
-| B4 | Stop tidak membatalkan background task in-flight | Rendah |
-| B5 | Reuse task tak menjangkau attempt ber-suffix | Rendah |
+| B1 | Kegagalan pasca-billing = kredit hangus tanpa jalur pulih | **Tinggi — FIXED 2026-07-03** |
+| B2 | `persistDeepReport` best-effort → laporan bisa hilang setelah refresh | **Tinggi — FIXED 2026-07-03** |
+| B3 | Hasil `bail` (blocked/cancelled) tak pernah sampai ke user | Sedang — FIXED 2026-07-07 |
+| B4 | Stop tidak membatalkan background task in-flight | Rendah — FIXED 2026-07-07 |
+| B5 | Reuse task tak menjangkau attempt ber-suffix | Rendah — FIXED 2026-07-07 |
 
-**B1 — Kredit hangus saat step pasca-billing gagal permanen.** Setelah debit di `approve-plan`:
-`counter-evidence`/`verify-citations`/`synthesize` gagal melewati `retries: 1`, atau
-`assign-citations` yang TANPA retries (blip DB pun mematikannya) → workflow `failed`. Branch
+**B1 — Kredit hangus saat step pasca-billing gagal permanen. (FIXED 2026-07-03)** Setelah debit
+di `approve-plan`: `counter-evidence`/`verify-citations`/`synthesize` gagal melewati `retries: 1`,
+atau `assign-citations` yang TANPA retries (blip DB pun mematikannya) → workflow `failed`. Branch
 failed FE (`use-mastra-agent.ts:1134`) men-settle turn TANPA pesan error, meng-clear runId,
 tanpa affordance retry (banner restart hanya utk `running`). Satu-satunya jalan user =
-regenerate = DEBIT BARU. Padahal `run.restart()` pada run failed me-reuse semua task selesai
-(nyaris gratis).
-**Rekomendasi:** `retries: 1` di `assign-citations`; branch failed → tampilkan error + TAHAN
-runId + tombol "Coba lagi" → `restart()`.
+regenerate = DEBIT BARU.
 
-**B2 — Laporan hilang bila persist gagal.** `persistDeepReport` (`deep-research.ts:461`)
-best-effort: gagal → run tetap `success`, laporan tampil live dari snapshot, tapi refresh membaca
-history dari `mastra_messages` → laporan LENYAP padahal user bayar penuh.
-**Rekomendasi:** biarkan persist THROW → `retries: 1` synthesize re-run → task
-`${runId}:synthesize` completed di-reuse (tak bayar LLM ulang), hanya persist yang diulang.
+KOREKSI atas rekomendasi awal: `run.restart()` TIDAK bisa dipakai pada run failed —
+`createRestartExecutionParams` (@mastra/core 1.47) melempar `"This workflow run was not active"`
+untuk snapshot ber-status selain `running`/`waiting`, dan step gagal men-persist
+`workflowStatus: "failed"`. Jalur pemulihan yang benar = **`timeTravel`** (hanya menolak snapshot
+`running`; stepResults lama dipertahankan, `snapshot.requestContext` di-merge → identitas
+owner/billing selamat; terekspos client-js 1.28 `run.timeTravelStream({ step })`, route
+`/workflows/:id/time-travel-stream` @mastra/server 1.47).
+
+**Fix:** (1) `retries: 1` di `assign-citations` (murni DB, idempoten — penomoran dihitung ulang
+deterministik lalu overwrite). (2) FE rekonsiliasi terminal SATU titik (`reconcileDeepTerminal`):
+`workflow-finish` tak membawa status (payload cuma `{runId}`) → jalur live baca `runById` sekali,
+rute ke handler yang sama dgn poll. (3) Branch failed (live+poll): TAHAN runId (selamat refresh)
++ state `deepFailed {runId, stepId, message}` (step failed + `steps[id].error` dari snapshot) →
+kartu "Coba lagi"/"Buang" di surface. (4) `retryDeep()` = `timeTravelStream({ step: <failed> })`
+→ `consumeWorkflow` (pipeline live yang sama); turn di-revive dulu (`reviveWorkflowTurn`) agar
+tak lahir bubble kembar. Jaminan uang: time-travel mulai DI step gagal → `approve-plan` tak
+re-eksekusi (debit `${runId}:deep` tak tersentuh); search re-run me-reuse task by `toolCallId`;
+`${runId}:verify` idempoten. `canceled` tetap clear senyap (tindakan user).
+
+**B2 — Laporan hilang bila persist gagal. (FIXED 2026-07-03)** `persistDeepReport`
+(`deep-research.ts:461`) best-effort: gagal → run tetap `success`, laporan tampil live dari
+snapshot, tapi refresh membaca history dari `mastra_messages` → laporan LENYAP padahal user bayar
+penuh. Rekomendasi awal (throw di dalam synthesize) DIREVISI: itu mencampur failure domain LLM
+(mahal, ter-reuse via task) dgn persist DB (murah) — retry granular & observabilitas kabur.
+
+**Fix:** persist dipisah jadi step ke-8 **`persist-report`** (`retries: 2`, failure domain
+sendiri): `synthesize` kini mengembalikan `SynthesizedSchema` (skema akumulatif + report +
+reasoning) TANPA persist; `persistDeepReport` THROW pada kegagalan nyata (guard `!mastra`/
+`!memory` tetap return — constraint environment test) + id pesan DETERMINISTIK
+`deep-report:<runId>` (paritas `deep-user:<runId>`) → retry/time-travel meng-upsert baris yang
+sama, mustahil bubble laporan kembar. Persist gagal permanen → run `failed` di `persist-report`
+→ kartu B1 → "Coba lagi" time-travel HANYA ke step persist (nol biaya LLM, laporan dari
+stepResults snapshot). FE: `persist-report` masuk `WF_STEP_ORDER` + label "Menyimpan laporan";
+laporan tetap dibaca dari output `synthesize` (kontrak `reportFromOutput` tak berubah).
+
+**Hardening pasca-review B1+B2 (code-review xhigh 2026-07-03).** Temuan review atas fix di atas,
+semua diterapkan: (1) rekonsiliasi live yang GAGAL memverifikasi (`runById` blip) tak lagi
+men-clear runId — diserahkan ke poll re-attach (toleran 8×) via `bumpReattach`; (2) catch
+`retryDeep` tak lagi memakai `clearDeepRunIdUnlessAlive` (status `failed` = "tak hidup" → kunci
+tersapu); helper itu sendiri kini MENAHAN kunci untuk status `failed` dan no-op untuk runId
+`undefined` (error start run baru tak menyapu kunci run lama); (3) `retryDeep` ber-guard
+`statusRef !== "ready"` + tombol "Coba lagi" disabled saat busy (chunk retry mid-stream menyasar
+bubble chat yang sedang streaming); (4) guard laporan kosong PINDAH ke `synthesize` (throw) —
+tanpa itu run gagal di validasi input `min(1)` `persist-report` dan time-travel me-replay laporan
+kosong yang sama selamanya (trigger nyata: `deep-tasks` memaksa `text:""` utk hasil task
+malformed); (5) `ensureProjected` kembali best-effort di `persistDeepReport` (kosmetik sidebar;
+`ensureMemoryThread` + `saveMessages` tetap throw); (6) handler terminal poll+live disatukan
+`applyDeepTerminal` (klaim "SATU titik" kini benar — tempat alami B3) + once-guard chunk terminal
+(canceled memancarkan `workflow-canceled` LALU `workflow-finish`); (7) `stop()` tak lagi membuang
+kartu gagal (Stop run chat ≠ keputusan atas run failed); `regenerate` membuang kartu+kunci
+(memilih debit baru = run lama tuntas); (8) `lastTurnMessageIds` kini menghapus turn MENGGANTUNG
+(pesan pasca-assistant-terakhir, mis. `deep-user:<runId>`) — regenerate pasca-failed tak lagi
+menghapus pasangan Q&A sebelumnya; (9) flag TEMP-TEST persist digerbang env
+`AQSHA_E2E_FAIL_PERSIST=1` (prod tanpa env = nol fs I/O; file /tmp nyasar tak bisa mematikan
+persist); (10) `SynthesizedSchema` diramping ke subset yang dikonsumsi persist-report/FE +
+`reviveWorkflowTurn` me-reset `error`. Sisa OPEN (kecil, dicatat saja): recovery failed lintas
+device (discovery mengecualikan `failed`); `createdAt` laporan hasil retry tertunda mengurut
+setelah chat yang lebih baru.
 
 **B3 — `bail` blocked/cancelled = settle senyap.** `bail()` mengakhiri workflow ber-status
 `success`; TIDAK ADA jalur FE yang membaca `result.status`/`reason` (live `workflow-finish`
@@ -121,14 +191,44 @@ mengabaikan payload — `mastra-timeline.ts:775`; branch success poll juga). Kas
 habis → bail di `draft-clarify` SEBELUM `ensureDeepThread` → turn settle senyap, bubble user tak
 dipersist, refresh = thread kosong; user tak pernah tahu alasannya.
 **Rekomendasi:** baca `result` workflow di kedua jalur → render `reason` sebagai error/kartu info.
+**Fix (2026-07-07), dua lapis.** Fakta terverifikasi: engine mem-persist run bail sebagai
+`success` dgn payload di `result` run (dan `runById` client-js MEMBAWA `result` — FE dulu
+membuangnya). (a) FE: `applyDeepTerminal` menerima `result`, `deepNoticeFromResult` → state
+`deepNotice` (hanya `status:"blocked"`; `cancelled` = keputusan user, tetap senyap) → kartu
+info-only "Riset mendalam dihentikan: <reason>" (`DeepRunNoticeCard` kini `secondary` opsional +
+`icon` primary); kedua jalur (poll + live-via-`reconcileDeepTerminal`) lewat satu titik. (b)
+Durable: helper `persistBlockedBail` di ketiga site blocked = `ensureDeepThread` (bubble user
+selamat refresh — site draft-clarify bail SEBELUM gerbang HITL mana pun) + `persistDeepNotice`
+(pesan assistant id deterministik `deep-bail:<runId>`, best-effort, upsert idempoten). Site
+`cancelled` (approve-plan) TIDAK disentuh.
 
 **B4 — `run.cancel()` tidak menghentikan task subagent.** Task in-flight jalan terus sampai
 selesai — tool `search_*` terus men-debit `external_search`. Bocor kecil & bounded;
 `manager.cancel(taskId)` tersedia bila mau ditutup.
+**Fix (2026-07-07):** `abortSignal` step (dipicu `run.cancel()`) di-thread ke `runDeepSubagentTask`
+dari ketiga step task (search/counter/synthesize; + guard empty-retry search). Abort → guard awal
+throw sebelum dispatch; `waitUntilTerminal` men-cancel task lama yang ditunggu; task baru ditutup
+via `handle.cancel()` (listener `abort`, dilepas di `finally`). Batasan JUJUR: kooperatif —
+`agent.generate` in-flight tak menerima signal (args task wajib JSON-serializable), bisa tuntas
+internal lalu hasil dibuang; yang dijamin: record `cancelled`, wait keluar dini, task antre tak
+mulai, debit `search_*` berikutnya berhenti. Hardening pasca code-review: abort yang mendarat
+SELAMA lookup `listTasks` di-cek ulang sebelum `createBackgroundTask` + sesudah `addEventListener`
+(event `abort` pada signal yang SUDAH aborted tak pernah fire — spec WHATWG; tanpa cek ulang task
+tetap lahir + ditunggu full timeout).
 
 **B5 — Dedupe task hanya mencocokkan `toolCallId` dasar.** `deep-tasks.ts:144-149`: attempt
 retry ber-suffix (`:r1:<ts>`) yang BERHASIL tak ditemukan pada restart berikutnya → sub-Q itu
 diriset (dan didebit) ulang. Edge case dari edge case; dicatat saja.
+**Fix (2026-07-07):** lookup kini `listTasks({ runId, orderBy createdAt desc })` + filter klien
+`isAttemptOf` (`=== base || startsWith(base + ":r")` — BUKAN prefix polos: `:empty-retry` kunci
+logis beda, `search:1` tak boleh match `search:10`). Prioritas: completed BER-TEKS terbaru →
+reuse (hardening pasca code-review `completedWithText`: completed ber-`text:""` — turn senyap
+CTX-7 / result malformed — TIDAK di-reuse; tanpa guard ini throw laporan-kosong `synthesize`
+menemukan task "completed" kosong yang sama di tiap retry/time-travel → run gagal PERMANEN
+padahal kredit terdebit); non-terminal terbaru → tunggu (deadline A2, cancel bila lewat); semua
+terminal non-completed / completed kosong → attempt baru ber-suffix. Smoke
+`apps/agent/scripts/smoke-deep-task.ts` diperluas: skenario 2 (reuse suffix B5) + 3 (guard
+abort B4) — PASS.
 
 ### Terverifikasi aman
 
@@ -151,7 +251,12 @@ terpisah.
 
 ## Prioritas pengerjaan (usulan)
 
-1. **B1 + B2** — uang user (kredit hangus / laporan hilang).
-2. **A1** — deploy membekukan run aktif (frekuensinya = frekuensi deploy).
-3. **B3** — kuota habis tak pernah dikomunikasikan.
-4. A2, A3, B4, B5 — menyusul, kecil-kecil.
+1. ~~**B1 + B2** — uang user (kredit hangus / laporan hilang).~~ **DONE 2026-07-03** (lihat fix di atas).
+2. ~~**A1** — deploy membekukan run aktif.~~ **DONE 2026-07-07** (sweep boot per-workflow).
+3. ~~**B3** — kuota habis tak pernah dikomunikasikan.~~ **DONE 2026-07-07** (kartu notice FE +
+   persist durable `deep-bail:<runId>`).
+4. ~~A2, A3, B4, B5 — menyusul, kecil-kecil.~~ **DONE 2026-07-07** (semua; lihat fix per-item).
+
+Verifikasi 2026-07-07: `bun run typecheck` + lint hijau; smoke `smoke-deep-task.ts` 3 skenario
+PASS (Postgres lokal sekali-pakai — VPS dev offline saat itu). Sisa: E2E owner (checklist di plan
+`~/.claude/plans/buat-plan-untuk-implementasi-peaceful-patterson.md`).

--- a/docs/deep-research-audit-2026-07-03.md
+++ b/docs/deep-research-audit-2026-07-03.md
@@ -1,0 +1,157 @@
+# Audit `/deep` (deep-research) — 2026-07-03
+
+Audit dipicu laporan owner atas thread prod `11a29a43-81b0-4a5f-8587-a467902385f3`
+(run `364ac57f-1088-4117-8144-7cd698ac4a28`, tier pro, 02-07 09:20→09:33 UTC, status `success`).
+Bagian 1 = temuan thread tersebut (SUDAH difix). Bagian 2 = hasil sweep lanjutan seluruh step
+Workflow + mesin background-task: potensi stuck & bug yang MASIH TERBUKA.
+
+Referensi kode: `apps/agent/src/mastra/workflows/deep-research.ts` (workflow),
+`apps/agent/src/mastra/workflows/deep-tasks.ts` (background task DUR-7),
+`apps/web/features/threads/lib/use-mastra-agent.ts` (poll/re-attach FE),
+`apps/web/features/threads/lib/mastra-timeline.ts` (reducer/seed FE).
+
+---
+
+## Bagian 1 — Temuan thread prod (STATUS: FIXED 2026-07-03, uncommitted)
+
+### 1.1 Plan rusak → riset jalan dengan 1 sub-question (FIXED)
+
+Bukti DB: output `draft-plan` di snapshot berisi junk `{"name": "deep-research"}{"name":
+"research-education"}` di awal + fence ```json TANPA penutup (persis 1 marker ``` di seluruh
+teks). `parsePlan` fence-regex gagal → fallback SENYAP: `plan` = teks mentah (dgn junk),
+`subQuestions = [pertanyaan mentah]` (1, bukan 5), `domain = general` (harusnya education).
+Terbukti: `research_sources` fase search semua `sub_question_index = 0`.
+
+Akar ganda:
+- Junk `{"name":…}`: `deepWriter` membawa `skills` tapi semua call `toolChoice:"none"` → model
+  "memanggil skill" sebagai teks.
+- Parser manual rapuh (fence wajib tertutup; fallback first-`{`-to-last-`}` mencakup multi-objek).
+
+**Fix:** `draft-plan`/`replan`/`draft-clarify` migrasi ke `structuredOutput` Mastra 1.47
+(`{schema zod, errorStrategy:"strict"}` → `out.object`); `parsePlan`/`parseClarifyQuestions`/
+`PLAN_JSON_CONTRACT` DIHAPUS; kardinalitas (≥2, cap 8) ditegakkan `ensurePlanOutput` di kode
+(bukan `minItems` — dukungan keyword tak seragam di gateway strict-mode); `skills` dicabut dari
+`deepWriter` (astra-lite tetap punya). Escape hatch gateway: `AQSHA_STRUCTURED_OUTPUT_INJECTION=1`
+→ `jsonPromptInjection`. Smoke hijau: `apps/agent/scripts/smoke-structured-plan.ts`.
+
+Sweep konsistensi: dua parser itu = SATU-SATUNYA parsing manual output LLM di repo.
+Dipertahankan by-design: `generateThreadTitle` + `summarizeArticleId` + findings subagent
+(teks memang produknya), `explore/suggest.ts` line-parser (typeahead murah, fast-model tanpa
+jaminan json_schema, soft-fail benign). Konvensi: struktur via response_format/tool-schema;
+prose untuk konsumsi manusia/prompt hilir.
+
+### 1.2 Refresh saat search-literature terlihat "reset" (FIXED — UI-only)
+
+Bukti DB: workflow TIDAK re-run (tiap step 1× `startedAt`, 0 URL duplikat di sources).
+Yang hilang = rekonstruksi FE: detail step hanya dari `output` (baru ada saat step selesai),
+progres per-subQ stream-only, invalidasi sources digerbang `status === "success"` padahal rows
+ditulis DI TENGAH step (bukti: 09:22:38–58, step selesai 09:25:57).
+
+**Fix:** `runningSearchDetail` men-seed kartu sub-agen dari output `approve-plan`/`draft-plan`
+saat step running tanpa output (guard `prev ?? planned`); invalidasi sources dua titik di poll
+re-attach (saat step muncul + saat success).
+
+### 1.3 Timer reset ke 0 saat refresh (FIXED)
+
+`ElapsedLabel` menghitung dari mount. **Fix:** prop `startedAt` durable (dihitung per-render,
+aman tiba terlambat, clamp ≥0); anchor `/deep` = `steps[id].startedAt` snapshot (semua varian
+`StepResult` Mastra membawanya, termasuk `StepRunning`); anchor chat normal = `createdAt` pesan
+user pemicu (`precedingUserCreatedAt`).
+
+---
+
+## Bagian 2 — Potensi stuck & bug step lain (STATUS: OPEN)
+
+### Kelas A — Run bisa macet
+
+| # | Temuan | Severity |
+|---|---|---|
+| A1 | Restart/deploy proses agent mid-run → run beku permanen | **Tinggi** |
+| A2 | Restart di atas task stale → hang tambahan sampai full timeout | Sedang |
+| A3 | Detektor stall buta terhadap status `waiting`/`pending` | Rendah |
+
+**A1 — Deploy membekukan semua run aktif.** Mastra 1.47 tidak me-resume run `running` setelah
+proses mati (`use-mastra-agent.ts:88` mengakuinya). Pemulihan satu-satunya = user melihat banner
+stall (muncul setelah `DEEP_STALL_MS` 300 dtk) lalu klik restart; user menutup tab → beku
+selamanya. Deploy Dokploy = restart container → SEMUA run /deep aktif beku tiap deploy. Fondasi
+pemulihan sudah ada (task di-recover saat boot + hasil reuse by `toolCallId`) tapi workflow induk
+tak ikut di-restart → hasil recovery menganggur.
+**Rekomendasi:** sweep saat boot agent — list run `deep-research` status `running` → `restart()`
+otomatis. Murah: step re-run me-reuse task selesai tanpa re-debit.
+
+**A2 — `waitUntilTerminal` menunggu task stale sampai timeout penuh.** `deep-tasks.ts:153-158`:
+task lama non-terminal → tunggu full `timeoutMs` (600–900 dtk) sebelum dispatch attempt baru.
+Task stale (eksekutor mati, recovery tak menyentuh) membuat klik "mulai ulang" terasa hang
+~10 menit lagi.
+**Rekomendasi:** cek `updatedAt` task; stale melewati ambang → langsung dispatch attempt baru.
+
+**A3 — Stall banner hanya untuk `running`.** `use-mastra-agent.ts:1156` — run beku di
+`waiting`/`pending` tak pernah memicu banner. Workflow ini tak memakai step waiting hari ini;
+fix gratis (tambahkan status ke kondisi).
+
+### Kelas B — Bug senyap
+
+| # | Temuan | Severity |
+|---|---|---|
+| B1 | Kegagalan pasca-billing = kredit hangus tanpa jalur pulih | **Tinggi** |
+| B2 | `persistDeepReport` best-effort → laporan bisa hilang setelah refresh | **Tinggi** |
+| B3 | Hasil `bail` (blocked/cancelled) tak pernah sampai ke user | Sedang |
+| B4 | Stop tidak membatalkan background task in-flight | Rendah |
+| B5 | Reuse task tak menjangkau attempt ber-suffix | Rendah |
+
+**B1 — Kredit hangus saat step pasca-billing gagal permanen.** Setelah debit di `approve-plan`:
+`counter-evidence`/`verify-citations`/`synthesize` gagal melewati `retries: 1`, atau
+`assign-citations` yang TANPA retries (blip DB pun mematikannya) → workflow `failed`. Branch
+failed FE (`use-mastra-agent.ts:1134`) men-settle turn TANPA pesan error, meng-clear runId,
+tanpa affordance retry (banner restart hanya utk `running`). Satu-satunya jalan user =
+regenerate = DEBIT BARU. Padahal `run.restart()` pada run failed me-reuse semua task selesai
+(nyaris gratis).
+**Rekomendasi:** `retries: 1` di `assign-citations`; branch failed → tampilkan error + TAHAN
+runId + tombol "Coba lagi" → `restart()`.
+
+**B2 — Laporan hilang bila persist gagal.** `persistDeepReport` (`deep-research.ts:461`)
+best-effort: gagal → run tetap `success`, laporan tampil live dari snapshot, tapi refresh membaca
+history dari `mastra_messages` → laporan LENYAP padahal user bayar penuh.
+**Rekomendasi:** biarkan persist THROW → `retries: 1` synthesize re-run → task
+`${runId}:synthesize` completed di-reuse (tak bayar LLM ulang), hanya persist yang diulang.
+
+**B3 — `bail` blocked/cancelled = settle senyap.** `bail()` mengakhiri workflow ber-status
+`success`; TIDAK ADA jalur FE yang membaca `result.status`/`reason` (live `workflow-finish`
+mengabaikan payload — `mastra-timeline.ts:775`; branch success poll juga). Kasus terburuk: kuota
+habis → bail di `draft-clarify` SEBELUM `ensureDeepThread` → turn settle senyap, bubble user tak
+dipersist, refresh = thread kosong; user tak pernah tahu alasannya.
+**Rekomendasi:** baca `result` workflow di kedua jalur → render `reason` sebagai error/kartu info.
+
+**B4 — `run.cancel()` tidak menghentikan task subagent.** Task in-flight jalan terus sampai
+selesai — tool `search_*` terus men-debit `external_search`. Bocor kecil & bounded;
+`manager.cancel(taskId)` tersedia bila mau ditutup.
+
+**B5 — Dedupe task hanya mencocokkan `toolCallId` dasar.** `deep-tasks.ts:144-149`: attempt
+retry ber-suffix (`:r1:<ts>`) yang BERHASIL tak ditemukan pada restart berikutnya → sub-Q itu
+diriset (dan didebit) ulang. Edge case dari edge case; dicatat saja.
+
+### Terverifikasi aman
+
+- `verify-citations` tak bisa hang di network: Crossref/OpenAlex/arXiv semua via `fetchWithRetry`
+  + `AbortSignal.timeout` (`packages/services/src/papers/http.ts`).
+- Semua debit idempoten per-run (`${runId}:deep`, `${runId}:verify`) → restart tak double-charge.
+- Isolasi per-sub-Q `search-literature` (CFG-4) → step tak pernah melempar; guard teks-kosong +
+  gap jujur ke sintesis.
+- `emitDetail`/`ensureDeepThread`/`subQuestionSources` best-effort — tak bisa mematikan run.
+- Wiring recovery task engine benar: `backgroundTasks.enabled` + `registerDeepTaskExecutors`
+  saat boot (`apps/agent/src/mastra/index.ts:93`).
+
+### Temuan sampingan
+
+`mastra_workflow_snapshot` prod berisi 625 baris `__mastra_notification_dispatcher` (1 baris/menit
+dari scheduler internal Mastra) vs 1 baris deep-research — polusi tabel, layak dibersihkan/di-cap
+terpisah.
+
+---
+
+## Prioritas pengerjaan (usulan)
+
+1. **B1 + B2** — uang user (kredit hangus / laporan hilang).
+2. **A1** — deploy membekukan run aktif (frekuensinya = frekuensi deploy).
+3. **B3** — kuota habis tak pernah dikomunikasikan.
+4. A2, A3, B4, B5 — menyusul, kecil-kecil.


### PR DESCRIPTION
## Ringkasan

Menuntaskan ketahanan run `/deep` (deep research) end-to-end plus perbaikan responsif composer/landing. Tiga alur kerja:

1. **Rencana `/deep` via `structuredOutput` strict + re-attach durable** (`e7fb50a`, sudah ada sebelumnya) — parsePlan manual → `structuredOutput` strict; re-attach seed kartu mid-step; anchor `startedAt` untuk `ElapsedLabel`.
2. **Audit deep research Bagian 2 — A1-A3 anti-macet + B1-B5 recovery** (`dedfdbb`).
3. **Palette slash/mention mobile + rapikan responsif landing** (`14a884b`).

## Audit Bagian 2 — Kelas A (run bisa macet)

- **A1** Boot sweep run beku via `getWorkflow("deep-research").restartAllActiveWorkflowRuns()` fire-and-forget, dipicu **request HTTP pertama** (`bootSweepMiddleware`, once-guard per proses) — bukan module scope, supaya proses smoke/build/test yang menunjuk DB sama tak ikut me-restart run milik user lalu mati di tengah. Scoped per-workflow (bukan facade) agar workflow internal Mastra tak tersapu; hanya `running`+`waiting` (bukan `suspended` — gerbang HITL sehat).
- **A2** `existingTaskDeadline` (anchor `startedAt ?? createdAt` + `timeoutMs` + margin) — task stale tak lagi hang full timeout ~10 menit; task lewat deadline di-`cancel` dulu sebelum attempt baru (anti subagent + debit dobel). Catatan: `BackgroundTask` tak punya `updatedAt` (koreksi rekomendasi audit).
- **A3** Detektor stall mencakup `running|waiting|pending`; `restartDeep` membedakan run `pending` (restart pasti menolak "run belum aktif") → arahkan user hentikan + kirim ulang.

## Audit Bagian 2 — Kelas B (bug senyap)

- **B1** Run `failed` pasca-billing → **tahan `runId`** (kunci pemulihan, selamat refresh) + kartu **"Coba lagi"** via `timeTravelStream` dari step gagal (tanpa debit baru). `reviveWorkflowTurn` anti bubble kembar; `applyDeepTerminal` = handler terminal tunggal (jalur live + poll re-attach).
- **B2** `persist-report` menjadi **step terpisah** (`retries: 2`, id deterministik `deep-report:<runId>`) — laporan tak lagi lenyap senyap saat persist gagal; `synthesize` gagal di teks kosong (bukan reuse completed kosong selamanya).
- **B3** Bail `blocked` (kuota/akses) → `persistBlockedBail` (thread + `deep-bail:<runId>`) + kartu `deepNotice` (ditekan bila bubble persisted sudah ada di timeline).
- **B4** `abortSignal` kooperatif diteruskan ke `runDeepSubagentTask` — Stop menutup background task in-flight (cancel + throw sebelum dispatch untuk signal yang sudah aborted).
- **B5** `isAttemptOf` reuse attempt ber-suffix `:r<N>:<ts>` (bukan prefix polos); `completedWithText` menolak reuse completed kosong.

`scripts/smoke-deep-task.ts`: 3 skenario (reuse by base, B5 suffix completed, B4 abort sebelum dispatch). `docs/deep-research-audit-2026-07-03.md` diperbarui: A1-A3 + B1-B5 ditandai FIXED dengan catatan koreksi.

## Palette mobile + responsif

- `tokenized-prompt-input`: saat mobile, `PopoverAnchor` `virtualRef` di-swap ke shell composer → palette selebar & center (`align="center"` + `w-[--radix-popover-trigger-width]`); desktop tetap anchor ke wrapper editor. Anchor selalu virtual (render null) agar wrapper editor tak remount lintas breakpoint.
- `composer`: teruskan `composerShellRef` sebagai `mobilePaletteAnchorRef`.
- `home-banner-carousel`: thumbnail + gap slide lebih ringkas di layar sempit.
- `explore-handwritten-cue`: sembunyikan cue `< sm` (di layar sempit menabrak header + hero).

## Verifikasi

- `bun run typecheck` seluruh workspace → **PASS** (exit 0).
- React Doctor: 2 warning a11y di `tokenized-prompt-input` (`role="textbox"` + `onMouseOver`) = **pre-existing** yang muncul karena baris ter-reindent; benar untuk rich `contentEditable` editor ber-chip — bukan regresi.

## Catatan owner

- Status keseluruhan: **owner E2E** (per catatan implementasi).
- ⚠️ `persist-report` masih memuat **TEMP-TEST E2E** di balik env `AQSHA_E2E_FAIL_PERSIST=1` + file flag `/tmp/aqsha-fail-persist` (nol I/O tanpa env; untuk uji recovery B1/B2). **Hapus setelah uji E2E B1/B2 selesai.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)