### PR TITLE
feat: evidence visualization untuk laporan /deep

### DIFF
--- a/apps/agent/src/mastra/workflows/deep-research.ts
+++ b/apps/agent/src/mastra/workflows/deep-research.ts
@@ -4,6 +4,16 @@ import {
   normalizeAskQuestions,
   type AskQuestion,
 } from "@aqsha/chat-core";
+import {
+  DEEP_VIZ_CLASSIFIED_STANCES,
+  DEEP_VIZ_STUDY_DESIGNS,
+  buildDeepVizBlocks,
+  deepVizBlockSchema,
+  formatDeepAnalyzeSummary,
+  injectVizBlocks,
+  type DeepVizBlock,
+  type DeepVizSourceInput,
+} from "@aqsha/chat-core/deep-viz";
 import { BillingService } from "@aqsha/services/billing";
 import { ThreadService, TitleService } from "@aqsha/services/chat";
 import { estimateCredits } from "@aqsha/services/plan";
@@ -48,9 +58,9 @@ import { effectiveBilledTier, liteProviderOptions, proProviderOptions } from "..
  *
  *   draftClarify (kuota + nilai klarifikasi) → clarify (HITL ask_questions, opsional) → draftPlan
  *   → approvePlan (HITL suspend/resume + gerbang billing) → searchLiterature → counterEvidence
- *   → verifyCitations → synthesize → persistReport
+ *   → assignCitations → analyzeSources (evidence viz) → verifyCitations → synthesize → persistReport
  *
- * Keputusan desain (deviasi sah dari §7 plan, dicatat):
+ * Keputusan desain (deviasi yang disengaja dari rancangan awal, dicatat):
  * - **Fan-out di dalam `searchStep`** (Promise.all per sub-pertanyaan) alih-alih builder
  *   `.foreach`. Rantai linear `.then` menjaga konteks (question/plan) mengalir utuh tanpa
  *   `.map`/`getStepResult` dan tetap observable per fase. Per-sub-pertanyaan paralel.
@@ -90,7 +100,7 @@ const ClarifiedSchema = InputSchema.extend({
 });
 
 /**
- * Domain-pack metodologi untuk sintesis (CFG-2): dipilih planner di `draft-plan`, dipakai
+ * Domain-pack metodologi untuk sintesis: dipilih planner di `draft-plan`, dipakai
  * `synthesize` untuk meng-inline skill `research-<domain>` ke prompt (langkah sintesis berjalan
  * `toolChoice:"none"` sehingga tool skill tak bisa dipanggil di sana).
  */
@@ -105,13 +115,13 @@ const PlanSchema = z.object({
     .max(8)
     .describe("3-6 sub-pertanyaan riset yang diturunkan dari rencana."),
   domain: ResearchDomainSchema.default("general").describe(
-    "Domain-pack metodologi yang di-inline ke prompt sintesis (CFG-2).",
+    "Domain-pack metodologi yang di-inline ke prompt sintesis.",
   ),
 });
 
 const EvidenceItemSchema = z.object({
   subQuestion: z.string(),
-  findings: z.string().describe("Temuan bukti dari literature-searcher (TANPA [n]; identifikasi via DOI/arXiv/URL — penomoran global di assign-citations, CTX-1)."),
+  findings: z.string().describe("Temuan bukti dari literature-searcher (TANPA [n]; identifikasi via DOI/arXiv/URL — penomoran global di assign-citations)."),
 });
 
 const PlannedSchema = InputSchema.extend(PlanSchema.shape);
@@ -126,7 +136,7 @@ const NumberedSourceSchema = z.object({
   origin: z.string(),
   snippet: z.string().optional(),
 });
-/** Referensi terstruktur per `[n]` unik — bahan `CitationService.verifyIdentifiers` langsung (IMP-5). */
+/** Referensi terstruktur per `[n]` unik — bahan `CitationService.verifyIdentifiers` langsung. */
 const VerifyRefSchema = z.object({
   citation: z.number(),
   title: z.string(),
@@ -144,11 +154,31 @@ const CitedSchema = CounteredSchema.extend({
     .describe("Sumber bernomor terstruktur → dipersist di metadata laporan (fallback Sumber FE)."),
   verifyRefs: z
     .array(VerifyRefSchema)
-    .describe("Referensi terstruktur per [n] unik → verify-citations panggil CitationService langsung (IMP-5)."),
+    .describe("Referensi terstruktur per [n] unik → verify-citations panggil CitationService langsung."),
 });
-const VerifiedSchema = CitedSchema.extend({ verification: z.string() });
 /**
- * Hasil sintesis → step `persist-report` (failure domain persist terpisah, B2). SUBSET yang
+ * Hasil analisis bukti (step `analyze-sources`, evidence viz): blok visual deterministik yang
+ * memenuhi ambang minimum data + jumlah unit terklasifikasi (bahan panel proses).
+ * Best-effort total: step gagal → `vizBlocks: []` dan laporan tampil polos seperti sebelumnya.
+ * `.default(...)` WAJIB: snapshot run yang dimulai sebelum field ini ada (restart boot-sweep
+ * maupun pemulihan time-travel "Coba lagi") tak memuat keduanya — tanpa default, validasi
+ * input step baru menolak run lama selamanya.
+ */
+const AnalyzedSchema = CitedSchema.extend({
+  vizBlocks: z
+    .array(deepVizBlockSchema)
+    .default([])
+    .describe(
+      "Blok visual berbasis bukti (chat-core `deep-viz`, deterministik) yang lolos ambang — [] bila analisis gagal/kurang data.",
+    ),
+  analyzedSourceCount: z
+    .number()
+    .default(0)
+    .describe("Jumlah unit sumber (pasangan [n]×sub-pertanyaan) yang berhasil diklasifikasikan."),
+});
+const VerifiedSchema = AnalyzedSchema.extend({ verification: z.string() });
+/**
+ * Hasil sintesis → step `persist-report` (failure domain persist terpisah). SUBSET yang
  * dikonsumsi persist-report + FE saja — korpus bukti (evidence/verifyRefs/question/context) sudah
  * tersimpan di output step-step sebelumnya; mengangkutnya lagi hanya menggemukkan snapshot dan
  * chunk `workflow-step-result` yang dikirim ke browser tepat saat user menunggu laporan.
@@ -162,6 +192,8 @@ const SynthesizedSchema = VerifiedSchema.pick({
   verification: true,
   numberedInventory: true,
   numberedSources: true,
+  vizBlocks: true,
+  analyzedSourceCount: true,
 }).extend({
   report: z.string().min(1).describe("Laporan tercitasi hasil penulis sintesis."),
   reasoning: z
@@ -178,7 +210,7 @@ const OutputSchema = z.object({
   reasoning: z
     .string()
     .optional()
-    .describe("Ringkasan penalaran penulis sintesis (Route B) → blok reasoning FE saat refresh poll."),
+    .describe("Ringkasan penalaran penulis sintesis → blok reasoning FE saat refresh poll."),
 });
 
 type Planned = z.infer<typeof PlannedSchema>;
@@ -191,7 +223,7 @@ type Verified = z.infer<typeof VerifiedSchema>;
  * Tanam threadId chat + run id deep (`AQSHA_DEEP_RUN_KEY`) ke RequestContext sebelum memanggil
  * subagent. Tool riset membaca `MASTRA_THREAD_ID_KEY` (lewat `threadScopeId`) untuk men-scope
  * `research_sources` + RAG, dan menstempel `research_sources.turnId = runId` (semua sumber satu run
- * berbagi turn) → penomoran sitasi `[n]` global + dedupe (G4). Owner/email yang sudah ada di rc tetap
+ * berbagi turn) → penomoran sitasi `[n]` global + dedupe. Owner/email yang sudah ada di rc tetap
  * terbawa (callerId/callerEmail subagent valid). Dipakai di step yang memanggil subagent ber-tool riset.
  */
 function withDeepRun(
@@ -260,8 +292,10 @@ type StepDetailEmit =
     }
   | { kind: "counter"; text: string }
   | { kind: "citations"; count: number }
+  /** Analisis bukti (step `analyze-sources`): status awal + ringkasan akhir (unit terklasifikasi, blok layak). */
+  | { kind: "analyze"; text: string }
   | { kind: "verify"; text: string }
-  /** Ringkasan penalaran penulis sintesis (`out.reasoningText`) → blok "reasoning" FE (Route B). */
+  /** Ringkasan penalaran penulis sintesis (`out.reasoningText`) → blok "reasoning" FE. */
   | { kind: "reasoning"; text: string };
 
 async function emitDetail(writer: StepWriter, data: StepDetailEmit): Promise<void> {
@@ -327,7 +361,7 @@ async function ensureMemoryThread(
  * Bangun satu pesan Mastra Memory (format V2) untuk `saveMessages` dari jalur Workflow `/deep`, yang
  * menulis pesan LANGSUNG ke memory thread di luar turn agent (pertanyaan user di plan-gate, laporan
  * akhir di sintesis). `metadata` (mis. `{ deepRunId }`) menempel di `content` agar FE memetakan Sumber
- * per-turn (G4).
+ * per-turn.
  */
 function buildMastraMessage(args: {
   role: "user" | "assistant";
@@ -372,7 +406,7 @@ function buildMastraMessage(args: {
  * Proyeksikan thread chat + persist pertanyaan user SEDINI gerbang HITL pertama (sebelum `suspend`).
  * Jalur `/deep` = Workflow yang dijalankan FE (bukan turn agent) → `threadProjectionProcessor` TAK
  * jalan, jadi tanpa ini `chat_threads` kosong → halaman thread "Akses ditolak" saat refresh di
- * clarify/plan-gate/riset (G1/TC13), dan thread tak muncul di sidebar. Pesan user memakai id
+ * clarify/plan-gate/riset, dan thread tak muncul di sidebar. Pesan user memakai id
  * DETERMINISTIK (`deep-user:<runId>`) → aman dipanggil >1× per run (clarify-gate LALU plan-gate):
  * `saveMessages` meng-upsert baris yang sama, bukan bubble kembar. Best-effort: kegagalan tak
  * menggagalkan run.
@@ -427,10 +461,10 @@ async function ensureDeepThread(
 /**
  * Persist laporan akhir (assistant) ke memory thread chat (`mastra_messages`) lewat agent `astra-lite`.
  * Disimpan VERBATIM (fidelitas sitasi `[n]`) + `metadata.deepRunId = runId` agar FE memetakan Sumber
- * per-turn (G4). Pertanyaan user sudah dipersist di `ensureDeepThread` (plan-gate) → JANGAN ulang di sini
+ * per-turn. Pertanyaan user sudah dipersist di `ensureDeepThread` (plan-gate) → JANGAN ulang di sini
  * (anti bubble kembar). Preview thread diperbarui ke laporan.
  *
- * THROW saat persist gagal (audit B2): laporan yang tak tersimpan = produk berbayar LENYAP saat
+ * THROW saat persist gagal: laporan yang tak tersimpan = produk berbayar LENYAP saat
  * refresh (history dibaca dari `mastra_messages`) — bukan side-effect opsional yang boleh ditelan.
  * Pemanggil = step `persist-report` ber-`retries`; id pesan deterministik `deep-report:<runId>`
  * membuat retry/time-travel meng-upsert baris yang SAMA (tak pernah bubble laporan kembar). Guard
@@ -447,7 +481,7 @@ async function persistDeepReport(
     reasoning?: string;
     runId: string;
     agentKind: AgentKind;
-    /** Jejak proses untuk rehydrate (FE bangun ulang langkah + detail saat refresh/riwayat, G7). */
+    /** Jejak proses untuk rehydrate (FE bangun ulang langkah + detail saat refresh/riwayat). */
     deepProcess?: Record<string, unknown>;
   },
 ): Promise<void> {
@@ -494,7 +528,7 @@ async function persistDeepReport(
 }
 
 /**
- * B3(b): persist alasan bail `blocked` sebagai pesan assistant — id deterministik
+ * Persist alasan bail `blocked` sebagai pesan assistant — id deterministik
  * `deep-bail:<runId>` (paritas `deep-report:<runId>`) → upsert idempoten, tak mungkin kembar.
  * Tanpa ini alasan hanya hidup di kartu notice sesi FE; refresh membaca history dari
  * `mastra_messages` dan kehilangan konteks kenapa run berhenti. BEST-EFFORT keseluruhan (beda
@@ -533,7 +567,7 @@ async function persistDeepNotice(
 }
 
 /**
- * B3(b): efek durable SEBELUM bail `blocked` (kuota/akses) — satu helper untuk ketiga site.
+ * Efek durable SEBELUM bail `blocked` (kuota/akses) — satu helper untuk ketiga site.
  * (1) `ensureDeepThread` (idempoten `deep-user:<runId>`) — site draft-clarify bisa bail sebelum
  * gerbang HITL mana pun memproyeksikan thread → tanpa ini refresh = thread kosong; (2)
  * `persistDeepNotice` — alasannya ikut tersimpan. Site `cancelled` (user menolak rencana)
@@ -577,8 +611,8 @@ function parseCitationCount(numberedInventory: string): number {
 // ── Prompt builders ────────────────────────────────────────────────────────────────────
 
 /**
- * Skema WIRE rencana untuk `structuredOutput` native (audit prod 2026-07-03: parser fence manual
- * gagal SENYAP — fence tak tertutup + junk `{"name":…}` → riset jalan dgn 1 sub-question fallback).
+ * Skema WIRE rencana untuk `structuredOutput` native — menggantikan parser fence manual yang di
+ * produksi gagal SENYAP (fence tak tertutup + junk `{"name":…}` → riset jalan dgn 1 sub-question fallback).
  * Sengaja TANPA constraint numerik (`minItems`/`minLength`): dukungan keyword itu tak seragam pada
  * gateway OpenAI-compatible mode strict; kardinalitas ditegakkan `ensurePlanOutput` di kode.
  */
@@ -637,7 +671,7 @@ function planPrompt(input: z.infer<typeof InputSchema>): string {
 }
 
 /**
- * Prompt re-derive rencana setelah edit plan-gate (CFG-3): edit user harus MENGUBAH
+ * Prompt re-derive rencana setelah edit plan-gate: edit user harus MENGUBAH
  * `subQuestions` yang benar-benar diriset, bukan hanya ditempel sebagai prosa untuk writer akhir.
  */
 function replanPrompt(input: Planned, edits: string): string {
@@ -677,7 +711,7 @@ function clarifyPrompt(input: z.infer<typeof InputSchema>): string {
 }
 
 function searcherPrompt(subQuestion: string, input: Planned): string {
-  return `Topik riset utama: ${input.question}\n\nSub-pertanyaan yang HARUS kamu jawab dengan literatur:\n${subQuestion}\n\nCari bukti terkuat dan kembalikan tiap sumber berguna dengan: judul, identifier (DOI/arXiv/URL), penulis + tahun bila tersedia, extract bukti 2-4 kalimat, dan rating kekuatan. JANGAN menomori sumber dan JANGAN menulis penanda [n] — penomoran sitasi global dilakukan belakangan (CTX-1).`;
+  return `Topik riset utama: ${input.question}\n\nSub-pertanyaan yang HARUS kamu jawab dengan literatur:\n${subQuestion}\n\nCari bukti terkuat dan kembalikan tiap sumber berguna dengan: judul, identifier (DOI/arXiv/URL), penulis + tahun bila tersedia, extract bukti 2-4 kalimat, dan rating kekuatan. JANGAN menomori sumber dan JANGAN menulis penanda [n] — penomoran sitasi global dilakukan belakangan.`;
 }
 
 function counterPrompt(input: Searched): string {
@@ -687,9 +721,151 @@ function counterPrompt(input: Searched): string {
   return `Inventaris bukti yang kesimpulannya sedang terbentuk untuk topik "${input.question}":\n\n${inventory}\n\nCari bukti yang MELEMAHKAN atau menentang kesimpulan-kesimpulan di atas. Laporkan jujur bila tak ada.`;
 }
 
+// ── Analisis bukti (evidence viz) — wire schema + prompt step `analyze-sources` ─────────
+
+/**
+ * Stance/design wire — diderivasi dari const chat-core `deep-viz` supaya vocab tak bisa
+ * drift dari builder viz; CHECK kolom `research_sources` menyalin daftar yang sama
+ * (dijaga test sinkronisasi di `packages/services`).
+ */
+const AnalyzeStanceSchema = z.enum(DEEP_VIZ_CLASSIFIED_STANCES);
+const AnalyzeDesignSchema = z.enum(DEEP_VIZ_STUDY_DESIGNS);
+
+/**
+ * Skema WIRE klasifikasi per unit `[n]×subQ`. Paritas `PlanOutputSchema`: TANPA constraint
+ * numerik (`min`/`max`) — dukungan keyword strict-mode tak seragam di gateway; integer/range
+ * disanitasi di kode (unit di luar inventaris dibuang).
+ */
+const AnalyzeInsightSchema = z.object({
+  n: z.number().describe("Nomor sitasi [n] unit — PERSIS dari daftar unit."),
+  subQuestionIndex: z.number().describe("Index sub-pertanyaan unit (0-based) — PERSIS dari daftar unit."),
+  stance: AnalyzeStanceSchema.describe(
+    "Posisi TEMUAN paper terhadap sub-pertanyaan unit (bukan opini penulis): ragu → mixed; tidak menjawab sub-pertanyaan → not_applicable.",
+  ),
+  studyDesign: AnalyzeDesignSchema.describe("Desain studi paper (tebakan terbaik dari judul+snippet)."),
+  outcomes: z
+    .array(z.string())
+    .describe("Maksimal 3 outcome/variabel utama yang diukur paper (frasa pendek, bahasa Indonesia, lowercase)."),
+});
+
+const AnalyzeChunkOutputSchema = z.object({
+  insights: z
+    .array(AnalyzeInsightSchema)
+    .describe("Satu entri per unit dari daftar unit — jangan mengarang unit di luar daftar."),
+});
+
+/**
+ * Chunk PERTAMA sekalian membawa penilaian global (answerable/claims/openQuestions) — hemat satu
+ * panggilan; chunk berikutnya memakai `AnalyzeChunkOutputSchema` (insights saja). Kardinalitas
+ * (3-6 klaim, 2-4 pertanyaan) ditegakkan builder chat-core, bukan skema wire.
+ */
+const AnalyzeFullOutputSchema = AnalyzeChunkOutputSchema.extend({
+  subQuestionAnswerable: z.array(
+    z.object({
+      subQuestionIndex: z.number(),
+      answerable: z
+        .boolean()
+        .describe("true HANYA bila sub-pertanyaan berbentuk dapat dijawab ya/tidak (mis. \"apakah X efektif?\")."),
+    }),
+  ),
+  claims: z
+    .array(
+      z.object({
+        text: z.string().describe("Klaim faktual ringkas (1 kalimat)."),
+        reasoning: z.string().describe("Alasan singkat kenapa bukti mendukung klaim ini."),
+        papers: z.array(z.number()).describe("Nomor sitasi [n] pendukung — HANYA dari inventaris."),
+      }),
+    )
+    .describe("3-6 klaim utama yang jujur terhadap bukti + bukti tandingan."),
+  openQuestions: z
+    .array(
+      z.object({
+        question: z.string(),
+        why: z.string().describe("Mengapa pertanyaan ini penting dan masih terbuka."),
+      }),
+    )
+    .describe("2-4 pertanyaan riset terbuka, dipandu bukti tandingan + celah bukti."),
+});
+
+/** Satu unit klasifikasi = pasangan unik `[n] × subQuestionIndex` + baris DB pemiliknya. */
+type AnalyzeUnit = {
+  n: number;
+  subQuestionIndex: number;
+  /** Id baris `research_sources` unit ini (bisa >1 — duplikat paper sama; semuanya di-update). */
+  rowIds: string[];
+  title: string;
+  snippet: string;
+  year: number | null;
+  venue: string | null;
+  evidenceStrength: "strong" | "medium" | "weak";
+};
+
+function analyzeUnitList(units: AnalyzeUnit[]): string {
+  return units
+    .map((u) => {
+      const meta = [u.year !== null ? String(u.year) : null, u.venue].filter(Boolean).join("; ");
+      return `- (n=${u.n}, subQ=${u.subQuestionIndex}) ${u.title}${meta ? ` (${meta})` : ""} [${u.evidenceStrength}] — ${u.snippet}`;
+    })
+    .join("\n");
+}
+
+/** Prompt klasifikasi satu chunk unit (dipakai SEMUA panggilan analisis). */
+function analyzeChunkPrompt(input: z.infer<typeof CitedSchema>, units: AnalyzeUnit[]): string {
+  const subs = input.subQuestions.map((q, i) => `${i}. ${q}`).join("\n");
+  return `Pertanyaan riset utama:\n${input.question}\n\nSub-pertanyaan (index 0-based):\n${subs}\n\nUnit sumber yang HARUS diklasifikasikan (satu entri \`insights\` per unit; \`n\` dan \`subQuestionIndex\` PERSIS seperti tertulis):\n${analyzeUnitList(units)}\n\nUntuk tiap unit: \`stance\` = posisi TEMUAN paper terhadap sub-pertanyaan unit itu, berdasar judul + abstrak/snippet (ragu → mixed; tidak menjawab sub-pertanyaan → not_applicable). \`studyDesign\` = desain studi. \`outcomes\` = maksimal 3 outcome/variabel utama yang diukur. JANGAN mengarang unit di luar daftar.`;
+}
+
+/** Seksi tambahan panggilan PERTAMA: penilaian global (answerable, claims, open questions). */
+function analyzeGlobalPrompt(input: z.infer<typeof CitedSchema>): string {
+  return `Selain klasifikasi unit di atas, nilai juga tingkat riset keseluruhan.\n\nInventaris sumber bernomor lengkap:\n${input.numberedInventory}\n\nBukti tandingan (adversarial):\n${input.counter}\n\nKembalikan juga:\n- \`subQuestionAnswerable\`: untuk TIAP sub-pertanyaan, \`answerable: true\` hanya bila pertanyaannya berbentuk dapat dijawab ya/tidak — bukan pertanyaan terbuka/deskriptif.\n- \`claims\`: 3-6 klaim faktual utama yang didukung inventaris, jujur terhadap bukti tandingan; \`papers\` = nomor sitasi [n] pendukung dari inventaris (JANGAN nomor di luar inventaris; JANGAN menulis angka agregat — kekuatan bukti dihitung sistem).\n- \`openQuestions\`: 2-4 pertanyaan riset terbuka paling penting, dipandu bukti tandingan dan celah pada bukti (\`why\` = mengapa penting).`;
+}
+
+/** Deskriptor satu baris per blok viz untuk prompt writer (id + ringkasan data — TANPA angka baru). */
+function vizBlockDescriptor(block: DeepVizBlock): string {
+  switch (block.type) {
+    case "consensus-meter":
+      return `- {{viz:${block.id}}} — meter konsensus sub-pertanyaan ${block.subQuestionIndex + 1} (N=${block.n}): "${block.question}"`;
+    case "results-timeline": {
+      const years = block.points.map((p) => p.year);
+      return `- {{viz:${block.id}}} — timeline publikasi ${Math.min(...years)}–${Math.max(...years)} (${block.points.length} paper)`;
+    }
+    case "top-contributors":
+      return `- {{viz:${block.id}}} — tabel top author & venue (${block.authors.length} author, ${block.venues.length} venue)`;
+    case "claims-evidence":
+      return `- {{viz:${block.id}}} — tabel klaim & kekuatan bukti (${block.claims.length} klaim)`;
+    case "gaps-matrix":
+      return `- {{viz:${block.id}}} — matriks research gaps (${block.rows.length} outcome × 4 desain studi)`;
+    case "open-questions":
+      return `- {{viz:${block.id}}} — pertanyaan riset terbuka (${block.items.length} item)`;
+  }
+}
+
+/**
+ * Seksi kontrak penempatan blok viz di prompt writer — hanya bila ada
+ * blok. Writer HANYA menaruh marker `{{viz:<id>}}`; datanya di-inject post-process
+ * (`injectVizBlocks`) sehingga model tak pernah menulis angka.
+ */
+function vizPromptSection(blocks: DeepVizBlock[]): string {
+  if (blocks.length === 0) return "";
+  return [
+    "",
+    "",
+    "## Blok visual tersedia (WAJIB ditempatkan)",
+    "Berikut blok visual yang SUDAH dihitung dari data. Sisipkan penandanya di laporan, masing-masing pada BARIS TERSENDIRI, persis: {{viz:<id>}}",
+    ...blocks.map(vizBlockDescriptor),
+    "Aturan penempatan (gaya artikel ilmiah):",
+    "- Meter konsensus: TEPAT setelah paragraf yang menyimpulkan sub-pertanyaan terkait.",
+    "- Timeline & kontributor: di bagian karakteristik/peta literatur (biasanya awal pembahasan), timeline dulu, dipisah minimal satu paragraf.",
+    "- Tabel klaim & bukti: di bagian sintesis bukti, sebelum kesimpulan.",
+    "- Gaps matrix lalu open questions: di bagian keterbatasan/arah riset ke depan, setelah kesimpulan utama.",
+    '- JANGAN dua penanda berurutan tanpa paragraf prosa di antaranya; setiap blok diantar kalimat yang merujuknya (mis. "Gambar berikut merangkum sebaran temuan…").',
+    "- JANGAN mengarang penanda lain, JANGAN menulis blok ```aqsha:viz sendiri, JANGAN mengubah data.",
+  ].join("\n");
+}
+
 /**
  * Format verdict `CitationService.verifyIdentifiers` → teks verifikasi untuk prompt sintesis +
- * panel proses. DETERMINISTIK (IMP-5) — dulu tabel hasil subagent LLM `citation-verifier`; data
+ * panel proses. DETERMINISTIK — dulu tabel hasil subagent LLM `citation-verifier`; data
  * sumbernya sudah terstruktur sejak `assign-citations`, jadi LLM hanya menambah biaya + drift
  * parsing. Framing netral: flag bukan tuduhan (bisa typo metadata / database tak lengkap /
  * provider outage) — paritas dgn instruksi subagent lama.
@@ -717,7 +893,7 @@ function formatVerificationText(result: VerificationResult): string {
   ].join("\n");
 }
 
-/** Nama skill domain-pack per `ResearchDomain` (di-inline ke prompt sintesis, CFG-2). */
+/** Nama skill domain-pack per `ResearchDomain` (di-inline ke prompt sintesis). */
 const DOMAIN_SKILL_NAME: Record<ResearchDomain, string> = {
   medicine: "research-medicine",
   "cs-ml": "research-cs-ml",
@@ -726,7 +902,7 @@ const DOMAIN_SKILL_NAME: Record<ResearchDomain, string> = {
 };
 
 /**
- * Panduan metodologi + gaya yang DI-INLINE ke prompt sintesis (CFG-2): langkah `synthesize`
+ * Panduan metodologi + gaya yang DI-INLINE ke prompt sintesis: langkah `synthesize`
  * berjalan `toolChoice:"none"` sehingga instruksi lama "baca skill lewat tool" tak pernah bisa
  * dieksekusi. Konten diambil dari inline skills (SSOT = SKILL.md via codegen) — bukan salinan.
  */
@@ -745,11 +921,22 @@ function synthesisGuidance(domain: ResearchDomain): string {
   ].join("\n");
 }
 
+/**
+ * Clamp temuan per sub-pertanyaan di prompt sintesis (lapis kedua setelah budget inventory —
+ * prompt sintesis yang menggelembung pernah membuat run macet permanen di produksi):
+ * teks subagent search umumnya ≤ ~11KB, tapi tak ada jaminan — batasi supaya prompt writer
+ * tetap berbatas walau satu subagent menulis sangat panjang. Codepoint-safe (`messagePreview`).
+ */
+const SYNTHESIS_FINDINGS_MAX_CHARS = 10_000;
+
 function synthesisPrompt(input: Verified): string {
   const evidence = input.evidence
-    .map((e, i) => `### Sub-pertanyaan ${i + 1}: ${e.subQuestion}\n${e.findings}`)
+    .map(
+      (e, i) =>
+        `### Sub-pertanyaan ${i + 1}: ${e.subQuestion}\n${messagePreview(e.findings, SYNTHESIS_FINDINGS_MAX_CHARS)}`,
+    )
     .join("\n\n");
-  return `Tulis jawaban riset tercitasi untuk pertanyaan:\n${input.question}\n\nRencana yang disetujui:\n${input.plan}\n\nDaftar sumber bernomor (SATU-SATUNYA sumber nomor [n] — WAJIB pakai nomor PERSIS ini saat mengutip; jangan menomori ulang):\n${input.numberedInventory}\n\nInventaris bukti (untuk ekstrak & narasi — teks temuan TIDAK bernomor; petakan tiap klaim ke daftar sumber bernomor di atas via DOI/arXiv/URL/judul):\n${evidence}\n\nBukti tandingan (adversarial):\n${input.counter}\n\nVerdict verifikasi sitasi:\n${input.verification}\n\nPanduan metodologi & gaya (SUDAH disertakan di bawah — kamu TIDAK bisa dan TIDAK perlu memuat skill lewat tool di langkah ini):\n\n${synthesisGuidance(input.domain)}\n\nSintesiskan menjadi jawaban terstruktur dan jujur: ringkasan temuan per sub-pertanyaan, lalu bukti tandingan & keterbatasan. Setiap klaim faktual membawa penanda [n] inline dari daftar sumber bernomor di atas (penanda dirender sebagai pill sumber + panel "Sumber" terpisah — JANGAN tulis daftar/bagian "Sumber"/daftar pustaka sendiri di akhir). JANGAN mengarang identifier.`;
+  return `Tulis jawaban riset tercitasi untuk pertanyaan:\n${input.question}\n\nRencana yang disetujui:\n${input.plan}\n\nDaftar sumber bernomor (SATU-SATUNYA sumber nomor [n] — WAJIB pakai nomor PERSIS ini saat mengutip; jangan menomori ulang):\n${input.numberedInventory}\n\nInventaris bukti (untuk ekstrak & narasi — teks temuan TIDAK bernomor; petakan tiap klaim ke daftar sumber bernomor di atas via DOI/arXiv/URL/judul):\n${evidence}\n\nBukti tandingan (adversarial):\n${input.counter}\n\nVerdict verifikasi sitasi:\n${input.verification}\n\nPanduan metodologi & gaya (SUDAH disertakan di bawah — kamu TIDAK bisa dan TIDAK perlu memuat skill lewat tool di langkah ini):\n\n${synthesisGuidance(input.domain)}\n\nSintesiskan menjadi jawaban terstruktur dan jujur: ringkasan temuan per sub-pertanyaan, lalu bukti tandingan & keterbatasan. Setiap klaim faktual membawa penanda [n] inline dari daftar sumber bernomor di atas (penanda dirender sebagai pill sumber + panel "Sumber" terpisah — JANGAN tulis daftar/bagian "Sumber"/daftar pustaka sendiri di akhir). JANGAN mengarang identifier.${vizPromptSection(input.vizBlocks)}`;
 }
 
 // ── Steps ─────────────────────────────────────────────────────────────────────────────────
@@ -773,7 +960,7 @@ const draftClarifyStep = createStep({
         feature: "deep_research",
       });
       if (!quota.ok) {
-        // B3: bail PALING DINI — belum ada gerbang HITL yang memproyeksikan thread, jadi efek
+        // Bail PALING DINI — belum ada gerbang HITL yang memproyeksikan thread, jadi efek
         // durable (bubble user + alasan) wajib dari sini.
         const reason = `Kuota deep research tidak tersedia (${quota.reason}).`;
         await persistBlockedBail(mastra, requestContext, { ...inputData, runId, reason });
@@ -800,7 +987,7 @@ const draftClarifyStep = createStep({
  * answers })`), sejajar plan-gate tapi memakai kontrak `ask_questions`. Tanpa pertanyaan → lanjut
  * langsung (tak suspend). Jawaban disisipkan ke `context` planner; dilewati → biarkan apa adanya.
  * Proyeksikan thread SEBELUM suspend (idempoten via `runId`) supaya refresh saat kartu tak "Akses
- * ditolak" (G1). TANPA gerbang billing di sini — billing tetap sekali di plan-gate.
+ * ditolak". TANPA gerbang billing di sini — billing tetap sekali di plan-gate.
  */
 const clarifyGateStep = createStep({
   id: "clarify",
@@ -832,9 +1019,9 @@ const clarifyGateStep = createStep({
 
 /**
  * 1. draftPlan — susun rencana prosa + sub-pertanyaan terstruktur via `deepWriter` dengan
- * `structuredOutput` strict (audit 2026-07-03: fallback parse-manual yang senyap DIHAPUS — gagal
+ * `structuredOutput` strict (fallback parse-manual yang senyap sengaja DIHAPUS — gagal
  * validasi → throw → `retries: 1` → run failed SEBELUM gerbang billing, user tak kehilangan kredit).
- * `toolChoice:"none"` (CFG-5): step ini berjalan SEBELUM gerbang billing `approve-plan`, jadi tool
+ * `toolChoice:"none"`: step ini berjalan SEBELUM gerbang billing `approve-plan`, jadi tool
  * berbayar (`search_*`) tak boleh bisa jalan di sini; `delete_artifact` (approval-suspend) juga
  * dilarang dalam workflow-generate (lihat `tools/index.ts`). Murni menulis rencana terstruktur.
  */
@@ -875,7 +1062,7 @@ const approvePlanStep = createStep({
   execute: async ({ inputData, resumeData, suspend, bail, requestContext, runId, mastra, writer }) => {
     if (!resumeData) {
       // Proyeksikan thread + persist pertanyaan SEBELUM suspend → refresh saat plan-gate me-resume
-      // kartu rencana (thread durable, tak "Akses ditolak"), bukan thread kosong (G1/TC13).
+      // kartu rencana (thread durable, tak "Akses ditolak"), bukan thread kosong.
       await ensureDeepThread(mastra, requestContext, {
         threadId: inputData.threadId,
         question: inputData.question,
@@ -928,7 +1115,7 @@ const approvePlanStep = createStep({
       }
     }
     if (!resumeData.edits) return inputData;
-    // CFG-3: edit user harus sampai ke `subQuestions` yang benar-benar diriset fan-out — bukan
+    // Edit user harus sampai ke `subQuestions` yang benar-benar diriset fan-out — bukan
     // hanya ditempel sebagai prosa yang baru dibaca writer akhir. Re-derive rencana+sub-pertanyaan
     // dengan satu pass murah (`toolChoice:"none"` + structuredOutput strict); gagal → fallback
     // perilaku lama (append prosa) — di titik ini debit SUDAH terjadi, run tak boleh mati.
@@ -955,7 +1142,7 @@ const approvePlanStep = createStep({
  * 3. searchLiterature — fan-out paralel: satu `literatureSearcher` per sub-pertanyaan. Tool
  * `search_*` men-debit `external_search` + persist `research_sources` ke thread chat.
  *
- * Isolasi kegagalan per sub-pertanyaan (CFG-4): satu subagent yang melempar (429/timeout
+ * Isolasi kegagalan per sub-pertanyaan: satu subagent yang melempar (429/timeout
  * terminal) TIDAK menggagalkan seluruh fan-out — kredit sudah didebit di plan-gate, jadi run
  * harus degradasi per-sub-Q (catat gap jujur ke sintesis), bukan `failed` tanpa hasil parsial.
  */
@@ -964,8 +1151,9 @@ const searchStep = createStep({
   inputSchema: PlannedSchema,
   outputSchema: SearchedSchema,
   // TANPA `retries`: re-run step = re-debit `external_search` per tool-call baru. Isolasi
-  // per-sub-Q di bawah sudah membuat step ini tak melempar. (Pasca-DUR-7 restart step justru
-  // AMAN: task selesai di-reuse by `toolCallId`, tak menjalankan ulang subagent.)
+  // per-sub-Q di bawah sudah membuat step ini tak melempar. (Karena subagent jalan sebagai
+  // background task persisten, restart step justru AMAN: task selesai di-reuse by `toolCallId`,
+  // tak menjalankan ulang subagent.)
   execute: async ({ inputData, mastra, requestContext, runId, writer, abortSignal }) => {
     // Tanam thread+run di rc induk dulu → entries() yang DI-CLONE per sub-Q sudah membawanya.
     withDeepRun(requestContext, inputData.threadId, runId, inputData.agentKind);
@@ -978,9 +1166,9 @@ const searchStep = createStep({
         subRc.set(AQSHA_DEEP_SUBQ_INDEX_KEY, subIndex);
         subRc.set(AQSHA_DEEP_SUBQ_TEXT_KEY, subQuestion);
         await emitDetail(writer, { kind: "search-sub", subIndex, subQuestion, status: "searching" });
-        // DUR-7: subagent jalan sebagai background task persisten — `toolCallId` deterministik
+        // Subagent jalan sebagai background task persisten — `toolCallId` deterministik
         // per (run, sub-Q) → restart run me-reuse hasil task selesai (tanpa re-debit search).
-        // B4: `abortSignal` ikut — Stop user menutup task run ini, bukan membiarkannya jalan terus.
+        // `abortSignal` ikut — Stop dari user menutup task run ini, bukan membiarkannya jalan terus.
         const taskBase = {
           mastra,
           runId,
@@ -1001,10 +1189,10 @@ const searchStep = createStep({
             },
           });
           findings = out.text.trim();
-          // Guard turn-senyap subagent (CTX-7): selesai pas di tool-call → teks kosong. Retry SEKALI
+          // Guard turn-senyap subagent: selesai pas di tool-call → teks kosong. Retry SEKALI
           // dengan pengingat eksplisit; masih kosong → catat gap jujur (jangan biarkan bucket kosong
-          // mengalir senyap ke sintesis). B4: jangan dispatch empty-retry untuk run yang sedang
-          // dibatalkan (catch CFG-4 di bawah menelan abort-error attempt pertama).
+          // mengalir senyap ke sintesis). Jangan dispatch empty-retry untuk run yang sedang
+          // dibatalkan (catch isolasi per-sub-Q di bawah menelan abort-error attempt pertama).
           if (!findings && !abortSignal.aborted) {
             const retry = await runDeepSubagentTask({
               ...taskBase,
@@ -1018,7 +1206,7 @@ const searchStep = createStep({
             findings = retry.text.trim();
           }
         } catch (err) {
-          // CFG-4: kegagalan satu subagent tak boleh menolak seluruh Promise.all.
+          // Kegagalan satu subagent tak boleh menolak seluruh Promise.all.
           console.error(`[deep-research] literature-searcher sub-Q ${subIndex} failed`, err);
         }
         if (!findings) {
@@ -1036,7 +1224,7 @@ const searchStep = createStep({
 });
 
 /**
- * 4. counterEvidence — cari bukti tandingan adversarial atas inventaris. `retries: 1` (CFG-4):
+ * 4. counterEvidence — cari bukti tandingan adversarial atas inventaris. `retries: 1`:
  * step LLM pasca-billing tak boleh mematikan run karena satu error transien (kredit deep sudah
  * didebit di plan-gate; re-run bisa mengulang sedikit debit `external_search` — jauh lebih murah
  * daripada run `failed` tanpa refund).
@@ -1047,13 +1235,13 @@ const counterEvidenceStep = createStep({
   outputSchema: CounteredSchema,
   retries: 1,
   execute: async ({ inputData, mastra, requestContext, runId, writer, abortSignal }) => {
-    // IMP-9: emit di AWAL step → body panel proses terisi jujur selama fase lambat berjalan
+    // Emit di AWAL step → body panel proses terisi jujur selama fase lambat berjalan
     // (ditimpa teks final di akhir step; paritas pola `search-sub` status "searching").
     await emitDetail(writer, {
       kind: "counter",
       text: `Menelusuri bukti tandingan atas temuan ${inputData.evidence.length} sub-pertanyaan…`,
     });
-    // DUR-7: background task persisten — restart run me-reuse hasil task selesai.
+    // Background task persisten — restart run me-reuse hasil task selesai.
     const rc = withDeepRun(requestContext, inputData.threadId, runId, inputData.agentKind);
     const owner = ownerFromRequestContext(requestContext);
     const out = await runDeepSubagentTask({
@@ -1070,7 +1258,7 @@ const counterEvidenceStep = createStep({
         requestContext: Array.from(rc.entries()),
       },
     });
-    // Guard teks kosong (CTX-7): jangan biarkan bagian adversarial hilang senyap.
+    // Guard teks kosong (turn subagent bisa selesai pas di tool-call): jangan biarkan bagian adversarial hilang senyap.
     const counter =
       out.text.trim() ||
       "(Pencarian bukti tandingan berakhir tanpa teks — perlakukan sebagai BELUM diverifikasi ada/tidaknya bukti tandingan, BUKAN sebagai ketiadaan bukti tandingan.)";
@@ -1079,10 +1267,15 @@ const counterEvidenceStep = createStep({
   },
 });
 
+/** Clamp snippet per baris inventory (codepoint-safe via `messagePreview`). */
+const INVENTORY_SNIPPET_MAX_CHARS = 240;
+/** Budget total inventory — melewati ini, baris berikutnya tanpa snippet (identitas [n] tetap). */
+const INVENTORY_CHAR_BUDGET = 48_000;
+
 /**
  * 5. assignCitations — nomori `research_sources` run ini (turnId=runId) → `citation_number` 1..N
- * (dedupe by DOI/arXiv/locator) lalu susun inventory bernomor GLOBAL untuk verify + synthesis (G4).
- * `retries: 1` (audit B1): step pasca-billing murni DB dan idempoten (`assignCitationNumbers`
+ * (dedupe by DOI/arXiv/locator) lalu susun inventory bernomor GLOBAL untuk verify + synthesis.
+ * `retries: 1`: step pasca-billing murni DB dan idempoten (`assignCitationNumbers`
  * menghitung ulang penomoran deterministik lalu overwrite) — blip DB satu kali tak boleh
  * mematikan run yang kreditnya sudah didebit.
  */
@@ -1097,8 +1290,17 @@ const assignCitationsStep = createStep({
       turnId: runId,
     });
     const numbered = items.filter((s) => s.citationNumber !== null);
-    // Baris inventory bawa authors/year/venue (CTX-8) → verify_identifiers + daftar pustaka APA
+    // Baris inventory bawa authors/year/venue → verify_identifiers + daftar pustaka APA
     // bekerja dari metadata asli provider, bukan karangan model.
+    //
+    // BERBATAS (temuan produksi run yang macet): run kaya-sumber (262 baris) dengan snippet penuh per baris
+    // menggelembungkan prompt sintesis sampai ~400KB (~100k token) → panggilan penulis merangkak
+    // melampaui timeout task 15 menit, dan tiap retry mewarisi prompt beracun yang sama → run
+    // "macet" permanen. Snippet per baris di-clamp; setelah budget total tersentuh, baris
+    // berikutnya ditulis TANPA snippet — identitas `[n] judul (meta) — identifier` tetap utuh
+    // sehingga SEMUA nomor sitasi tetap bisa dikutip writer.
+    let inventoryChars = 0;
+    let snippetlessRows = 0;
     const numberedInventory = numbered
       .map((s) => {
         const meta = [
@@ -1108,11 +1310,22 @@ const assignCitationsStep = createStep({
         ]
           .filter(Boolean)
           .join("; ");
-        return `[${s.citationNumber}] ${s.title}${meta ? ` (${meta})` : ""} — ${
+        const withinBudget = inventoryChars < INVENTORY_CHAR_BUDGET;
+        if (s.snippet && !withinBudget) snippetlessRows += 1;
+        const snippet =
+          s.snippet && withinBudget ? ` — ${messagePreview(s.snippet, INVENTORY_SNIPPET_MAX_CHARS)}` : "";
+        const line = `[${s.citationNumber}] ${s.title}${meta ? ` (${meta})` : ""} — ${
           s.doi ?? s.arxivId ?? s.url ?? s.locator
-        }${s.snippet ? ` — ${s.snippet}` : ""} (${s.evidenceStrength})`;
+        }${snippet} (${s.evidenceStrength})`;
+        inventoryChars += line.length + 1;
+        return line;
       })
       .join("\n");
+    if (snippetlessRows > 0) {
+      console.log(
+        `[deep-research] assign-citations run=${runId}: inventory menyentuh budget ${INVENTORY_CHAR_BUDGET} char — ${snippetlessRows} baris ditulis tanpa snippet`,
+      );
+    }
     // Jumlah sitasi unik [n] (dedupe by DOI/arXiv/locator) — sumber penomoran ditampilkan FE.
     const uniqueCitations = new Set(numbered.map((s) => s.citationNumber)).size;
     // Sumber bernomor terstruktur (format kartu FE) → dipersist di `metadata.deepProcess.sources`
@@ -1126,7 +1339,7 @@ const assignCitationsStep = createStep({
       ...(s.snippet ? { snippet: s.snippet } : {}),
     }));
     // Referensi terstruktur per [n] UNIK (baris bisa berbagi nomor karena dedupe) — bahan
-    // `verify-citations` memanggil CitationService LANGSUNG, tanpa parsing inventory (IMP-5).
+    // `verify-citations` memanggil CitationService LANGSUNG, tanpa parsing inventory.
     const seenCitation = new Set<number>();
     const verifyRefs = numbered.flatMap((s) => {
       const n = s.citationNumber ?? 0;
@@ -1150,17 +1363,249 @@ const assignCitationsStep = createStep({
   },
 });
 
+/** Cap unit klasifikasi per run (lebih → prioritaskan evidenceStrength kuat, sisanya di-drop). */
+const ANALYZE_UNIT_CAP = 60;
+/** Unit per panggilan LLM klasifikasi. */
+const ANALYZE_CHUNK_SIZE = 20;
+const ANALYZE_STRENGTH_PRIORITY: Record<AnalyzeUnit["evidenceStrength"], number> = {
+  strong: 0,
+  medium: 1,
+  weak: 2,
+};
+
 /**
- * 6. verifyCitations — verifikasi integritas referensi bernomor. DETERMINISTIK (IMP-5): data
+ * 5b. analyzeSources — klasifikasi stance/design/outcomes per unit `[n]×subQ` (LLM structuredOutput
+ * strict, pola draft-plan) lalu `buildDeepVizBlocks` deterministik (chat-core) → blok visual untuk
+ * writer. Keputusan desain: model SELALU lite (tugas klasifikasi, hemat) dan
+ * TANPA ledger `deep_analyze` (butuh migration CHECK `provider_usage_ledger` baru — tak sepadan
+ * untuk rate 0; biaya sudah tertanggung debit deep di plan-gate). BEST-EFFORT TOTAL pasca-billing:
+ * retry per panggilan LLM di DALAM step (bukan `retries` engine — step pasca-billing tak boleh
+ * melempar); gagal total → `vizBlocks: []`, laporan tampil polos. Panggilan generate langsung
+ * (bukan `runDeepSubagentTask`) mengikuti preseden draft-plan — `structuredOutput` belum lewat
+ * jalur task; restart run mengulang step ini (murah, deterministik-ish).
+ */
+const analyzeSourcesStep = createStep({
+  id: "analyze-sources",
+  inputSchema: CitedSchema,
+  outputSchema: AnalyzedSchema,
+  execute: async ({ inputData, requestContext, runId, writer }) => {
+    const fallback = { ...inputData, vizBlocks: [] as DeepVizBlock[], analyzedSourceCount: 0 };
+    try {
+      const rows = await ResearchService.listTurnSources(getServiceDb(), {
+        threadId: inputData.threadId,
+        turnId: runId,
+      });
+      const numbered = rows.filter((r) => r.citationNumber !== null);
+      if (numbered.length === 0) return fallback;
+
+      // Unit klasifikasi = pasangan unik `[n] × subQuestionIndex` (kemunculan pertama menang;
+      // baris duplikat paper yang sama menambah `rowIds` — persist klasifikasi menyasar semuanya).
+      // Baris tanpa subQuestionIndex tak bisa dinilai stance-nya (tetap ikut builder di bawah).
+      const unitByKey = new Map<string, AnalyzeUnit>();
+      for (const row of numbered) {
+        if (row.subQuestionIndex === null) continue;
+        const key = `${row.citationNumber}:${row.subQuestionIndex}`;
+        const existing = unitByKey.get(key);
+        if (existing) {
+          existing.rowIds.push(row.id);
+          continue;
+        }
+        unitByKey.set(key, {
+          n: row.citationNumber as number,
+          subQuestionIndex: row.subQuestionIndex,
+          rowIds: [row.id],
+          title: row.title,
+          snippet: row.snippet,
+          year: row.year,
+          venue: row.venue,
+          evidenceStrength: row.evidenceStrength,
+        });
+      }
+      const allUnits = [...unitByKey.values()].sort(
+        (a, b) =>
+          ANALYZE_STRENGTH_PRIORITY[a.evidenceStrength] - ANALYZE_STRENGTH_PRIORITY[b.evidenceStrength] ||
+          a.n - b.n ||
+          a.subQuestionIndex - b.subQuestionIndex,
+      );
+      const units = allUnits.slice(0, ANALYZE_UNIT_CAP);
+      if (allUnits.length > units.length) {
+        console.log(
+          `[deep-research] analyze-sources run=${runId}: ${allUnits.length - units.length} unit di-drop (cap ${ANALYZE_UNIT_CAP})`,
+        );
+      }
+      await emitDetail(writer, {
+        kind: "analyze",
+        text: `Menganalisis bukti: mengklasifikasikan ${units.length} unit sumber (${numbered.length} baris)…`,
+      });
+
+      // Model SELALU lite — clone rc supaya tier run (pro) di rc induk tak ikut ke panggilan
+      // analisis. Cast `out.object` per skema: generic `structuredOutput` tak terbawa inference
+      // Mastra melalui helper (validasi runtime tetap strict via `structuredOutputOpts`).
+      const analyzeGenerate = async <T extends z.ZodType>(
+        prompt: string,
+        schema: T,
+      ): Promise<z.output<T> | undefined> => {
+        const out = await deepWriter.generate(prompt, {
+          requestContext: withDeepRun(
+            new RequestContext(requestContext.entries()),
+            inputData.threadId,
+            runId,
+            "lite",
+          ),
+          ...deepProviderOptions("lite"),
+          toolChoice: "none",
+          structuredOutput: structuredOutputOpts(schema),
+        });
+        return out.object as z.output<T> | undefined;
+      };
+      const withOneRetry = async <T>(label: string, fn: () => Promise<T>): Promise<T | null> => {
+        try {
+          return await fn();
+        } catch (err) {
+          console.error(`[deep-research] analyze-sources ${label} attempt 1 failed`, err);
+          try {
+            return await fn();
+          } catch (err2) {
+            console.error(`[deep-research] analyze-sources ${label} attempt 2 failed`, err2);
+            return null;
+          }
+        }
+      };
+
+      const chunks: AnalyzeUnit[][] = [];
+      for (let i = 0; i < units.length; i += ANALYZE_CHUNK_SIZE) {
+        chunks.push(units.slice(i, i + ANALYZE_CHUNK_SIZE));
+      }
+      // Semua chunk paralel — prompt tiap chunk hanya bergantung inputData + unit chunk itu.
+      // Chunk pertama sekalian membawa penilaian global (answerable/claims/openQuestions).
+      // Kegagalan satu chunk = insight-nya hilang saja (blok yang ambangnya tak terpenuhi
+      // otomatis drop) — bukan kegagalan step.
+      let global: z.infer<typeof AnalyzeFullOutputSchema> | null = null;
+      const rawInsights: Array<z.infer<typeof AnalyzeInsightSchema>> = [];
+      if (chunks.length > 0) {
+        const firstPromise = withOneRetry("chunk 0 (global)", () =>
+          analyzeGenerate(
+            `${analyzeChunkPrompt(inputData, chunks[0] ?? [])}\n\n${analyzeGlobalPrompt(inputData)}`,
+            AnalyzeFullOutputSchema,
+          ),
+        );
+        const restPromise = Promise.all(
+          chunks.slice(1).map((chunk, i) =>
+            withOneRetry(`chunk ${i + 1}`, () =>
+              analyzeGenerate(analyzeChunkPrompt(inputData, chunk), AnalyzeChunkOutputSchema),
+            ),
+          ),
+        );
+        const first = await firstPromise;
+        const rest = await restPromise;
+        if (first) {
+          global = first;
+          rawInsights.push(...(first.insights ?? []));
+        }
+        for (const r of rest) if (r) rawInsights.push(...(r.insights ?? []));
+      }
+
+      // Sanitasi insight: hanya unit yang benar-benar DIKIRIM ke LLM (set ter-cap) — dalam praktik
+      // model ikut "mengklasifikasi" pasangan lain yang dilihatnya di inventaris global; subQ
+      // pasangan itu tebakan (inventaris tak memuat subQ) → tak dipercaya.
+      // Duplikat: kemunculan pertama menang.
+      const sentKeys = new Set(units.map((u) => `${u.n}:${u.subQuestionIndex}`));
+      const insightByKey = new Map<
+        string,
+        { stance: z.infer<typeof AnalyzeStanceSchema>; studyDesign: z.infer<typeof AnalyzeDesignSchema>; outcomes: string[] }
+      >();
+      for (const ins of rawInsights) {
+        if (!Number.isInteger(ins.n) || !Number.isInteger(ins.subQuestionIndex)) continue;
+        const key = `${ins.n}:${ins.subQuestionIndex}`;
+        if (!sentKeys.has(key) || insightByKey.has(key)) continue;
+        insightByKey.set(key, {
+          stance: ins.stance,
+          studyDesign: ins.studyDesign,
+          outcomes: ins.outcomes.filter((o) => o.trim().length > 0).slice(0, 3),
+        });
+      }
+
+      // Persist klasifikasi ke `research_sources` (best-effort — kolom = fallback/observabilitas;
+      // kegagalan DB tak menggagalkan step, blok tetap dibangun dari state workflow).
+      const updates = [...unitByKey.entries()].flatMap(([key, unit]) => {
+        const insight = insightByKey.get(key);
+        if (!insight) return [];
+        return unit.rowIds.map((id) => ({ id, ...insight }));
+      });
+      if (updates.length > 0) {
+        try {
+          await ResearchService.setSourceClassification(getServiceDb(), updates);
+        } catch (err) {
+          console.error("[deep-research] analyze-sources persist classification failed", err);
+        }
+      }
+
+      // Input builder = SEMUA baris bernomor (termasuk unit di luar cap / tanpa subQ — blok yang
+      // tak butuh stance seperti timeline/kontributor tetap memakai metadatanya; stance null aman).
+      const sources: DeepVizSourceInput[] = numbered.map((row) => {
+        const insight =
+          row.subQuestionIndex !== null
+            ? insightByKey.get(`${row.citationNumber}:${row.subQuestionIndex}`)
+            : undefined;
+        return {
+          n: row.citationNumber as number,
+          subQuestionIndex: row.subQuestionIndex,
+          title: row.title,
+          authors: row.authors,
+          year: row.year,
+          venue: row.venue,
+          citedByCount: row.citedByCount,
+          evidenceStrength: row.evidenceStrength,
+          stance: insight?.stance ?? null,
+          studyDesign: insight?.studyDesign ?? null,
+          outcomes: insight?.outcomes ?? [],
+          topics: row.topics,
+        };
+      });
+      const subQuestionAnswerable = (global?.subQuestionAnswerable ?? [])
+        .filter(
+          (e) =>
+            Number.isInteger(e.subQuestionIndex) &&
+            e.subQuestionIndex >= 0 &&
+            e.subQuestionIndex < inputData.subQuestions.length,
+        )
+        .map((e) => ({ subQuestionIndex: e.subQuestionIndex, answerable: e.answerable === true }));
+      const claims = (global?.claims ?? [])
+        .map((c) => ({ text: c.text, reasoning: c.reasoning, papers: c.papers.filter((p) => Number.isInteger(p)) }))
+        .slice(0, 6);
+      const openQuestions = (global?.openQuestions ?? []).slice(0, 4);
+
+      const vizBlocks = buildDeepVizBlocks({
+        subQuestions: inputData.subQuestions,
+        sources,
+        subQuestionAnswerable,
+        claims,
+        openQuestions,
+      });
+      await emitDetail(writer, {
+        kind: "analyze",
+        text: formatDeepAnalyzeSummary(insightByKey.size, vizBlocks.map((b) => b.id)),
+      });
+      return { ...inputData, vizBlocks, analyzedSourceCount: insightByKey.size };
+    } catch (err) {
+      // Best-effort total: analisis gagal → laporan polos, JANGAN throw pasca-billing.
+      console.error("[deep-research] analyze-sources failed", err);
+      return fallback;
+    }
+  },
+});
+
+/**
+ * 6. verifyCitations — verifikasi integritas referensi bernomor. DETERMINISTIK: data
  * referensi sudah terstruktur sejak `assign-citations` (`verifyRefs` per [n] unik) → panggil
  * `CitationService.verifyIdentifiers` LANGSUNG, tanpa subagent LLM (lebih murah, tanpa drift
- * parsing inventory↔verdict, hasil konsisten lintas-run; tak perlu background task DUR-7 karena
+ * parsing inventory↔verdict, hasil konsisten lintas-run; tak perlu background task persisten karena
  * tak ada model call — restart run tinggal mengulang batch lookup Crossref/OpenAlex yang murah).
  * `retries: 1` tetap (provider di engine bisa transien).
  */
 const citationVerifyStep = createStep({
   id: "verify-citations",
-  inputSchema: CitedSchema,
+  inputSchema: AnalyzedSchema,
   outputSchema: VerifiedSchema,
   retries: 1,
   execute: async ({ inputData, requestContext, runId, writer }) => {
@@ -1169,12 +1614,12 @@ const citationVerifyStep = createStep({
       await emitDetail(writer, { kind: "verify", text: verification });
       return { ...inputData, verification };
     }
-    // IMP-9: emit di AWAL step (ditimpa verdict final) → panel proses jujur selama fase verifikasi.
+    // Emit di AWAL step (ditimpa verdict final) → panel proses jujur selama fase verifikasi.
     await emitDetail(writer, {
       kind: "verify",
       text: `Memverifikasi ${inputData.verifyRefs.length} referensi (keberadaan, konsistensi metadata, DOI/arXiv)…`,
     });
-    // Paritas CFG-7 dgn tool `verify_identifiers`: rekam usage `citation_verify` (rate 0 hari ini,
+    // Paritas dgn tool `verify_identifiers`: rekam usage `citation_verify` (rate 0 hari ini,
     // idempoten per-run) dan hormati gate — kuota habis TIDAK boleh tetap menjalankan verifikasi.
     const { id: ownerUserId, email: ownerEmail } = ownerFromRequestContext(requestContext);
     if (ownerUserId) {
@@ -1209,7 +1654,7 @@ const synthesizeStep = createStep({
   execute: async ({ inputData, requestContext, mastra, runId, writer, abortSignal }) => {
     // `toolChoice: "none"`: seluruh bukti sudah ada di prompt; paksa penulis MENULIS teks
     // (bukan berhenti di tool-call kosong) — jaminan `out.text` terisi pada model gateway.
-    // DUR-7: background task persisten — restart run me-reuse laporan task selesai.
+    // Background task persisten — restart run me-reuse laporan task selesai.
     const rc = withDeepRun(requestContext, inputData.threadId, runId, inputData.agentKind);
     const owner = ownerFromRequestContext(requestContext);
     const out = await runDeepSubagentTask({
@@ -1228,7 +1673,7 @@ const synthesizeStep = createStep({
       },
     });
     // Ringkasan penalaran penulis (Responses API `reasoningSummary`) → blok "reasoning" di atas
-    // laporan (parity dgn chat). Route B: dipanen post-hoc dari hasil `.generate`, bukan di-stream
+    // laporan (parity dgn chat). Dipanen post-hoc dari hasil `.generate`, bukan di-stream
     // token-level (aman thd durable refresh) → emit live + dipersist di pesan untuk rehydrate.
     const reasoning = (out.reasoningText ?? "").trim();
     if (reasoning) await emitDetail(writer, { kind: "reasoning", text: reasoning });
@@ -1238,9 +1683,29 @@ const synthesizeStep = createStep({
     // retry/time-travel synthesize menulis ulang; deep-tasks TIDAK me-reuse completed kosong
     // (completedWithText) → retry itu benar-benar men-dispatch attempt penulis baru, bukan
     // memutar hasil kosong yang sama selamanya.
-    const report = (out.text ?? "").trim();
-    if (!report) throw new Error("deep-research: penulis sintesis mengembalikan teks kosong");
-    // Persist ke memory = step `persist-report` TERPISAH (B2) — kegagalan simpan tak lagi menelan
+    const rawReport = (out.text ?? "").trim();
+    if (!rawReport) throw new Error("deep-research: penulis sintesis mengembalikan teks kosong");
+    // Post-process viz — SELALU dijalankan (juga saat `vizBlocks` kosong: anti-forgery men-strip
+    // fence ```aqsha:viz tulisan model + marker liar). Pure & idempoten — retry synthesize
+    // mengulang injeksi dengan hasil sama.
+    const injected = injectVizBlocks(rawReport, inputData.vizBlocks);
+    const report = injected.report;
+    // Guard kosong DIULANG pasca-strip: laporan yang hanya berisi fence viz palsu jadi kosong
+    // setelah injeksi — harus gagal di sini (retry menulis ulang; `completedWithText` deep-tasks
+    // menilai hasil seperti itu tak layak reuse sehingga attempt baru benar-benar di-dispatch).
+    if (!report.trim()) {
+      throw new Error("deep-research: laporan kosong setelah stripping anti-forgery viz");
+    }
+    if (
+      inputData.vizBlocks.length > 0 ||
+      injected.strippedFenceCount > 0 ||
+      injected.removedMarkerCount > 0
+    ) {
+      console.log(
+        `[deep-research] viz injection run=${runId}: placed=[${injected.placedIds.join(",")}] appended=[${injected.appendedIds.join(",")}] dropped=[${injected.droppedIds.join(",")}] strippedFences=${injected.strippedFenceCount} removedMarkers=${injected.removedMarkerCount}`,
+      );
+    }
+    // Persist ke memory = step `persist-report` TERPISAH — kegagalan simpan tak lagi menelan
     // laporan senyap, dan retry/time-travel persist tak menyentuh jalur LLM/task sama sekali.
     return {
       threadId: inputData.threadId,
@@ -1251,6 +1716,8 @@ const synthesizeStep = createStep({
       verification: inputData.verification,
       numberedInventory: inputData.numberedInventory,
       numberedSources: inputData.numberedSources,
+      vizBlocks: inputData.vizBlocks,
+      analyzedSourceCount: inputData.analyzedSourceCount,
       report,
       reasoning,
     };
@@ -1258,12 +1725,12 @@ const synthesizeStep = createStep({
 });
 
 /**
- * 8. persistReport — simpan laporan ke memory thread sebagai step tersendiri (audit B2). Failure
+ * 8. persistReport — simpan laporan ke memory thread sebagai step tersendiri. Failure
  * domain terpisah dari `synthesize`: persist murni DB, idempoten (id pesan `deep-report:<runId>`),
  * jadi boleh `retries: 2` + di-time-travel TANPA menyentuh jalur LLM/task. Dulu best-effort di
  * dalam synthesize → gagal = run tetap `success` tapi laporan LENYAP saat refresh (history dibaca
  * dari `mastra_messages`) padahal user bayar penuh. `deepProcess` = jejak proses agar FE bangun
- * ulang langkah + detail tanpa runId (riwayat/refresh, G7); teks counter/verify dipersist PENUH
+ * ulang langkah + detail tanpa runId (riwayat/refresh); teks counter/verify dipersist PENUH
  * (tanpa clamp) → panel detail menampilkan narasi utuh.
  */
 const persistReportStep = createStep({
@@ -1272,7 +1739,7 @@ const persistReportStep = createStep({
   outputSchema: OutputSchema,
   retries: 2,
   execute: async ({ inputData, requestContext, mastra, runId }) => {
-    // TEMP-TEST E2E B1/B2 (HAPUS SETELAH UJI): HANYA saat env `AQSHA_E2E_FAIL_PERSIST=1` — gagal
+    // TEMP-TEST E2E (HAPUS SETELAH UJI): HANYA saat env `AQSHA_E2E_FAIL_PERSIST=1` — gagal
     // selama file flag ada (toggle mid-run tanpa restart proses); hapus flag lalu "Coba lagi"
     // (time-travel) harus memulihkan tanpa debit baru. Tanpa env (prod) = nol I/O fs, dan file
     // /tmp nyasar di host TIDAK bisa mematikan persist semua user.
@@ -1297,6 +1764,15 @@ const persistReportStep = createStep({
         // Fallback Sumber DB-independen: FE me-resolve `[n]` + panel "Sumber" dari sini bila fetch
         // `research_sources` live meleset (lihat `messageSourceCards`).
         sources: inputData.numberedSources,
+        // Evidence viz: ringkasan untuk baris panel proses "analyze" di riwayat. HANYA id + jumlah
+        // — data blok penuh sudah terangkut di fence ```aqsha:viz dalam `report` (satu-satunya
+        // sumber render figure); menduplikasinya di metadata menggemukkan tiap load pesan.
+        ...(inputData.vizBlocks.length > 0 || inputData.analyzedSourceCount > 0
+          ? {
+              vizBlockIds: inputData.vizBlocks.map((b) => b.id),
+              analyzedSourceCount: inputData.analyzedSourceCount,
+            }
+          : {}),
       },
     });
     return {
@@ -1311,7 +1787,7 @@ const persistReportStep = createStep({
 
 export const deepResearch = createWorkflow({
   id: "deep-research",
-  description: "Riset mendalam tercitasi: klarifikasi (HITL, opsional) → plan-gate (HITL) → cari literatur → bukti tandingan → verifikasi sitasi → sintesis → persist laporan.",
+  description: "Riset mendalam tercitasi: klarifikasi (HITL, opsional) → plan-gate (HITL) → cari literatur → bukti tandingan → nomori sitasi → analisis bukti (viz) → verifikasi sitasi → sintesis → persist laporan.",
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
 })
@@ -1322,6 +1798,7 @@ export const deepResearch = createWorkflow({
   .then(searchStep)
   .then(counterEvidenceStep)
   .then(assignCitationsStep)
+  .then(analyzeSourcesStep)
   .then(citationVerifyStep)
   .then(synthesizeStep)
   .then(persistReportStep)

--- a/apps/agent/src/mastra/workflows/deep-tasks.ts
+++ b/apps/agent/src/mastra/workflows/deep-tasks.ts
@@ -1,3 +1,4 @@
+import { injectVizBlocks } from "@aqsha/chat-core/deep-viz";
 import type { BackgroundTask, BackgroundTaskManager } from "@mastra/core/background-tasks";
 import { createBackgroundTask } from "@mastra/core/background-tasks";
 import type { Mastra } from "@mastra/core/mastra";
@@ -9,14 +10,14 @@ import { AQSHA_AGENT_KIND_KEY, type AgentKind } from "../lib/tool-context";
 import { liteProviderOptions, proProviderOptions } from "../model";
 
 /**
- * DUR-7 — subagent `/deep` sebagai BACKGROUND TASK persisten (`mastra_background_tasks`).
+ * Subagent `/deep` sebagai BACKGROUND TASK persisten (`mastra_background_tasks`).
  *
  * Setiap pemanggilan subagent pasca-billing (search per sub-Q, counter-evidence, synthesize;
- * verify-citations kini deterministik tanpa LLM — IMP-5) di-dispatch sebagai task dengan
+ * verify-citations kini deterministik tanpa LLM) di-dispatch sebagai task dengan
  * `toolCallId` DETERMINISTIK (`<runId>:<step>[...]`).
  * Dua manfaat durability:
  *
- * 1. **Restart run idempoten**: `run.restart()` (DUR-5) / restart proses agent → step yang re-run
+ * 1. **Restart run idempoten**: `run.restart()` / restart proses agent → step yang re-run
  *    menemukan task lama by `toolCallId`: `completed` → hasil dipakai ulang dari kolom `result`
  *    (subagent TIDAK dijalankan ulang → `external_search` TIDAK di-debit ulang); non-terminal →
  *    executor di-register ulang lalu ditunggu, bukan dijalankan dobel.
@@ -29,7 +30,7 @@ import { liteProviderOptions, proProviderOptions } from "../model";
  */
 
 /** Subagent yang boleh dijalankan sebagai task — key = id agent (dipakai juga sebagai `agentId` task). */
-// `citation-verifier` DIHAPUS (IMP-5): step verify kini memanggil CitationService langsung tanpa
+// `citation-verifier` DIHAPUS: step verify kini memanggil CitationService langsung tanpa
 // LLM — task warisan ber-agentId itu (pre-deploy) akan gagal recover, lalu step re-run jalur baru.
 const DEEP_TASK_AGENTS = {
   "literature-searcher": literatureSearcher,
@@ -104,12 +105,12 @@ function normalizeResult(result: unknown): DeepTaskResult {
 const STALE_WAIT_MARGIN_MS = 30_000;
 
 /**
- * A2: batas tunggu untuk task LAMA = sisa umur task itu sendiri (`startedAt ?? createdAt` +
+ * Batas tunggu untuk task LAMA = sisa umur task itu sendiri (`startedAt ?? createdAt` +
  * `task.timeoutMs` + margin) — BUKAN full timeout baru. Task stale (eksekutor proses lama mati,
  * recovery tak menyentuh) punya deadline di masa lalu → loop wait langsung keluar → dispatch
  * attempt baru segera, alih-alih klik "Mulai ulang" terasa hang ~10 menit. Catatan: record
- * `BackgroundTask` TIDAK punya `updatedAt` (rekomendasi audit dikoreksi di sini). Tetap di-cap
- * timeout step pemanggil.
+ * `BackgroundTask` TIDAK punya `updatedAt`, jadi anchor umurnya `startedAt ?? createdAt`.
+ * Tetap di-cap timeout step pemanggil.
  */
 function existingTaskDeadline(task: BackgroundTask, callerTimeoutMs: number): number {
   const anchor = new Date(task.startedAt ?? task.createdAt).getTime();
@@ -117,28 +118,33 @@ function existingTaskDeadline(task: BackgroundTask, callerTimeoutMs: number): nu
 }
 
 /**
- * B5: attempt yang satu identitas logis dgn `base` = base persis ATAU suffix retry `:r<N>:<ts>`.
- * BUKAN prefix polos: `:empty-retry` adalah kunci logis BERBEDA (retry teks-kosong CTX-7), dan
- * `search:1` tak boleh mencocokkan `search:10`.
+ * Attempt yang satu identitas logis dgn `base` = base persis ATAU suffix retry `:r<N>:<ts>`.
+ * BUKAN prefix polos: `:empty-retry` adalah kunci logis BERBEDA (retry khusus turn subagent
+ * yang selesai tanpa teks), dan `search:1` tak boleh mencocokkan `search:10`.
  */
 function isAttemptOf(toolCallId: string, base: string): boolean {
   return toolCallId === base || toolCallId.startsWith(`${base}:r`);
 }
 
 /**
- * Hasil `completed` layak reuse hanya bila MEMBAWA TEKS. Task completed ber-`text:""` (turn senyap
- * CTX-7 / result malformed yang dipaksa kosong `normalizeResult`) yang di-reuse membuat synthesize
- * gagal PERMANEN: throw laporan-kosong → retry/time-travel menemukan task "completed" yang sama →
- * tak pernah dispatch attempt baru — kredit run hangus tanpa jalur pulih. Empty completed
- * diperlakukan seperti terminal non-completed → attempt baru ber-suffix (untuk search ini berarti
- * re-riset sub-Q yang hasilnya memang kosong/tak berguna — debit ulang yang membeli jawaban nyata).
+ * Hasil `completed` layak reuse hanya bila MEMBAWA TEKS YANG BERGUNA. Task completed ber-`text:""`
+ * (turn senyap / result malformed yang dipaksa kosong `normalizeResult`) yang di-reuse membuat
+ * synthesize gagal PERMANEN: throw laporan-kosong → retry/time-travel menemukan task "completed"
+ * yang sama → tak pernah dispatch attempt baru — kredit run hangus tanpa jalur pulih. Empty
+ * completed diperlakukan seperti terminal non-completed → attempt baru ber-suffix (untuk search
+ * ini berarti re-riset sub-Q yang hasilnya memang kosong/tak berguna — debit ulang yang membeli
+ * jawaban nyata). Teks yang HANYA berisi fence ```aqsha:viz / marker viz palsu dinilai kosong
+ * juga: synthesize men-strip-nya (anti-forgery) lalu throw laporan-kosong, jadi me-reuse hasil
+ * seperti itu mengunci retry pada kegagalan yang sama.
  */
 function completedWithText(task: BackgroundTask): boolean {
-  return normalizeResult(task.result).text.trim().length > 0;
+  const text = normalizeResult(task.result).text;
+  if (text.trim().length === 0) return false;
+  return injectVizBlocks(text, []).report.trim().length > 0;
 }
 
 /** Poll sampai task terminal (getTask baca storage — andal juga untuk task yang dipulihkan).
- *  Deadline ABSOLUT (epoch ms, A2); abort run (B4) → tutup task lalu lempar. */
+ *  Deadline ABSOLUT (epoch ms); abort run → tutup task lalu lempar. */
 async function waitUntilTerminal(
   manager: BackgroundTaskManager,
   taskId: string,
@@ -161,11 +167,11 @@ async function waitUntilTerminal(
 /**
  * Jalankan satu pemanggilan subagent `/deep` sebagai background task persisten.
  *
- * - Manager tak tersedia (backgroundTasks off / unit test) → fallback FOREGROUND (perilaku
- *   pra-DUR-7, tanpa persist).
- * - Task lama satu identitas logis (base ATAU attempt ber-suffix `:r<N>:<ts>`, B5): `completed`
+ * - Manager tak tersedia (backgroundTasks off / unit test) → fallback FOREGROUND (eksekusi
+ *   langsung tanpa persist).
+ * - Task lama satu identitas logis (base ATAU attempt ber-suffix `:r<N>:<ts>`): `completed`
  *   BER-TEKS → reuse hasil (no re-run/no re-debit); `pending/running/suspended` → register ulang
- *   executor + tunggu maksimal sisa umur task itu (A2; melewati deadline → di-cancel supaya tak
+ *   executor + tunggu maksimal sisa umur task itu (melewati deadline → di-cancel supaya tak
  *   jalan dobel); semua terminal non-completed (atau completed kosong) → dispatch BARU dgn suffix
  *   percobaan berikutnya.
  * - Throw hanya bila task baru berakhir non-completed — pemanggil (step) yang memutuskan isolasi
@@ -179,7 +185,7 @@ export async function runDeepSubagentTask(params: {
   threadId: string;
   resourceId?: string;
   timeoutMs: number;
-  /** B4: abortSignal step (dipicu `run.cancel()`) — tutup task run ini alih-alih jalan terus. */
+  /** abortSignal step (dipicu `run.cancel()`) — Stop dari user menutup task run ini alih-alih membiarkannya jalan terus. */
   abortSignal?: AbortSignal;
 }): Promise<DeepTaskResult> {
   const manager = params.mastra?.backgroundTaskManager;
@@ -188,7 +194,7 @@ export async function runDeepSubagentTask(params: {
 
   let toolCallId = params.toolCallId;
   try {
-    // B5: list per-RUN (bukan exact `toolCallId` — filter storage exact-match) supaya attempt
+    // List per-RUN (bukan exact `toolCallId` — filter storage exact-match) supaya attempt
     // ber-suffix `:r<N>:<ts>` yang BERHASIL ikut ditemukan saat restart; dulu attempt sukses itu
     // tak terlihat → sub-Q diriset (dan didebit `external_search`) ulang.
     const { tasks } = await manager.listTasks({
@@ -202,7 +208,7 @@ export async function runDeepSubagentTask(params: {
     // Prioritas: (1) completed BER-TEKS terbaru → reuse hasil (no re-run / no re-debit);
     const completed = attempts.find((t) => t.status === "completed" && completedWithText(t));
     if (completed) return normalizeResult(completed.result);
-    // (2) non-terminal TERBARU → register ulang executor + tunggu ber-deadline umur task (A2);
+    // (2) non-terminal TERBARU → register ulang executor + tunggu ber-deadline sisa umur task;
     const active = attempts.find((t) => !TERMINAL_STATUSES.has(t.status));
     if (active) {
       manager.registerTaskContext(active.id, { executor: deepTaskExecutor });
@@ -234,7 +240,7 @@ export async function runDeepSubagentTask(params: {
     console.error("[deep-tasks] task lookup failed", err);
   }
 
-  // B4: abort bisa mendarat SELAMA lookup di atas (await panjang) — listener `abort` di bawah
+  // Abort bisa mendarat SELAMA lookup di atas (await panjang) — listener `abort` di bawah
   // dipasang SETELAHNYA dan event pada signal yang sudah aborted tak pernah fire (spec WHATWG),
   // jadi tanpa cek ulang ini task baru lahir + ditunggu full timeout untuk run yang dibatalkan.
   if (params.abortSignal?.aborted) throw new Error("deep task dibatalkan: run di-cancel");
@@ -250,7 +256,7 @@ export async function runDeepSubagentTask(params: {
     timeoutMs: params.timeoutMs,
     context: { executor: deepTaskExecutor },
   });
-  // B4: run di-cancel → tutup task yang baru di-dispatch. KOOPERATIF & JUJUR: cancel menandai
+  // Run di-cancel → tutup task yang baru di-dispatch. KOOPERATIF & JUJUR: cancel menandai
   // record `cancelled` + wait di bawah keluar dini via status terminal itu, tapi `agent.generate`
   // in-flight TIDAK menerima signal (args task wajib JSON-serializable, tanpa closure) — panggilan
   // LLM yang sudah jalan bisa tuntas internal lalu hasilnya dibuang. Kebocoran debit `search_*`

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -87,6 +87,14 @@
   --coral-soft: color-mix(in oklch, var(--coral) 15%, var(--card));
   --coral-soft-border: color-mix(in oklch, var(--coral) 30%, var(--border));
   --shadow-soft-card: var(--shadow);
+  /* Evidence viz /deep — stance meter (yes/possibly/mixed/no). Tervalidasi
+     dataviz validate_palette terhadap surface card tema ini (#f4efe4): lightness
+     band + chroma + CVD PASS; WARN kontras <3:1 di-relief oleh label & angka
+     yang selalu tertulis di komponen. JANGAN ganti sebagian. */
+  --viz-stance-yes: #22a87e;
+  --viz-stance-possibly: #d9a514;
+  --viz-stance-mixed: #bd86ff;
+  --viz-stance-no: #c43f3f;
   /* Global scrollbar — thin, floating, palette-aware. The thumb derives from
      `--muted-foreground`, so it re-resolves per theme (warm taupe in light,
      soft gray in dark) without a separate `.dark` override. */
@@ -164,6 +172,12 @@
   --coral-soft: color-mix(in oklch, var(--coral) 18%, var(--card));
   --coral-soft-border: color-mix(in oklch, var(--coral) 34%, var(--border));
   --shadow-soft-card: var(--shadow);
+  /* Evidence viz /deep — varian dark (surface card #1c1c1c): semua cek PASS
+     termasuk kontras ≥3:1. JANGAN ganti sebagian. */
+  --viz-stance-yes: #22a87e;
+  --viz-stance-possibly: #b3891a;
+  --viz-stance-mixed: #8f7ae0;
+  --viz-stance-no: #d95c5c;
 }
 
 @theme inline {
@@ -683,7 +697,10 @@
   padding: 0.95rem 1.15rem;
 }
 
-:where(.aqsha-prose, .artifact-prose) table {
+/* Semua aturan tabel prose menghormati opt-out `.not-prose` (mis. figur deep-viz yang membawa
+   tabelnya sendiri): subtree .not-prose tak disentuh sama sekali, jadi komponen di dalamnya cukup
+   pakai utility Tailwind polos tanpa perang !important melawan rule unlayered ini. */
+:where(.aqsha-prose, .artifact-prose) table:not(:where(.not-prose, .not-prose *)) {
   display: block;
   width: 100%;
   max-width: 100%;
@@ -695,31 +712,31 @@
   line-height: 1.45;
 }
 
-:where(.aqsha-prose, .artifact-prose) thead {
+:where(.aqsha-prose, .artifact-prose) thead:not(:where(.not-prose, .not-prose *)) {
   background: var(--muted);
 }
 
-:where(.aqsha-prose, .artifact-prose) th,
-:where(.aqsha-prose, .artifact-prose) td {
+:where(.aqsha-prose, .artifact-prose) th:not(:where(.not-prose, .not-prose *)),
+:where(.aqsha-prose, .artifact-prose) td:not(:where(.not-prose, .not-prose *)) {
   border: 1px solid var(--border);
   padding: 0.55rem 0.7rem;
   vertical-align: top;
 }
 
-:where(.aqsha-prose, .artifact-prose) th {
+:where(.aqsha-prose, .artifact-prose) th:not(:where(.not-prose, .not-prose *)) {
   color: var(--foreground);
   font-size: 12px;
   font-weight: 700;
   text-align: left;
 }
 
-:where(.aqsha-prose, .artifact-prose) td p,
-:where(.aqsha-prose, .artifact-prose) th p {
+:where(.aqsha-prose, .artifact-prose) td p:not(:where(.not-prose, .not-prose *)),
+:where(.aqsha-prose, .artifact-prose) th p:not(:where(.not-prose, .not-prose *)) {
   margin: 0;
 }
 
-:where(.aqsha-prose, .artifact-prose) td ul,
-:where(.aqsha-prose, .artifact-prose) td ol {
+:where(.aqsha-prose, .artifact-prose) td ul:not(:where(.not-prose, .not-prose *)),
+:where(.aqsha-prose, .artifact-prose) td ol:not(:where(.not-prose, .not-prose *)) {
   margin: 0.25rem 0;
   padding-left: 1rem;
 }
@@ -759,7 +776,7 @@
   margin: 1.25rem 0 0.55rem;
 }
 
-.aqsha-prose-message table {
+.aqsha-prose-message table:not(:where(.not-prose, .not-prose *)) {
   font-size: 11.5px;
 }
 

--- a/apps/web/components/ai-elements/inline-citation.tsx
+++ b/apps/web/components/ai-elements/inline-citation.tsx
@@ -33,7 +33,11 @@ export function CitationProvider({
   return <CitationContext.Provider value={value}>{children}</CitationContext.Provider>;
 }
 
-function useCitationMap(): Map<number, SourceCardData[]> | undefined {
+/**
+ * Peta sitasi `nomor → kartu` subtree jawaban aktif. Diekspor untuk komponen evidence viz
+ * (`deep-viz/*`) yang me-resolve `papers: number[]` payload ke kartu sumber yang sama.
+ */
+export function useCitationMap(): Map<number, SourceCardData[]> | undefined {
   return useContext(CitationContext);
 }
 

--- a/apps/web/components/ai-elements/message.tsx
+++ b/apps/web/components/ai-elements/message.tsx
@@ -13,6 +13,7 @@ import type {
   ReactNode,
 } from "react";
 import { Streamdown } from "streamdown";
+import dynamic from "next/dynamic";
 import { CitationMarkdownComponent } from "./inline-citation";
 import { TableBlock } from "./table-block";
 import {
@@ -59,9 +60,27 @@ export const MessageContent = ({
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const streamdownPlugins = { cjk, code, math, mermaid };
-// Komponen default: tabel kustom + element `citation` (pill sitasi inline). `citation` hanya muncul
-// bila pemanggil meneruskan `citationRehypePlugins` (lihat `Response`); tanpa itu komponen tak terpakai.
-const streamdownComponents = { table: TableBlock, citation: CitationMarkdownComponent };
+// Subtree deep-viz (6 komponen blok + skema zod chat-core) di-lazy-load: element `deepviz` hanya
+// muncul di laporan `/deep`, jadi pesan chat biasa tak perlu ikut memuatnya di bundle awal.
+const DeepVizMarkdownComponent = dynamic(
+  () =>
+    import("@/features/threads/components/deep-viz/viz-block").then(
+      (m) => m.DeepVizMarkdownComponent,
+    ),
+  {
+    loading: () => (
+      <div className="my-4 h-24 animate-pulse rounded-xl border border-dashed bg-muted/30" />
+    ),
+  },
+);
+// Komponen default: tabel kustom + element `citation` (pill sitasi inline) + element `deepviz`
+// (blok evidence viz laporan `/deep`). `citation`/`deepviz` hanya muncul bila pemanggil meneruskan
+// `reportRehypePlugins` (lihat `Response`); tanpa itu komponen tak terpakai.
+const streamdownComponents = {
+  table: TableBlock,
+  citation: CitationMarkdownComponent,
+  deepviz: DeepVizMarkdownComponent,
+};
 
 export const MessageResponse = ({ className, components, ...props }: MessageResponseProps) => (
     <Streamdown

--- a/apps/web/components/ai-elements/response.tsx
+++ b/apps/web/components/ai-elements/response.tsx
@@ -2,7 +2,8 @@
 
 import { CitationProvider } from "@/components/ai-elements/inline-citation";
 import { MessageResponse } from "@/components/ai-elements/message";
-import { citationRehypePlugins } from "@/features/threads/lib/citation-markdown";
+import { VizFigureProvider } from "@/features/threads/components/deep-viz/viz-context";
+import { reportRehypePlugins } from "@/features/threads/lib/citation-markdown";
 import type { SourceCardData } from "@/features/threads/lib/timeline-types";
 import { useSmoothText } from "@/features/threads/lib/use-smooth-text";
 import { cn } from "@/lib/utils";
@@ -16,27 +17,36 @@ import { cn } from "@/lib/utils";
  * `citations` (peta `nomor → kartu`, dibangun `buildCitationMap`) mengaktifkan pill sitasi inline:
  * penanda `[n]` diubah jadi pill sumber + kartu Link Preview saat hover. Tanpa `citations`, `[n]`
  * tetap teks biasa (degradasi mulus, mis. jawaban tanpa pencarian).
+ *
+ * `viz` HANYA untuk laporan `/deep`: memasang `VizFigureProvider` yang mengizinkan fence
+ * `aqsha:viz` dirender sebagai figur evidence viz. Di pesan lain fence semacam itu pasti
+ * tulisan model (bukan keluaran injector) dan dirender sebagai code block polos (anti-pemalsuan).
  */
 export function Response({
   text,
   streaming,
   className,
   citations,
+  viz,
 }: {
   text: string;
   streaming?: boolean;
   className?: string;
   citations?: Map<number, SourceCardData[]>;
+  viz?: boolean;
 }) {
   const shown = useSmoothText(text, { enabled: streaming ?? false });
+  const content = (
+    <MessageResponse
+      className={cn("aqsha-prose aqsha-prose-message", className)}
+      rehypePlugins={reportRehypePlugins}
+    >
+      {shown}
+    </MessageResponse>
+  );
   return (
     <CitationProvider value={citations}>
-      <MessageResponse
-        className={cn("aqsha-prose aqsha-prose-message", className)}
-        rehypePlugins={citationRehypePlugins}
-      >
-        {shown}
-      </MessageResponse>
+      {viz ? <VizFigureProvider>{content}</VizFigureProvider> : content}
     </CitationProvider>
   );
 }

--- a/apps/web/features/threads/components/deep-viz/claims-evidence.tsx
+++ b/apps/web/features/threads/components/deep-viz/claims-evidence.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { ClaimsEvidenceBlock } from "@aqsha/chat-core/deep-viz";
+import { CLAIM_COLORS, CLAIM_LABELS, CLAIM_TRACK_COLORS } from "./labels";
+import { PaperPills } from "./viz-block";
+
+/**
+ * Tabel klaim & bukti (ala Consensus): 4 kolom Klaim | Kekuatan bukti | Alasan | Paper.
+ * Meter kekuatan = 10 batang vertikal; terisi = warna label (skor DETERMINISTIK builder
+ * chat-core — bukan tulisan LLM), track = step lebih terang ramp yang sama; label teks di
+ * bawah meter (kekuatan tak pernah color-alone). Wrapper `overflow-x-auto` (mobile).
+ */
+export function ClaimsEvidence({ block }: { block: ClaimsEvidenceBlock }) {
+  return (
+    <div className="min-w-0 overflow-x-auto">
+      <table className="w-full min-w-[620px] border-collapse text-left text-[12.5px]">
+        <thead>
+          <tr className="border-b text-[12px] text-foreground">
+            <th className="w-[28%] py-2.5 pr-4 font-semibold">Klaim</th>
+            <th className="w-[19%] py-2.5 pr-4 font-semibold">Kekuatan bukti</th>
+            <th className="w-[33%] py-2.5 pr-4 font-semibold">Alasan</th>
+            <th className="py-2.5 font-semibold">Paper</th>
+          </tr>
+        </thead>
+        <tbody>
+          {block.claims.map((claim, i) => (
+            <tr
+              key={`${i}-${claim.text.slice(0, 24)}`}
+              className="border-b border-border/60 align-top last:border-b-0"
+            >
+              <td className="py-4 pr-4">
+                <p className="break-words font-medium text-foreground leading-5">{claim.text}</p>
+              </td>
+              <td className="py-4 pr-4">
+                <StrengthMeter score={claim.score} label={claim.label} />
+              </td>
+              <td className="py-4 pr-4">
+                <p className="break-words text-muted-foreground leading-5">{claim.reasoning}</p>
+              </td>
+              <td className="py-4">
+                <PaperPills papers={claim.papers} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Meter 10 batang vertikal: terisi = round(score); label teks di bawah (bukan color-alone). */
+function StrengthMeter({
+  score,
+  label,
+}: {
+  score: number;
+  label: ClaimsEvidenceBlock["claims"][number]["label"];
+}) {
+  const filled = Math.round(Math.min(10, Math.max(0, score)));
+  return (
+    <div className="grid gap-1.5" title={`Skor ${score} dari 10`}>
+      <div
+        className="flex items-end gap-[3px]"
+        role="img"
+        aria-label={`Kekuatan bukti ${CLAIM_LABELS[label]} (skor ${score} dari 10)`}
+      >
+        {Array.from({ length: 10 }, (_, i) => (
+          <span
+            key={i}
+            className="h-4 w-[5px] rounded-full"
+            style={{
+              background: i < filled ? CLAIM_COLORS[label] : CLAIM_TRACK_COLORS[label],
+            }}
+          />
+        ))}
+      </div>
+      <span className="text-[11px] text-muted-foreground leading-4">{CLAIM_LABELS[label]}</span>
+    </div>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/consensus-meter.tsx
+++ b/apps/web/features/threads/components/deep-viz/consensus-meter.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import {
+  DEEP_VIZ_STUDY_DESIGNS,
+  type ConsensusMeterBlock,
+  type DeepVizStance,
+} from "@aqsha/chat-core/deep-viz";
+import { ChevronDownIcon } from "@aqsha/ui/icons";
+import { useState } from "react";
+import { DESIGN_ICONS, DESIGN_LABELS, STANCE_COLORS, STANCE_LABELS, STANCE_ORDER } from "./labels";
+
+/**
+ * Meter konsensus per sub-pertanyaan (ala Consensus.app): pertanyaan tebal + chip `N = x`,
+ * kapsul stance dominan, bar bertumpuk TEBAL dengan angka di dalam segmen, legend berkolom
+ * (dot + label + persen + chip ikon design), dan expander "Semua detail". Identitas tak
+ * pernah color-alone (label + angka selalu tampil — relief WARN kontras validator dataviz).
+ */
+
+/** Ink angka DI DALAM segmen, dipilih by luminance fill (spec label-in-fill dataviz):
+ * `no` (merah gelap) satu-satunya yang butuh putih; sisanya ink gelap. */
+const STANCE_SEGMENT_INK: Record<DeepVizStance, string> = {
+  yes: "#1f1d18",
+  possibly: "#1f1d18",
+  mixed: "#1f1d18",
+  no: "#fdfbf6",
+};
+
+/** Angka muat di segmen hanya bila segmen cukup lebar (label tak boleh terpotong). */
+const SEGMENT_LABEL_MIN_PCT = 5;
+
+export function ConsensusMeter({ block }: { block: ConsensusMeterBlock }) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = STANCE_ORDER.filter((stance) => block.stances[stance] > 0);
+  const dominant = visible.reduce<DeepVizStance | null>(
+    (best, stance) => (best === null || block.stances[stance] > block.stances[best] ? stance : best),
+    null,
+  );
+  const pct = (count: number) => (block.n > 0 ? Math.round((count / block.n) * 100) : 0);
+
+  return (
+    <div className="grid min-w-0 gap-3">
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <p className="min-w-0 flex-1 break-words font-semibold text-[14px] text-foreground leading-6">
+          {block.question}
+        </p>
+        <span className="shrink-0 rounded-md bg-muted px-2 py-1 font-medium font-mono text-[11px] text-muted-foreground leading-none tabular-nums">
+          N = {block.n}
+        </span>
+      </div>
+      {dominant ? (
+        <div className="flex justify-end">
+          <span className="inline-flex items-center rounded-full border bg-card px-3 py-1.5 font-medium text-[12px] text-foreground leading-none shadow-xs">
+            {pct(block.stances[dominant])}% paper mengindikasikan &ldquo;{STANCE_LABELS[dominant]}&rdquo;
+          </span>
+        </div>
+      ) : null}
+      {/* Bar bertumpuk tebal — gap 2px antar segmen (surface gap dataviz), angka count di
+          dalam segmen (rata kanan) hanya bila muat. */}
+      <div
+        className="flex h-6 w-full gap-0.5 overflow-hidden"
+        role="img"
+        aria-label={`Sebaran stance ${block.n} paper: ${visible
+          .map((s) => `${STANCE_LABELS[s]} ${block.stances[s]}`)
+          .join(", ")}`}
+      >
+        {visible.map((stance) => {
+          const share = pct(block.stances[stance]);
+          return (
+            <div
+              key={stance}
+              className="flex h-full items-center justify-end rounded-[5px] pr-1.5"
+              style={{
+                width: `${(block.stances[stance] / block.n) * 100}%`,
+                background: STANCE_COLORS[stance],
+                minWidth: 8,
+              }}
+              title={`${STANCE_LABELS[stance]}: ${block.stances[stance]} paper (${share}%)`}
+            >
+              {share >= SEGMENT_LABEL_MIN_PCT ? (
+                <span
+                  className="font-semibold text-[11px] leading-none tabular-nums"
+                  style={{ color: STANCE_SEGMENT_INK[stance] }}
+                >
+                  {block.stances[stance]}
+                </span>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      <div className="grid grid-cols-[auto_minmax(4rem,auto)_3.25rem_1fr] items-center gap-x-3 gap-y-2">
+        {visible.map((stance) => {
+          const designs = block.designByStance[stance];
+          const present = DEEP_VIZ_STUDY_DESIGNS.filter((d) => (designs[d] ?? 0) > 0);
+          return (
+            <div key={stance} className="contents">
+              <span
+                aria-hidden
+                className="size-2.5 rounded-full"
+                style={{ background: STANCE_COLORS[stance] }}
+              />
+              <span className="font-semibold text-[13px] text-foreground leading-5">
+                {STANCE_LABELS[stance]}
+              </span>
+              <span className="text-[12px] text-muted-foreground leading-5 tabular-nums">
+                {pct(block.stances[stance])}%
+              </span>
+              <span className="flex min-w-0 flex-wrap items-center gap-1">
+                {present.map((d) => {
+                  const Icon = DESIGN_ICONS[d];
+                  return (
+                    <span
+                      key={d}
+                      className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-1 text-muted-foreground"
+                      title={`${designs[d]} ${DESIGN_LABELS[d]}`}
+                    >
+                      <Icon className="size-3" />
+                      <span className="text-[10px] leading-none tabular-nums">{designs[d]}</span>
+                    </span>
+                  );
+                })}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => setExpanded((cur) => !cur)}
+          aria-expanded={expanded}
+          className="inline-flex items-center gap-1.5 rounded-full border bg-card px-3 py-1.5 font-medium text-[12px] text-foreground leading-none transition-colors hover:bg-accent"
+        >
+          Semua detail
+          <ChevronDownIcon
+            className={`size-3.5 transition-transform ${expanded ? "rotate-180" : ""}`}
+          />
+        </button>
+      </div>
+      {expanded ? (
+        <ul className="grid gap-1 rounded-lg border bg-muted/20 p-3">
+          {visible.map((stance) => {
+            const designs = block.designByStance[stance];
+            const breakdown = DEEP_VIZ_STUDY_DESIGNS.filter((d) => (designs[d] ?? 0) > 0)
+              .map((d) => `${designs[d]} ${DESIGN_LABELS[d]}`)
+              .join(", ");
+            return (
+              <li key={stance} className="text-[12px] leading-5">
+                <span className="font-medium text-foreground">{STANCE_LABELS[stance]}</span>{" "}
+                <span className="text-muted-foreground tabular-nums">
+                  — {block.stances[stance]} paper ({pct(block.stances[stance])}%)
+                  {breakdown ? `: ${breakdown}` : ""}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/gaps-matrix.tsx
+++ b/apps/web/features/threads/components/deep-viz/gaps-matrix.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { GapsMatrixBlock } from "@aqsha/chat-core/deep-viz";
+import { DESIGN_BUCKET_LABELS } from "./labels";
+
+/**
+ * Matriks celah riset (heatmap outcome × desain studi, ala Consensus): sel = blok warna penuh
+ * dengan count SELALU tertulis (nilai tak pernah color-alone); intensitas = skala SEKUENSIAL
+ * satu hue (`--lavender` via color-mix, dinormalisasi per-matrix, dark/light adaptif). Sel 0 =
+ * polos "–" → celah riset terlihat sebagai "lubang". Kolom pertama sticky + `overflow-x-auto`.
+ */
+export function GapsMatrix({ block }: { block: GapsMatrixBlock }) {
+  const max = Math.max(1, ...block.cells.flat());
+  // 14%..58% dari hue lavender — monoton naik, teks foreground tetap terbaca di dua mode.
+  const cellBg = (value: number): string | undefined =>
+    value > 0
+      ? `color-mix(in oklab, var(--lavender) ${Math.round(14 + (value / max) * 44)}%, var(--card))`
+      : undefined;
+
+  return (
+    <div className="grid min-w-0 gap-2">
+      <div className="min-w-0 overflow-x-auto">
+        <table className="w-full min-w-[520px] table-fixed border-separate border-spacing-[2px] text-[12.5px]">
+          <thead>
+            <tr className="text-[12px] text-foreground">
+              <th className="sticky left-0 z-10 w-[24%] bg-background py-2.5 pr-3 text-left align-bottom font-semibold">
+                Topik/outcome
+              </th>
+              {block.cols.map((col) => (
+                <th key={col} className="px-2 py-2.5 text-left align-bottom font-semibold leading-4">
+                  {DESIGN_BUCKET_LABELS[col]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {block.rows.map((row, ri) => (
+              <tr key={row}>
+                <th
+                  scope="row"
+                  className="sticky left-0 z-10 bg-background py-1.5 pr-3 text-left align-middle font-medium text-foreground"
+                >
+                  <span className="block truncate" title={row}>
+                    {row}
+                  </span>
+                </th>
+                {block.cols.map((col, ci) => {
+                  const value = block.cells[ri]?.[ci] ?? 0;
+                  return (
+                    <td key={col} className="p-0">
+                      <div
+                        className="flex h-11 items-center justify-center rounded-sm font-medium text-foreground tabular-nums"
+                        style={{ background: cellBg(value) }}
+                        title={`${row} × ${DESIGN_BUCKET_LABELS[col]}: ${value} paper`}
+                      >
+                        {value > 0 ? value : <span className="text-muted-foreground/50">–</span>}
+                      </div>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-[11px] text-muted-foreground/70 leading-4">
+        Warna lebih pekat = lebih banyak paper; sel &ldquo;–&rdquo; = belum ada studi (celah riset).
+      </p>
+    </div>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/labels.ts
+++ b/apps/web/features/threads/components/deep-viz/labels.ts
@@ -1,0 +1,85 @@
+// Label + warna + ikon bersama komponen evidence viz `/deep`. Warna stance = token CSS
+// `--viz-stance-*` (apps/web/app/globals.css, tervalidasi dataviz per mode light/dark) —
+// komponen TIDAK menulis hex sendiri. Copy sentence case (aturan copywriting no-uppercase).
+
+import {
+  DEEP_VIZ_STANCES,
+  type DeepVizDesignBucket,
+  type DeepVizStance,
+  type DeepVizStudyDesign,
+} from "@aqsha/chat-core/deep-viz";
+import {
+  BookOpenIcon,
+  ChartColumnIcon,
+  EyeIcon,
+  FileTextIcon,
+  FlaskConicalIcon,
+  SearchIcon,
+} from "@aqsha/ui/icons";
+import type { ComponentType } from "react";
+
+export const STANCE_ORDER: readonly DeepVizStance[] = DEEP_VIZ_STANCES;
+
+export const STANCE_LABELS: Record<DeepVizStance, string> = {
+  yes: "Ya",
+  possibly: "Mungkin",
+  mixed: "Campuran",
+  no: "Tidak",
+};
+
+/** Warna stance via CSS var token (adaptif light/dark) — dipakai sbg `style.background`. */
+export const STANCE_COLORS: Record<DeepVizStance, string> = {
+  yes: "var(--viz-stance-yes)",
+  possibly: "var(--viz-stance-possibly)",
+  mixed: "var(--viz-stance-mixed)",
+  no: "var(--viz-stance-no)",
+};
+
+export const DESIGN_LABELS: Record<DeepVizStudyDesign, string> = {
+  meta_analysis: "meta-analisis",
+  systematic_review: "tinjauan sistematis",
+  rct: "RCT",
+  observational: "observasional",
+  review: "review",
+  other: "lainnya",
+};
+
+/** Ikon badge design ala Consensus (chip kecil di legend meter) — dari `@aqsha/ui/icons`. */
+export const DESIGN_ICONS: Record<DeepVizStudyDesign, ComponentType<{ className?: string }>> = {
+  meta_analysis: ChartColumnIcon,
+  systematic_review: SearchIcon,
+  rct: FlaskConicalIcon,
+  observational: EyeIcon,
+  review: BookOpenIcon,
+  other: FileTextIcon,
+};
+
+export const DESIGN_BUCKET_LABELS: Record<DeepVizDesignBucket, string> = {
+  meta_sysrev: "Meta/tinjauan sistematis",
+  rct: "RCT",
+  observational: "Observasional",
+  other: "Lainnya",
+};
+
+export const CLAIM_LABELS: Record<"strong" | "moderate" | "limited", string> = {
+  strong: "Kuat",
+  moderate: "Sedang",
+  limited: "Terbatas",
+};
+
+/** Warna isi meter kekuatan klaim: kuat=hijau, sedang=kuning (token stance), terbatas=netral. */
+export const CLAIM_COLORS: Record<"strong" | "moderate" | "limited", string> = {
+  strong: "var(--viz-stance-yes)",
+  moderate: "var(--viz-stance-possibly)",
+  limited: "var(--muted-foreground)",
+};
+
+/**
+ * Track (segmen tak terisi) meter kekuatan = step lebih terang dari ramp warna isinya
+ * (spec meter dataviz: state terbaca di sepanjang bar, bukan cuma bagian terisi).
+ */
+export const CLAIM_TRACK_COLORS: Record<"strong" | "moderate" | "limited", string> = {
+  strong: "color-mix(in oklab, var(--viz-stance-yes) 22%, var(--muted))",
+  moderate: "color-mix(in oklab, var(--viz-stance-possibly) 22%, var(--muted))",
+  limited: "color-mix(in oklab, var(--muted-foreground) 18%, var(--muted))",
+};

--- a/apps/web/features/threads/components/deep-viz/open-questions.tsx
+++ b/apps/web/features/threads/components/deep-viz/open-questions.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { OpenQuestionsBlock } from "@aqsha/chat-core/deep-viz";
+
+/**
+ * Pertanyaan riset terbuka (ala Consensus): dua kolom Pertanyaan | Mengapa penting — kartu
+ * membulat di kiri, alasan polos di kanan, pemisah hairline antar baris (stack di mobile).
+ * Tombol panah prefill `/deep <question>` DITUNDA ke follow-up (keputusan terbuka #3 plan:
+ * kanal draft composer butuh kerja baru — jangan bengkakkan slice ini).
+ */
+export function OpenQuestions({ block }: { block: OpenQuestionsBlock }) {
+  return (
+    <div className="grid min-w-0">
+      <div className="hidden grid-cols-2 gap-x-6 border-b pb-2 text-[12px] text-foreground sm:grid">
+        <span className="font-semibold">Pertanyaan</span>
+        <span className="font-semibold">Mengapa penting</span>
+      </div>
+      <ul className="grid min-w-0">
+        {block.items.map((item, i) => (
+          <li
+            key={`${i}-${item.question.slice(0, 24)}`}
+            className="grid min-w-0 grid-cols-1 items-center gap-x-6 gap-y-2 border-b border-border/60 py-3 last:border-b-0 sm:grid-cols-2"
+          >
+            <p className="break-words rounded-xl border bg-muted/30 p-3 font-medium text-[13px] text-foreground leading-5">
+              {item.question}
+            </p>
+            <p className="break-words text-[12.5px] text-muted-foreground leading-5">{item.why}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/results-timeline.tsx
+++ b/apps/web/features/threads/components/deep-viz/results-timeline.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import type { ResultsTimelineBlock } from "@aqsha/chat-core/deep-viz";
+import { useMemo, useState } from "react";
+import { useCitationMap } from "@/components/ai-elements/inline-citation";
+import { SourceCardList } from "../deep-search-cards";
+
+/**
+ * Timeline publikasi (SVG in-house, tanpa lib chart) ala Consensus: marker = PILL bulat
+ * bernomor `[n]`, ukuran 3 kelas by kuantil `citedByCount` (null → terkecil), disusun per
+ * KOLOM TAHUN dari tengah ke atas/bawah (center-out, deterministik — tanpa Math.random).
+ * Gridline tahun putus-putus + baseline sumbu solid. Tahun yang terlalu padat menampilkan
+ * paper paling banyak disitasi + chip `+k` untuk sisanya (tanpa silent cap — dicatat di
+ * keterangan). Klik pill → kartu sumber di bawah chart (resolve via `CitationProvider`).
+ */
+
+type SizeClass = { h: number; fs: number; pad: number };
+const SIZES: Record<"lg" | "md" | "sm", SizeClass> = {
+  lg: { h: 26, fs: 12, pad: 8 },
+  md: { h: 20, fs: 10.5, pad: 6 },
+  sm: { h: 16, fs: 9, pad: 5 },
+};
+
+const COL_W = 44;
+const PAD_X = 18;
+const PLOT_TOP = 10;
+const PLOT_H = 236;
+const AXIS_GAP = 10;
+const H = PLOT_TOP + PLOT_H + AXIS_GAP + 24;
+const PILL_GAP = 5;
+
+type PillLayout = {
+  n: number;
+  year: number;
+  citedByCount: number | null;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fs: number;
+};
+
+type OverflowChip = { year: number; x: number; y: number; count: number };
+
+function pillWidth(n: number, size: SizeClass): number {
+  const digits = String(n).length;
+  return Math.round(size.pad * 2 + digits * size.fs * 0.64);
+}
+
+export function ResultsTimeline({ block }: { block: ResultsTimelineBlock }) {
+  const map = useCitationMap();
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const { pills, overflows, years, width, hiddenTotal } = useMemo(() => {
+    const yearsSorted = block.points.map((p) => p.year).sort((a, b) => a - b);
+    const minYear = yearsSorted[0] ?? 0;
+    const maxYear = yearsSorted[yearsSorted.length - 1] ?? 0;
+    const years = Array.from({ length: maxYear - minYear + 1 }, (_, i) => minYear + i);
+    const width = PAD_X * 2 + years.length * COL_W;
+
+    // Kuantil citedByCount (non-null) → 3 kelas ukuran; null = kelas terkecil.
+    const cited = block.points
+      .map((p) => p.citedByCount)
+      .filter((v): v is number => v !== null)
+      .sort((a, b) => a - b);
+    const q = (f: number) => cited[Math.min(cited.length - 1, Math.floor(f * cited.length))] ?? 0;
+    const q33 = q(1 / 3);
+    const q66 = q(2 / 3);
+    const sizeFor = (citedByCount: number | null): SizeClass => {
+      if (citedByCount === null || cited.length === 0) return SIZES.sm;
+      return citedByCount > q66 ? SIZES.lg : citedByCount > q33 ? SIZES.md : SIZES.sm;
+    };
+
+    // Susun per kolom tahun: paling tersitasi dulu (di tengah), lalu selang-seling atas/bawah.
+    const byYear = new Map<number, ResultsTimelineBlock["points"]>();
+    for (const point of block.points) {
+      if (!byYear.has(point.year)) byYear.set(point.year, []);
+      byYear.get(point.year)?.push(point);
+    }
+    const centerY = PLOT_TOP + PLOT_H / 2;
+    const top = PLOT_TOP;
+    const bottom = PLOT_TOP + PLOT_H;
+    const pills: PillLayout[] = [];
+    const overflows: OverflowChip[] = [];
+    let hiddenTotal = 0;
+    for (const [year, points] of byYear) {
+      const x = PAD_X + (year - minYear + 0.5) * COL_W;
+      const ordered = [...points].sort(
+        (a, b) => (b.citedByCount ?? -1) - (a.citedByCount ?? -1) || a.n - b.n,
+      );
+      let upEdge = centerY;
+      let downEdge = centerY;
+      let upFull = false;
+      let downFull = false;
+      let placed = 0;
+      for (const [i, point] of ordered.entries()) {
+        const size = sizeFor(point.citedByCount);
+        // Selang-seling atas/bawah dari tengah; arah yang penuh DILOMPATI (bukan menghentikan
+        // seluruh kolom — tinggi pill bervariasi, satu sisi bisa penuh duluan padahal sisi lain
+        // masih muat). Berhenti hanya saat kedua arah penuh.
+        const tryUp = (): number | null => {
+          const candidate = upEdge - PILL_GAP - size.h / 2;
+          if (candidate - size.h / 2 < top) {
+            upFull = true;
+            return null;
+          }
+          upEdge = candidate - size.h / 2;
+          return candidate;
+        };
+        const tryDown = (): number | null => {
+          const candidate = downEdge + PILL_GAP + size.h / 2;
+          if (candidate + size.h / 2 > bottom) {
+            downFull = true;
+            return null;
+          }
+          downEdge = candidate + size.h / 2;
+          return candidate;
+        };
+        let y: number | null;
+        if (i === 0) {
+          y = centerY;
+          upEdge = centerY - size.h / 2;
+          downEdge = centerY + size.h / 2;
+        } else if (i % 2 === 1) {
+          y = (upFull ? null : tryUp()) ?? (downFull ? null : tryDown());
+        } else {
+          y = (downFull ? null : tryDown()) ?? (upFull ? null : tryUp());
+        }
+        if (y === null) break;
+        pills.push({
+          n: point.n,
+          year,
+          citedByCount: point.citedByCount,
+          x,
+          y,
+          w: pillWidth(point.n, size),
+          h: size.h,
+          fs: size.fs,
+        });
+        placed += 1;
+      }
+      const hidden = ordered.length - placed;
+      if (hidden > 0) {
+        hiddenTotal += hidden;
+        overflows.push({
+          year,
+          x,
+          y: Math.min(bottom - SIZES.sm.h / 2, downEdge + PILL_GAP + SIZES.sm.h / 2),
+          count: hidden,
+        });
+      }
+    }
+    return { pills, overflows, years, width, hiddenTotal };
+  }, [block.points]);
+
+  const selectedCards = selected !== null ? (map?.get(selected) ?? []) : [];
+  const axisY = PLOT_TOP + PLOT_H + AXIS_GAP;
+
+  return (
+    <div className="grid min-w-0 gap-2">
+      <div className="min-w-0 overflow-x-auto border-t pt-2">
+        <svg
+          width={width}
+          height={H}
+          viewBox={`0 0 ${width} ${H}`}
+          className="text-muted-foreground"
+          role="img"
+          aria-label={`Sebaran ${block.points.length} paper menurut tahun terbit`}
+        >
+          {/* Gridline tahun putus-putus (ala referensi) — recessive, di belakang marker. */}
+          {years.map((year, i) => {
+            const x = PAD_X + (i + 0.5) * COL_W;
+            return (
+              <line
+                key={year}
+                x1={x}
+                x2={x}
+                y1={PLOT_TOP}
+                y2={axisY - 6}
+                stroke="var(--border)"
+                strokeWidth={1}
+                strokeDasharray="2 6"
+              />
+            );
+          })}
+          <line
+            x1={0}
+            x2={width}
+            y1={axisY}
+            y2={axisY}
+            stroke="var(--border)"
+            strokeWidth={1}
+          />
+          {years.map((year, i) => {
+            const x = PAD_X + (i + 0.5) * COL_W;
+            return (
+              <g key={year}>
+                <line x1={x} x2={x} y1={axisY} y2={axisY + 4} stroke="var(--border)" strokeWidth={1} />
+                <text x={x} y={axisY + 16} textAnchor="middle" fontSize={10} className="fill-current">
+                  {year}
+                </text>
+              </g>
+            );
+          })}
+          {pills.map((pill) => {
+            const isSelected = selected === pill.n;
+            return (
+              <g
+                key={`${pill.n}-${pill.year}`}
+                className="cursor-pointer"
+                onClick={() => setSelected((cur) => (cur === pill.n ? null : pill.n))}
+              >
+                <rect
+                  x={pill.x - pill.w / 2}
+                  y={pill.y - pill.h / 2}
+                  width={pill.w}
+                  height={pill.h}
+                  rx={Math.min(8, pill.h * 0.34)}
+                  fill="var(--muted)"
+                  stroke={isSelected ? "var(--ring)" : "none"}
+                  strokeWidth={isSelected ? 1.5 : 0}
+                />
+                <text
+                  x={pill.x}
+                  y={pill.y}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fontSize={pill.fs}
+                  fontWeight={600}
+                  fill="var(--foreground)"
+                  className="pointer-events-none font-mono"
+                >
+                  {pill.n}
+                </text>
+                <title>
+                  {`[${pill.n}] ${pill.year}${pill.citedByCount !== null ? ` · ${pill.citedByCount} sitasi` : ""}`}
+                </title>
+              </g>
+            );
+          })}
+          {overflows.map((chip) => (
+            <g key={`overflow-${chip.year}`}>
+              <text
+                x={chip.x}
+                y={chip.y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={9}
+                fontWeight={600}
+                className="fill-current font-mono"
+              >
+                +{chip.count}
+              </text>
+              <title>{`${chip.count} paper lain tahun ${chip.year}`}</title>
+            </g>
+          ))}
+        </svg>
+      </div>
+      <p className="text-[11px] text-muted-foreground/70 leading-4">
+        Angka = nomor sumber [n]; klik marker untuk melihat sumbernya.
+        {hiddenTotal > 0
+          ? ` Tahun yang padat menampilkan paper paling banyak disitasi (+${hiddenTotal} paper lain tersedia di panel sumber).`
+          : ""}
+      </p>
+      {selected !== null ? (
+        selectedCards.length > 0 ? (
+          <div className="rounded-lg border bg-muted/20 text-[12px]">
+            <SourceCardList sources={selectedCards} />
+          </div>
+        ) : (
+          <p className="text-[11px] text-muted-foreground/70">
+            Sumber [{selected}] tidak ditemukan di panel sumber.
+          </p>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/top-contributors.tsx
+++ b/apps/web/features/threads/components/deep-viz/top-contributors.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { TopContributorsBlock } from "@aqsha/chat-core/deep-viz";
+import { BookOpenIcon, UsersRoundIcon } from "@aqsha/ui/icons";
+import type { ComponentType } from "react";
+import { PaperPills } from "./viz-block";
+
+/**
+ * Kontributor teratas (ala Consensus): tabel Tipe | Nama | Paper — kolom tipe di-rowspan per
+ * grup (ikon + label "Author"/"Jurnal"), nama jurnal italic, kolom paper = chip `[n]` (resolve
+ * `CitationProvider`, `+n lagi` bila > 3). Pemisah baris hairline; header hairline lebih tegas.
+ */
+export function TopContributors({ block }: { block: TopContributorsBlock }) {
+  const groups = [
+    { label: "Author", icon: UsersRoundIcon, rows: block.authors, italic: false },
+    { label: "Jurnal", icon: BookOpenIcon, rows: block.venues, italic: true },
+  ].filter((group) => group.rows.length > 0);
+
+  return (
+    <div className="min-w-0 overflow-x-auto">
+      <table className="w-full min-w-[480px] border-collapse text-left text-[13px]">
+        <thead>
+          <tr className="border-b text-[12px] text-foreground">
+            <th className="w-[26%] py-2.5 pr-3 font-semibold">Tipe</th>
+            <th className="w-[34%] py-2.5 pr-3 font-semibold">Nama</th>
+            <th className="py-2.5 font-semibold">Paper</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map((group) => (
+            <ContributorGroup key={group.label} {...group} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ContributorGroup({
+  label,
+  icon: Icon,
+  rows,
+  italic,
+}: {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  rows: Array<{ name: string; papers: number[] }>;
+  italic: boolean;
+}) {
+  return (
+    <>
+      {rows.map((row, i) => (
+        <tr key={row.name} className="border-b border-border/60 last:border-b-0">
+          {i === 0 ? (
+            <th
+              scope="rowgroup"
+              rowSpan={rows.length}
+              className="py-3.5 pr-3 align-top font-medium text-foreground"
+            >
+              <span className="inline-flex items-center gap-2">
+                <Icon className="size-4 text-muted-foreground" />
+                {label}
+              </span>
+            </th>
+          ) : null}
+          <td className={`py-3.5 pr-3 align-middle ${italic ? "italic" : ""}`}>
+            <span className="block break-words text-foreground">{row.name}</span>
+          </td>
+          <td className="py-3.5 align-middle">
+            <PaperPills papers={row.papers} />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/viz-block.tsx
+++ b/apps/web/features/threads/components/deep-viz/viz-block.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { parseDeepVizBlock, type DeepVizBlock } from "@aqsha/chat-core/deep-viz";
+import { Component, useMemo, type ReactNode } from "react";
+import { useCitationMap } from "@/components/ai-elements/inline-citation";
+import { sourceHref } from "../../lib/source-card";
+import { ClaimsEvidence } from "./claims-evidence";
+import { ConsensusMeter } from "./consensus-meter";
+import { GapsMatrix } from "./gaps-matrix";
+import { OpenQuestions } from "./open-questions";
+import { ResultsTimeline } from "./results-timeline";
+import { TopContributors } from "./top-contributors";
+import { useVizFigureAssign } from "./viz-context";
+
+/**
+ * Renderer element `<deepviz payload="…">` (hasil transform `reportRehypePlugin`) untuk
+ * Streamdown — blok evidence viz laporan `/deep`. Tanpa `VizFigureProvider` (pesan non-deep)
+ * payload dirender sebagai code block polos: fence `aqsha:viz` di chat biasa pasti tulisan
+ * model, bukan keluaran injector (anti-pemalsuan). `payload` divalidasi `parseDeepVizBlock`
+ * (zod contract chat-core, di-memo — payload multi-KB tak perlu diparse ulang tiap render):
+ * JSON korup / `v` tak dikenal / `type` tak dikenal → kotak fallback ringkas + expander JSON,
+ * BUKAN crash; runtime error komponen ditangkap error boundary dengan fallback yang sama.
+ */
+export function DeepVizMarkdownComponent(props: Record<string, unknown>) {
+  const payload = typeof props.payload === "string" ? props.payload : "";
+  const assignFigure = useVizFigureAssign();
+  const block = useMemo(() => (payload ? parseDeepVizBlock(payload) : null), [payload]);
+  if (!assignFigure) return <VizPlainCode payload={payload} />;
+  if (!block) return <VizFallback payload={payload} />;
+  // Nomor figur: `block.figure` di-stamp injector sesuai urutan dokumen final; fallback
+  // registry mount-order untuk laporan lama yang dipersist sebelum field itu ada.
+  const figure = block.figure ?? assignFigure(block.id);
+  return (
+    <VizErrorBoundary payload={payload}>
+      <VizFigure figure={figure} block={block} />
+    </VizErrorBoundary>
+  );
+}
+
+/** Render polos fence `aqsha:viz` di luar laporan `/deep` — tampil sebagai kode, bukan figur. */
+function VizPlainCode({ payload }: { payload: string }) {
+  return (
+    <pre className="overflow-x-auto">
+      <code>{payload}</code>
+    </pre>
+  );
+}
+
+/** Judul seksi di ATAS konten (ala Consensus) — meter konsensus tanpa judul generik
+ * (pertanyaannya sendiri yang jadi judul). */
+const VIZ_TITLES: Partial<Record<DeepVizBlock["type"], string>> = {
+  "results-timeline": "Timeline publikasi",
+  "top-contributors": "Kontributor teratas",
+  "claims-evidence": "Tabel klaim & bukti",
+  "gaps-matrix": "Celah riset",
+  "open-questions": "Pertanyaan riset terbuka",
+};
+
+/** Deskripsi caption "Gambar n" di BAWAH konten (sentence case, jujur soal metode). */
+function vizCaption(block: DeepVizBlock): string {
+  switch (block.type) {
+    case "consensus-meter":
+      return `Sebaran temuan ${block.n} paper terhadap sub-pertanyaan; klasifikasi berdasar judul + abstrak/snippet (bukan teks penuh).`;
+    case "results-timeline":
+      return "Timeline publikasi paper yang disertakan; marker lebih besar = lebih banyak sitasi.";
+    case "top-contributors":
+      return "Author & jurnal yang paling sering muncul pada paper yang disertakan.";
+    case "claims-evidence":
+      return "Klaim kunci beserta kekuatan bukti pendukung yang teridentifikasi dari paper.";
+    case "gaps-matrix":
+      return "Jumlah studi per topik/outcome dan desain studi; sel kosong = celah riset.";
+    case "open-questions":
+      return "Pertanyaan terbuka yang menyoroti arah riset selanjutnya.";
+  }
+}
+
+/**
+ * Frame figur ala artikel ilmiah (referensi Consensus): judul tebal di atas, konten flush
+ * (tanpa kotak card — hairline dibawa masing-masing blok), caption "Gambar n" + deskripsi
+ * kecil di bawah.
+ */
+function VizFigure({ figure, block }: { figure: number; block: DeepVizBlock }) {
+  const label = Number.isFinite(figure) && figure > 0 ? `Gambar ${figure}` : "Gambar";
+  const title = VIZ_TITLES[block.type];
+  return (
+    <figure className="deep-viz my-6 min-w-0 not-prose">
+      {title ? (
+        <p className="mb-3 font-semibold text-[15px] text-foreground leading-6">{title}</p>
+      ) : null}
+      <VizBlockBody block={block} />
+      <figcaption className="mt-3 flex min-w-0 items-baseline gap-2 text-[11px] leading-4">
+        <span className="shrink-0 font-medium font-mono text-muted-foreground/80 tracking-wide">
+          {label}
+        </span>
+        <span className="min-w-0 text-muted-foreground">{vizCaption(block)}</span>
+      </figcaption>
+    </figure>
+  );
+}
+
+function VizBlockBody({ block }: { block: DeepVizBlock }) {
+  switch (block.type) {
+    case "consensus-meter":
+      return <ConsensusMeter block={block} />;
+    case "results-timeline":
+      return <ResultsTimeline block={block} />;
+    case "top-contributors":
+      return <TopContributors block={block} />;
+    case "claims-evidence":
+      return <ClaimsEvidence block={block} />;
+    case "gaps-matrix":
+      return <GapsMatrix block={block} />;
+    case "open-questions":
+      return <OpenQuestions block={block} />;
+    default:
+      return null;
+  }
+}
+
+/** Fallback ringkas saat payload korup/tak dikenal — bukan crash, JSON tetap bisa diintip. */
+function VizFallback({ payload }: { payload: string }) {
+  return (
+    <div className="my-4 rounded-xl border border-dashed bg-muted/30 p-3 text-[12px] text-muted-foreground not-prose">
+      <p>Visual tidak dapat dimuat.</p>
+      {payload ? (
+        <details className="mt-1.5">
+          <summary className="cursor-pointer text-[11px] text-muted-foreground/70">
+            Lihat data mentah
+          </summary>
+          <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted/50 p-2 text-[10px] leading-4">
+            {payload}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+/** Error boundary per blok: runtime error satu visual tak boleh merobohkan seluruh laporan. */
+class VizErrorBoundary extends Component<
+  { payload: string; children: ReactNode },
+  { failed: boolean }
+> {
+  override state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  override render() {
+    if (this.state.failed) return <VizFallback payload={this.props.payload} />;
+    return this.props.children;
+  }
+}
+
+/**
+ * Pill nomor paper `[n]` kompak untuk tabel viz (kolom Papers) — resolve ke kartu sumber lewat
+ * `CitationProvider` yang SUDAH membungkus laporan. Nomor tanpa kartu ter-resolve tetap tampil
+ * sebagai teks `[n]` (degradasi mulus). Maksimal `max` pill; sisanya diringkas "+n lainnya".
+ */
+export function PaperPills({ papers, max = 3 }: { papers: number[]; max?: number }) {
+  const map = useCitationMap();
+  const shown = papers.slice(0, max);
+  const extra = papers.length - shown.length;
+  const chipClass =
+    "inline-flex items-center rounded-md bg-muted px-2 py-1 font-medium font-mono text-[10px] text-muted-foreground leading-none tabular-nums transition-colors hover:bg-accent hover:text-foreground";
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5">
+      {shown.map((n) => {
+        const card = map?.get(n)?.[0];
+        const href = card ? sourceHref(card) : null;
+        const pill = <span className={chipClass}>[{n}]</span>;
+        return href ? (
+          <a
+            key={n}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={card?.title}
+            className="no-underline"
+          >
+            {pill}
+          </a>
+        ) : (
+          <span key={n} title={card?.title}>
+            {pill}
+          </span>
+        );
+      })}
+      {extra > 0 ? (
+        <span
+          className={chipClass}
+          title={papers
+            .slice(max)
+            .map((n) => `[${n}]`)
+            .join(" ")}
+        >
+          +{extra} lagi
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/web/features/threads/components/deep-viz/viz-context.tsx
+++ b/apps/web/features/threads/components/deep-viz/viz-context.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { createContext, useCallback, useContext, useRef, type ReactNode } from "react";
+
+/**
+ * Context figur evidence viz. Kehadirannya SEKALIGUS gate render: provider hanya dipasang
+ * `Response` untuk pesan laporan `/deep` (fence `aqsha:viz`-nya keluaran injector tepercaya).
+ * Di luar itu — chat biasa, di mana fence semacam itu pasti tulisan model — komponen `deepviz`
+ * melihat context `null` dan merender code block polos, bukan figur "resmi" (anti-pemalsuan).
+ *
+ * Nomor figur utama datang dari `block.figure` (di-stamp injector chat-core sesuai urutan
+ * dokumen). `assign` = fallback mount-order untuk laporan lama yang dipersist sebelum field
+ * `figure` ada: id blok → nomor urut saat pertama dirender (id unik per laporan → stabil
+ * antar re-render dan selama streaming).
+ */
+const VizFigureContext = createContext<((id: string) => number) | null>(null);
+
+export function useVizFigureAssign(): ((id: string) => number) | null {
+  return useContext(VizFigureContext);
+}
+
+export function VizFigureProvider({ children }: { children: ReactNode }) {
+  const registry = useRef(new Map<string, number>());
+  const assign = useCallback((id: string) => {
+    const numbers = registry.current;
+    const existing = numbers.get(id);
+    if (existing !== undefined) return existing;
+    const next = numbers.size + 1;
+    numbers.set(id, next);
+    return next;
+  }, []);
+  return <VizFigureContext.Provider value={assign}>{children}</VizFigureContext.Provider>;
+}

--- a/apps/web/features/threads/components/message-list.tsx
+++ b/apps/web/features/threads/components/message-list.tsx
@@ -283,6 +283,11 @@ function AssistantMessage({
   const processParts = message.parts.filter(
     (p) => p.kind === "tool" || p.kind === "reasoning" || (p.kind === "text" && p.id !== answerId),
   );
+  // Pesan laporan `/deep` = punya baris step Workflow (`wf:<stepId>`), live maupun riwayat.
+  // Hanya pesan ini yang boleh merender fence `aqsha:viz` sebagai figur (lihat prop `viz` Response).
+  const isDeepReport = message.parts.some(
+    (p) => p.kind === "tool" && p.model.toolCallId.startsWith("wf:"),
+  );
   const toolSteps = processParts.filter((p) => p.kind === "tool").length;
   // Anchor timer "Sedang bekerja": startedAt step Workflow yang SEDANG berjalan (snapshot `/deep`,
   // durable lintas-refresh — sengaja bukan awal run supaya jeda menunggu plan-gate tak terhitung);
@@ -345,7 +350,12 @@ function AssistantMessage({
       ) : null}
 
       {answer ? (
-        <Response text={answer.text} streaming={answer.streaming} citations={citationMap} />
+        <Response
+          text={answer.text}
+          streaming={answer.streaming}
+          citations={citationMap}
+          viz={isDeepReport}
+        />
       ) : null}
 
       {artifactParts.map((part) =>

--- a/apps/web/features/threads/components/tool-row.tsx
+++ b/apps/web/features/threads/components/tool-row.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@aqsha/ui/components/badge";
 import {
   BookmarkIcon,
   BookOpenIcon,
+  ChartColumnIcon,
   CheckCircle2Icon,
   ChevronDownIcon,
   FileTextIcon,
@@ -55,6 +56,8 @@ function ToolGlyph({ name, className }: { name: string; className?: string }) {
       return <Scale className={className} />;
     case "assign-citations":
       return <Quote className={className} />;
+    case "analyze-sources":
+      return <ChartColumnIcon className={className} />;
     case "verify-citations":
     case "verify_citations":
     case "verify_identifiers":
@@ -93,7 +96,7 @@ function ToolGlyph({ name, className }: { name: string; className?: string }) {
 
 // Afordans live/gagal selalu menang: running → spinner; failed/denied → silang; selain
 // itu → ikon semantik per nama tool (fallback wrench). Delegasi subagent (kind
-// "subagent-call", Slice 7.1) pakai teleskop agar terbaca sebagai riset terdelegasi.
+// "subagent-call") pakai teleskop agar terbaca sebagai riset terdelegasi.
 function ToolStatusIcon({
   status,
   name,
@@ -141,7 +144,7 @@ function toneClass(status: ToolStatus): string {
 }
 
 /**
- * Satu pemanggilan alat sebagai baris collapsible (Slice 6.3, port shell V1).
+ * Satu pemanggilan alat sebagai baris collapsible.
  * Collapsed: ikon status + judul (Shimmer + kueri inline selagi running) + badge
  * hasil. Expanded: scalar curated (default-deny via adapter) dikelompokkan Masukan
  * / Hasil. Tool tanpa body scalar = baris polos.
@@ -282,7 +285,8 @@ export function ToolRow({
             </div>
           </ScrollDetailTrigger>
         ) : detail && detail.kind === "text" ? (
-          // Prosa panjang (bukti tandingan / verifikasi) → preview, klik buka panel step penuh.
+          // Prosa panjang (bukti tandingan / verifikasi / analisis bukti) → preview, klik buka
+          // panel step penuh.
           <ScrollDetailTrigger
             className="mt-1.5"
             onOpen={openStep ? () => openStep(model.toolCallId) : undefined}

--- a/apps/web/features/threads/lib/citation-markdown.ts
+++ b/apps/web/features/threads/lib/citation-markdown.ts
@@ -1,16 +1,18 @@
 // Parsing penanda sitasi `[n]` / `[n, m]` di prosa jawaban Astra → element kustom `<citation>` yang
 // dirender sebagai pill sumber (lihat `components/ai-elements/inline-citation.tsx`). Dua bagian:
 //
-//  1. `citationRehypePlugin` — rehype plugin yang memindai HAST text node, memecah token `[n]`, dan
-//     menyisipkan element `citation` (atribut `citations="1,2"`). Berjalan PALING AKHIR dalam pipeline
-//     (lihat `citationRehypePlugins`) sehingga element kita dibuat SETELAH sanitize/harden bawaan
-//     Streamdown → tak perlu memperluas skema sanitasi, dan node kode/tautan dilewati.
+//  1. `reportRehypePlugin` — rehype plugin (SATU traversal) yang memindai HAST: text node dipecah
+//     pada token `[n]` → element `citation` (atribut `citations="1,2"`), dan `pre>code` ber-bahasa
+//     `aqsha:viz` → element `deepviz` (helper `viz-markdown.ts`). Berjalan PALING AKHIR dalam
+//     pipeline (lihat `reportRehypePlugins`) sehingga element kita dibuat SETELAH sanitize/harden
+//     bawaan Streamdown → tak perlu memperluas skema sanitasi, dan node kode/tautan dilewati.
 //  2. `buildCitationMap` — `Map<number, SourceCardData[]>` dari kartu sumber pesan (chat `search-flat`
 //     yang membawa `citationNumber`, atau baris `research_sources` deep). Komponen `citation` melihat
 //     map ini lewat React Context untuk me-resolve `[n]` → kartu (fallback teks `[n]` bila tak ada).
 
 import { defaultRehypePlugins, type StreamdownProps } from "streamdown";
 import type { SourceCardData } from "./timeline-types";
+import { DEEP_VIZ_TAG, vizElementFromPre } from "./viz-markdown";
 
 /** Nama tag + atribut element sitasi kustom (dipakai bareng komponen render di message.tsx). */
 export const CITATION_TAG = "citation";
@@ -19,19 +21,20 @@ export const CITATION_ATTR = "citations";
 // `[1]`, `[1, 2]`, `[3,4,5]` — hanya digit + koma di dalam kurung (tak menyentuh `[teks](url)`).
 const CITATION_RE = /\[(\d+(?:\s*,\s*\d+)*)\]/g;
 // Subtree yang TAK boleh diutak-atik: kode (indeks array `arr[0]`), tautan (label numerik), serta
-// element sitasi yang sudah jadi.
-const SKIP_TAGS = new Set(["code", "pre", "a", CITATION_TAG]);
+// element sitasi/viz yang sudah jadi.
+const SKIP_TAGS = new Set(["code", "pre", "a", CITATION_TAG, DEEP_VIZ_TAG]);
 
-// Subset bentuk HAST yang kita pakai — paket tipe `hast` tak terpasang sebagai dependency langsung.
-type HastText = { type: "text"; value: string };
-type HastElement = {
+// Subset bentuk HAST yang kita pakai — paket tipe `hast` tak terpasang sebagai dependency
+// langsung. Diekspor untuk plugin rehype saudara (`viz-markdown.ts`) — satu definisi bersama.
+export type HastText = { type: "text"; value: string };
+export type HastElement = {
   type: "element";
   tagName: string;
   properties?: Record<string, unknown>;
   children: HastChild[];
 };
-type HastChild = HastText | HastElement | { type: string; [k: string]: unknown };
-type HastRoot = { type: "root"; children: HastChild[] };
+export type HastChild = HastText | HastElement | { type: string; [k: string]: unknown };
+export type HastRoot = { type: "root"; children: HastChild[] };
 
 /** Pecah satu text node pada token `[n]` → [teks, <citation>, teks, …]. Tanpa token → node apa adanya. */
 function splitTextNode(node: HastText): HastChild[] {
@@ -63,7 +66,7 @@ function splitTextNode(node: HastText): HastChild[] {
   return out;
 }
 
-/** Rekursi anak HAST: pecah text node, lewati subtree `SKIP_TAGS`. */
+/** Rekursi anak HAST: pecah text node, ganti `pre` viz → `deepviz`, lewati subtree `SKIP_TAGS`. */
 function walk(children: HastChild[]): HastChild[] {
   const out: HastChild[] = [];
   for (const child of children) {
@@ -71,6 +74,12 @@ function walk(children: HastChild[]): HastChild[] {
       out.push(...splitTextNode(child as HastText));
     } else if (child.type === "element") {
       const el = child as HastElement;
+      if (el.tagName === "pre") {
+        // Satu-satunya transform di dalam `pre`: fence `aqsha:viz` → `deepviz`; `pre` lain
+        // dilewati utuh (sitasi tak boleh menyentuh kode).
+        out.push(vizElementFromPre(el) ?? el);
+        continue;
+      }
       if (!SKIP_TAGS.has(el.tagName) && Array.isArray(el.children)) {
         el.children = walk(el.children);
       }
@@ -82,8 +91,8 @@ function walk(children: HastChild[]): HastChild[] {
   return out;
 }
 
-/** Rehype plugin: transform `[n]` → `<citation>` di seluruh pohon. */
-function citationRehypePlugin() {
+/** Rehype plugin: transform `[n]` → `<citation>` dan fence `aqsha:viz` → `<deepviz>` — satu traversal. */
+function reportRehypePlugin() {
   return (tree: HastRoot) => {
     if (Array.isArray(tree.children)) tree.children = walk(tree.children);
   };
@@ -113,15 +122,16 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 /**
- * Pipeline rehype lengkap untuk jawaban tercitasi: plugin bawaan Streamdown (raw → sanitize → harden)
- * lalu transform sitasi di urutan TERAKHIR. Kita merekonstruksi default-nya karena meneruskan prop
- * `rehypePlugins` MENGGANTIKAN seluruh default (bukan menambah); menjalankan transform setelah sanitize
- * berarti element `citation` kita tepercaya (dibuat dari teks yang sudah bersih) tanpa perlu allowlist.
+ * Pipeline rehype lengkap untuk jawaban laporan: plugin bawaan Streamdown (raw → sanitize → harden)
+ * lalu transform sitasi `[n]` → `<citation>` + fence `aqsha:viz` → `<deepviz>` (satu walk) di
+ * urutan TERAKHIR. Kita merekonstruksi default-nya karena meneruskan prop `rehypePlugins`
+ * MENGGANTIKAN seluruh default (bukan menambah); menjalankan transform setelah sanitize berarti
+ * element kustom kita tepercaya (dibuat dari pohon yang sudah bersih) tanpa perlu allowlist.
  * Referensi modul-level yang stabil → memo Block Streamdown tetap valid.
  */
-export const citationRehypePlugins = [
+export const reportRehypePlugins = [
   ...Object.values(defaultRehypePlugins as unknown as Record<string, unknown>),
-  citationRehypePlugin,
+  reportRehypePlugin,
 ] as NonNullable<StreamdownProps["rehypePlugins"]>;
 
 /**

--- a/apps/web/features/threads/lib/mastra-timeline.ts
+++ b/apps/web/features/threads/lib/mastra-timeline.ts
@@ -1,5 +1,6 @@
 import type { AskQuestion } from "@aqsha/chat-core";
 import { normalizeAskQuestions } from "@aqsha/chat-core";
+import { formatDeepAnalyzeSummary } from "@aqsha/chat-core/deep-viz";
 import { toCards } from "./source-card";
 import type {
   ArtifactCardModel,
@@ -46,7 +47,7 @@ export type MastraPlanGate = { plan: string; subQuestions: string[] };
 export type MastraAskGate = {
   source: "tool" | "workflow";
   questions: AskQuestion[];
-  /** Temuan parsial pra-klarifikasi (TOOL-3) — dirender di atas pertanyaan agar riset tak terbuang. */
+  /** Temuan parsial pra-klarifikasi — dirender di atas pertanyaan agar riset tak terbuang. */
   findings?: string;
   /** toolCallId — jalur chat (resume via sendToolApproval/resumeStream). */
   toolCallId?: string;
@@ -162,7 +163,7 @@ type ToolInvocationLike = {
 /**
  * History thread Mastra (`getMemoryThread().listMessages()` → `MastraDBMessage[]`) →
  * `TimelineMessage[]` seed. Rekonstruksi part TERURUT: teks, reasoning, DAN tool/artifact
- * (`tool-invocation`) — supaya kartu artefak + jejak proses tetap muncul setelah refresh (G7),
+ * (`tool-invocation`) — supaya kartu artefak + jejak proses tetap muncul setelah refresh,
  * konsisten dengan tampilan live.
  */
 export function mastraMessagesToTimeline(messages: readonly MastraDBMessageLike[]): TimelineMessage[] {
@@ -203,10 +204,10 @@ export function mastraMessagesToTimeline(messages: readonly MastraDBMessageLike[
         parts.push({ kind: "text", id: `${m.id}:t`, text: m.content.content, streaming: false });
       }
     }
-    // `turnId` dari metadata laporan `/deep` (`deepRunId`) → memetakan Sumber per-turn (G4).
+    // `turnId` dari metadata laporan `/deep` (`deepRunId`) → memetakan Sumber per-turn.
     const deepRunId = m.content?.metadata?.deepRunId;
     // Jejak proses `/deep` (`metadata.deepProcess`) → bangun ulang langkah + detail DI DEPAN laporan
-    // (process block sebelum jawaban), agar tetap muncul di riwayat & setelah refresh (G7).
+    // (process block sebelum jawaban), agar tetap muncul di riwayat & setelah refresh.
     const deepProcessRaw = m.content?.metadata?.deepProcess;
     const deepProcessObj =
       deepProcessRaw && typeof deepProcessRaw === "object" && !Array.isArray(deepProcessRaw)
@@ -214,7 +215,7 @@ export function mastraMessagesToTimeline(messages: readonly MastraDBMessageLike[
         : undefined;
     const deepParts = deepProcessObj ? deepProcessParts(deepProcessObj) : [];
     // Sumber bernomor laporan (`deepProcess.sources`, format tool `{ n, title, url, … }`) → fallback
-    // DB-independen untuk pill `[n]` + panel "Sumber" bila fetch `research_sources` live meleset (G4 robust).
+    // DB-independen untuk pill `[n]` + panel "Sumber" bila fetch `research_sources` live meleset.
     const reportSources = deepProcessObj ? toCards(deepProcessObj.sources) : [];
     return {
       id: m.id,
@@ -296,7 +297,7 @@ export function settleAssistantTurn(state: MastraTimelineState): MastraTimelineS
 }
 
 /**
- * Apakah pesan asisten terakhir sudah memuat TEKS jawaban non-kosong? Pembeda `error` chunk (FE-6):
+ * Apakah pesan asisten terakhir sudah memuat TEKS jawaban non-kosong? Pembeda `error` chunk:
  * ada teks → jawaban kemungkinan TERPOTONG (settle + banner "mungkin terpotong", retry via Buat
  * ulang); belum ada teks (baru tool-call/reasoning) → user belum dapat jawaban sama sekali →
  * banner error penuh. Tool-row saja TIDAK dihitung output — dulu 1 tool-row cukup membuat error
@@ -309,7 +310,7 @@ function lastAssistantHasAnswerText(state: MastraTimelineState): boolean {
 }
 
 /**
- * Buang pasangan [user, assistant] TERAKHIR dari timeline lokal — dipakai regenerate `/deep` (FE-8):
+ * Buang pasangan [user, assistant] TERAKHIR dari timeline lokal — dipakai regenerate `/deep`:
  * `sendDeep` menambah ulang bubble user + placeholder-nya sendiri, jadi keduanya harus hilang dulu
  * (beda dari `startRegenerate` yang mempertahankan bubble user untuk jalur chat).
  */
@@ -329,7 +330,7 @@ export function dropLastTurn(state: MastraTimelineState): MastraTimelineState {
 }
 
 /**
- * Mulai regenerate (G6): buang pesan assistant terakhir (jawaban lama) lalu tambah placeholder
+ * Mulai regenerate: buang pesan assistant terakhir (jawaban lama) lalu tambah placeholder
  * assistant streaming baru — TANPA menambah bubble user duplikat (pertahankan pesan user terakhir).
  */
 export function startRegenerate(state: MastraTimelineState): MastraTimelineState {
@@ -438,7 +439,7 @@ export function reduceMastraChunk(
     }
 
     case "tool-call-delta": {
-      // IMP-11: arg tool mengalir sebagai teks JSON parsial — akumulasikan + parse best-effort
+      // Arg tool mengalir sebagai teks JSON parsial — akumulasikan + parse best-effort
       // agar kartu tool terisi progresif (kueri terlihat "mengetik"), bukan pop utuh saat
       // `tool-call` final tiba (yang tetap menimpa dengan args lengkap).
       const [s, idx] = ensureActiveAssistant(streaming(state));
@@ -516,11 +517,11 @@ export function reduceMastraChunk(
     }
 
     case "abort":
-      // Stop bersih (server cancel via abortThread) → settle, tanpa error. (G5)
+      // Stop bersih (server cancel via abortThread) → settle, tanpa error.
       return settleAssistantTurn(state);
 
     case "error":
-      // FE-6: bedakan error-ekor berdasarkan ada/tidaknya TEKS jawaban. Sudah ada teks → provider
+      // Bedakan error-ekor berdasarkan ada/tidaknya TEKS jawaban. Sudah ada teks → provider
       // mati mid-jawaban: settle + banner "mungkin terpotong" supaya user tahu bisa retry (dulu
       // di-settle senyap → setengah jawaban tampak lengkap). Belum ada teks (baru tool-call/
       // reasoning) → turn gagal tanpa jawaban: banner error penuh.
@@ -544,7 +545,7 @@ export function reduceMastraChunk(
 }
 
 /**
- * Settle turn Workflow BY `runId` (FE-7): `settleAssistantTurn` menyasar last-streaming-by-POSITION,
+ * Settle turn Workflow BY `runId`: `settleAssistantTurn` menyasar last-streaming-by-POSITION,
  * jadi `workflow-finish` yang telat (reject-plan → kirim pesan baru cepat) bisa men-settle placeholder
  * turn BARU → ghost bubble kosong. Di sini sasar pesan ber-`turnId === runId` (di-tag saat
  * `workflow-start`/seed); status hanya kembali "ready" bila tak ada turn lain yang masih streaming.
@@ -575,7 +576,7 @@ export function settleWorkflowTurn(
 }
 
 /**
- * B1: hidupkan lagi turn `/deep` yang failed SEBELUM retry time-travel. Chunk retry mengalir via
+ * Hidupkan lagi turn `/deep` yang failed SEBELUM retry time-travel. Chunk retry mengalir via
  * `reduceWorkflowChunk` yang menyasar assistant STREAMING (`ensureActiveAssistant`) — turn failed
  * sudah settle (`streaming: false`), jadi tanpa revive retry melahirkan bubble kembar. Turn
  * ber-`turnId === runId` ditandai streaming lagi; tak ditemukan (mis. retry sebelum seed) →
@@ -613,7 +614,7 @@ function finishReason(payload: Record<string, unknown>): string {
   return str(payload.reason);
 }
 
-// ── adapter Workflow `/deep` (G2) ──────────────────────────────────────────────
+// ── adapter Workflow `/deep` ───────────────────────────────────────────────────
 //
 // Stream Workflow (`run.stream`/`resumeStream`/`observe`) memancarkan `StreamVNextChunkType`
 // {type,payload,runId,from:'WORKFLOW'} STEP-LEVEL (subagent pakai `.generate()`, tak ada token
@@ -629,12 +630,13 @@ const WF_STEP_LABELS: Record<string, string> = {
   "search-literature": "Menelaah literatur",
   "counter-evidence": "Mencari bukti tandingan",
   "assign-citations": "Menomori sumber",
+  "analyze-sources": "Menganalisis bukti",
   "verify-citations": "Memverifikasi sitasi",
   synthesize: "Menulis sintesis",
   "persist-report": "Menyimpan laporan",
 };
 
-/** Diekspor untuk kartu run gagal (B1) — label langkah yang sama dgn baris "Proses". */
+/** Diekspor untuk kartu run `/deep` gagal — label langkah yang sama dgn baris "Proses". */
 export function wfStepLabel(stepId: string): string {
   return WF_STEP_LABELS[stepId] ?? humanizeSlug(stepId);
 }
@@ -642,7 +644,7 @@ export function wfStepLabel(stepId: string): string {
 /**
  * Urutan step user-facing Workflow `/deep` (cocokkan rantai `.then()` di `deep-research.ts`).
  * Dipakai untuk menyeed stepper saat re-attach refresh. Step `input` (mapping) sengaja dilewati.
- * `draft-clarify`/`clarify` ikut di-seed (IMP-12) — tanpa ini baris klarifikasi hilang dari trace
+ * `draft-clarify`/`clarify` ikut di-seed — tanpa ini baris klarifikasi hilang dari trace
  * setelah reload; step yang tak ada di snapshot (mis. clarify yang dilewati) otomatis di-skip.
  */
 const WF_STEP_ORDER = [
@@ -653,6 +655,7 @@ const WF_STEP_ORDER = [
   "search-literature",
   "counter-evidence",
   "assign-citations",
+  "analyze-sources",
   "verify-citations",
   "synthesize",
   "persist-report",
@@ -701,7 +704,7 @@ export function seedWorkflowProgress(
   const base: MastraTimelineState = { ...state, status: "streaming", runId, activeRunId: runId };
   // Sasar turn assistant yang SUDAH ber-`turnId === runId` (poll re-seed = idempoten, tak menduplikat
   // bubble). Bila belum ada (seed pertama saat re-attach), buat placeholder lalu tandai turnId =
-  // runId → memetakan Sumber per-turn (G4), konsisten dengan `workflow-start` live.
+  // runId → memetakan Sumber per-turn, konsisten dengan `workflow-start` live.
   const existing = base.messages.findIndex((m) => m.role === "assistant" && m.turnId === runId);
   let idx: number;
   let next: MastraTimelineState;
@@ -733,7 +736,7 @@ export function seedWorkflowProgress(
     if (stepId === "synthesize" && status === "success") {
       const report = reportFromOutput(sr?.output);
       if (report) next = setReportText(next, idx, report);
-      // Penalaran sintesis (Route B) dari nilai return step → blok reasoning tetap muncul saat
+      // Penalaran sintesis dari nilai return step → blok reasoning tetap muncul saat
       // refresh poll fase RUNNING sebelum pesan riwayat termuat (rehydrate dari content part).
       const reasoning = reasoningFromOutput(sr?.output);
       if (reasoning) next = setDeepReasoning(next, idx, reasoning);
@@ -756,7 +759,7 @@ export function reduceWorkflowChunk(
         ...(runId ? { runId, activeRunId: runId } : {}),
       };
       const [s, idx] = ensureActiveAssistant(withRun);
-      // Tandai turn assistant dgn runId → memetakan Sumber per-turn live (G4).
+      // Tandai turn assistant dgn runId → memetakan Sumber per-turn live.
       if (!runId) return s;
       return { ...s, messages: s.messages.map((m, i) => (i === idx ? { ...m, turnId: runId } : m)) };
     }
@@ -815,8 +818,8 @@ export function reduceWorkflowChunk(
       // `closeOnSuspend` (default) menutup stream saat gerbang HITL dengan chunk terminal ini. Bila
       // plan-gate/ask-gate masih aktif, ini SUSPEND-close — BUKAN finish sungguhan → PERTAHANKAN
       // kartu + status streaming (tunggu keputusan user), jangan settle. `resolvePlan`/`resolveAsk`
-      // yang membersihkan gate saat user memutuskan → finish berikutnya (resume) baru settle (G2).
-      // FE-7: settle by runId — finish telat dari run lama tak boleh mengenai turn baru.
+      // yang membersihkan gate saat user memutuskan → finish berikutnya (resume) baru settle.
+      // Settle by runId — finish telat dari run lama tak boleh mengenai turn baru.
       if (state.planGate || state.askGate) return state;
       return settleWorkflowTurn({ ...state, planGate: undefined, askGate: undefined }, chunk.runId);
 
@@ -826,7 +829,7 @@ export function reduceWorkflowChunk(
       const stepId = str(payload.stepName);
       if (!stepId) return state;
       const [s, idx] = ensureActiveAssistant(streaming(state));
-      // Ringkasan penalaran sintesis (Route B) → blok reasoning (mengambang ke atas, parity chat),
+      // Ringkasan penalaran sintesis → blok reasoning (mengambang ke atas, parity chat),
       // BUKAN detail step. Sisanya = detail proses biasa.
       const out = asRecord(payload.output);
       if (str(out.kind) === "reasoning") {
@@ -837,7 +840,7 @@ export function reduceWorkflowChunk(
     }
 
     case "error":
-      // FE-7: sejajar workflow-finish — error run lama tak boleh men-settle turn baru secara posisi.
+      // Sejajar workflow-finish — error run lama tak boleh men-settle turn baru secara posisi.
       return {
         ...settleWorkflowTurn({ ...state, planGate: undefined, askGate: undefined }, chunk.runId),
         error: extractError(payload.error),
@@ -924,7 +927,7 @@ function reasoningFromOutput(output: unknown): string {
 }
 
 /**
- * Blok penalaran `/deep` (Route B) — satu part reasoning (id stabil `wf:reasoning`) di atas laporan,
+ * Blok penalaran `/deep` — satu part reasoning (id stabil `wf:reasoning`) di atas laporan,
  * dirender `<Reasoning>` yang sama dgn chat. Overwrite (bukan skip) → emit live/refresh/seed konvergen.
  */
 function setDeepReasoning(
@@ -990,6 +993,7 @@ function mergeLiveDetail(
     }
     case "counter":
     case "verify":
+    case "analyze":
       return { kind: "text", text: str(data.text) };
     case "citations":
       return { kind: "citations", count: num(data.count) };
@@ -1073,6 +1077,14 @@ function detailFromStepOutput(stepId: string, output: unknown): DeepStepDetail |
       const inventory = str(o.numberedInventory);
       return inventory ? { kind: "citations", count: countInventory(inventory) } : null;
     }
+    case "analyze-sources": {
+      const analyzed = num(o.analyzedSourceCount);
+      const vizIds = Array.isArray(o.vizBlocks)
+        ? o.vizBlocks.map((b) => str(asRecord(b).id)).filter(Boolean)
+        : [];
+      if (analyzed <= 0 && vizIds.length === 0) return null;
+      return { kind: "text", text: formatDeepAnalyzeSummary(analyzed, vizIds) };
+    }
     case "verify-citations": {
       const text = str(o.verification);
       return text ? { kind: "text", text } : null;
@@ -1134,6 +1146,20 @@ function deepProcessParts(deepProcess: Record<string, unknown>): TimelinePart[] 
   }
   if (counter) push("counter-evidence", { kind: "text", text: counter });
   if (citationCount > 0) push("assign-citations", { kind: "citations", count: citationCount });
+  // Evidence viz: `deepProcess.vizBlockIds` + `analyzedSourceCount` dipersist hanya bila analisis
+  // menghasilkan sesuatu → baris "Menganalisis bukti" ikut di riwayat. `deepProcess.viz` (array
+  // blok penuh) = bentuk lama pesan yang dipersist sebelum metadata diringkas jadi id saja.
+  const persistedIds = strArray(deepProcess.vizBlockIds);
+  const vizIds =
+    persistedIds.length > 0
+      ? persistedIds
+      : Array.isArray(deepProcess.viz)
+        ? deepProcess.viz.map((b) => str(asRecord(b).id)).filter(Boolean)
+        : [];
+  const analyzedCount = num(deepProcess.analyzedSourceCount);
+  if (vizIds.length > 0 || analyzedCount > 0) {
+    push("analyze-sources", { kind: "text", text: formatDeepAnalyzeSummary(analyzedCount, vizIds) });
+  }
   if (verification) push("verify-citations", { kind: "text", text: verification });
   return parts;
 }
@@ -1208,7 +1234,7 @@ function upsertToolPart(
 }
 
 /**
- * Parse JSON parsial arg tool yang masih mengalir (IMP-11): coba apa adanya, lalu coba menutup
+ * Parse JSON parsial arg tool yang masih mengalir: coba apa adanya, lalu coba menutup
  * string/objek yang menggantung dengan beberapa suffix umum. Gagal semua → null (baris input
  * lama dipertahankan sampai delta berikutnya bisa diparse).
  */
@@ -1228,7 +1254,7 @@ function parsePartialArgs(raw: string): Record<string, unknown> | null {
   return null;
 }
 
-/** Akumulasi `tool-call-delta` ke tool-row + render ulang baris input dari parse parsial (IMP-11). */
+/** Akumulasi `tool-call-delta` ke tool-row + render ulang baris input dari parse parsial. */
 function appendToolArgsDelta(
   state: MastraTimelineState,
   msgIdx: number,
@@ -1493,7 +1519,7 @@ function asRecord(v: unknown): Record<string, unknown> {
 }
 /**
  * Pesan error dari payload longgar (string / `{message}`) — `null` bila tak ada. Diekspor untuk
- * kartu run gagal B1 (`deepFailed.message` dari `steps[id].error` snapshot) agar normalisasi
+ * kartu run `/deep` gagal (`deepFailed.message` dari `steps[id].error` snapshot) agar normalisasi
  * bentuk error Mastra hidup di SATU tempat.
  */
 export function errorMessageFrom(err: unknown): string | null {

--- a/apps/web/features/threads/lib/viz-markdown.ts
+++ b/apps/web/features/threads/lib/viz-markdown.ts
@@ -1,0 +1,62 @@
+// Deteksi fenced block ` ```aqsha:viz ` (JSON blok evidence viz laporan `/deep`, disuntik
+// `injectVizBlocks` di agent) → element kustom `<deepviz payload="…">` yang dirender
+// `DeepVizMarkdownComponent` (features/threads/components/deep-viz). Transformasinya dijalankan
+// oleh walk tunggal `reportRehypePlugin` di `citation-markdown.ts` — PALING AKHIR dalam pipeline,
+// SETELAH sanitize/harden Streamdown, jadi element kita tepercaya tanpa memperluas skema
+// sanitasi; skema default rehype-sanitize mempertahankan `className` code ber-pola `language-*`
+// sehingga info string `aqsha:viz` selamat sampai ke sini. Karena node `pre>code` diganti SEBELUM
+// mapping komponen, plugin `code` Streamdown (syntax highlight) tak pernah menyentuhnya.
+//
+// Nomor "Gambar n" TIDAK dihitung di sini: injector chat-core sudah men-stamp `figure` di payload
+// sesuai urutan dokumen final (Streamdown me-render markdown per blok, jadi counter di plugin
+// tak pernah bisa melihat urutan lintas-blok).
+
+import type { HastElement, HastText } from "./citation-markdown";
+
+/** Nama tag + atribut element viz kustom (dipakai bareng komponen render di message.tsx). */
+export const DEEP_VIZ_TAG = "deepviz";
+export const DEEP_VIZ_PAYLOAD_ATTR = "payload";
+
+const VIZ_LANGUAGE_CLASS = "language-aqsha:viz";
+
+/** `code` anak `pre` ber-class `language-aqsha:viz` (className bisa array ATAU string). */
+function vizCodeChild(pre: HastElement): HastElement | null {
+  for (const child of pre.children) {
+    if (child.type !== "element") continue;
+    const el = child as HastElement;
+    if (el.tagName !== "code") continue;
+    const className = el.properties?.className;
+    const classes = Array.isArray(className)
+      ? className.map(String)
+      : typeof className === "string"
+        ? className.split(/\s+/)
+        : [];
+    if (classes.includes(VIZ_LANGUAGE_CLASS)) return el;
+  }
+  return null;
+}
+
+/** Gabungan seluruh text node langsung di bawah `code` (payload JSON satu baris). */
+function codeText(code: HastElement): string {
+  return code.children
+    .filter((c): c is HastText => c.type === "text")
+    .map((c) => c.value)
+    .join("")
+    .trim();
+}
+
+/**
+ * `pre > code.language-aqsha:viz` → element `deepviz` ber-atribut `payload` (string JSON —
+ * divalidasi komponen via zod contract chat-core, fallback bila korup); `pre` lain → `null`
+ * (biarkan apa adanya).
+ */
+export function vizElementFromPre(pre: HastElement): HastElement | null {
+  const code = vizCodeChild(pre);
+  if (!code) return null;
+  return {
+    type: "element",
+    tagName: DEEP_VIZ_TAG,
+    properties: { [DEEP_VIZ_PAYLOAD_ATTR]: codeText(code) },
+    children: [],
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -142,6 +142,9 @@
     "packages/chat-core": {
       "name": "@aqsha/chat-core",
       "version": "0.1.0",
+      "dependencies": {
+        "zod": "4.4.3",
+      },
       "devDependencies": {
         "bun-types": "^1.3.13",
         "typescript": "^6.0.3",

--- a/docs/deep-research-evidence-viz-plan.md
+++ b/docs/deep-research-evidence-viz-plan.md
@@ -1,0 +1,398 @@
+# Plan: Evidence Viz di Laporan `/deep` (fitur ala Consensus, tanpa sandbox)
+
+> Status: Fase A–D SUDAH DIIMPLEMENTASIKAN (2026-07-07) — migration 0027 di DEV;
+> kontrak/builders/injector di `@aqsha/chat-core/deep-viz`; step `analyze-sources` +
+> injeksi di agent; 6 komponen FE + restyle ala referensi Consensus (tema token web).
+> Fase E berjalan: smoke run thread 116b9eb6 (run 09303c8a) menghasilkan 5 blok valid;
+> temuan audit data (consensus-meter tak pernah lolos ambang karena cap 60 unit global +
+> 79% not_applicable; gaps-matrix didominasi fallback topics provider level field →
+> semua massa di kolom "Lainnya") = kandidat perbaikan menyusul.
+> Tanggal: 2026-07-07. Referensi visual: 6 screenshot Consensus.app (consensus meter,
+> results timeline, top contributors, claims & evidence table, research gaps matrix,
+> open research questions).
+
+## 1. Tujuan
+
+Laporan akhir `/deep` menampilkan enam blok visual berbasis bukti yang **diselang-seling
+dengan prosa** (bukan enam visual berurutan), mengikuti struktur artikel ilmiah:
+visual muncul di bagian yang argumennya sedang dibangun, seperti *figure* di paper.
+
+| # | Blok (`type`) | Padanan Consensus | Sumber data |
+|---|---|---|---|
+| 1 | `consensus-meter` | Yes/Possibly/Mixed/No meter per pertanyaan | Klasifikasi stance per paper (LLM) + agregasi deterministik |
+| 2 | `results-timeline` | Timeline publikasi (tahun × sitasi) | Metadata OpenAlex/Crossref (deterministik penuh) |
+| 3 | `top-contributors` | Tabel top authors & journals | Metadata `authors`/`venue` (deterministik penuh) |
+| 4 | `claims-evidence` | Claims & Evidence table + strength meter | Klaim (LLM) + skor kekuatan deterministik |
+| 5 | `gaps-matrix` | Research gaps heatmap | Tagging outcome (LLM) × design, pivot deterministik |
+| 6 | `open-questions` | Open research questions + "Why" | LLM (dipandu counter-evidence + gaps) |
+
+## 2. Prinsip desain
+
+1. **Angka tidak pernah ditulis LLM.** Semua agregat (persentase, N, skor kekuatan,
+   sel matrix) dihitung kode TS deterministik — selaras keputusan verify `/deep`
+   deterministik (IMP-5). LLM hanya melakukan dua hal: (a) klasifikasi per paper
+   (stance/design/outcomes) via `structuredOutput` strict, (b) memilih **posisi**
+   blok dalam prosa via marker.
+2. **Laporan markdown self-contained.** Data blok di-embed sebagai fenced block
+   ` ```aqsha:viz ` di markdown yang dipersist (`deep-report:<runId>`), jalur yang
+   sama dengan pill sitasi `[n]` → riwayat, refresh, re-attach durable, dan
+   time-travel aman TANPA jalur persist baru.
+3. **Degradasi mulus di setiap lapisan.** Step analisis gagal → laporan tampil
+   seperti hari ini (tanpa blok). Blok tak memenuhi ambang data → tidak ditawarkan
+   ke writer. JSON korup di FE → fallback kotak ringkas, bukan crash.
+4. **Anti-pemalsuan.** Post-processor MEMBUANG semua fence `aqsha:viz` yang ditulis
+   model sendiri sebelum injeksi — snippet paper yang mengandung prompt-injection
+   tidak bisa menyuntik visual palsu.
+
+## 3. Arus data (pipeline baru)
+
+```
+search-literature ── counter-evidence ── assign-citations ──► analyze-sources (BARU)
+                                                                │  LLM structuredOutput strict:
+                                                                │  stance/design/outcomes per [n]×subQ,
+                                                                │  claims, openQuestions
+                                                                ▼
+                                              verify-citations (tak berubah)
+                                                                ▼
+                buildDeepVizBlocks() ──────────► synthesize (prompt + daftar blok tersedia;
+                (deterministik, chat-core)       writer menaruh marker {{viz:<id>}})
+                                                                │  post-process: strip fence liar,
+                                                                │  replace marker → fenced JSON,
+                                                                │  append blok wajib yang tak ditaruh
+                                                                ▼
+                                              persist-report (+ deepProcess.viz)
+                                                                ▼
+                        FE: rehype plugin `aqsha:viz` → komponen <DeepVizBlock/>
+```
+
+## 4. Kontrak data — `@aqsha/chat-core` (dipakai agent + web)
+
+Modul baru `packages/chat-core/src/deep-viz/` (pure TS, tanpa dependency db/services;
+chat-core sudah jadi dependency `apps/agent` DAN `apps/web`, dan punya test runner):
+
+- `contract.ts` — zod schema + type per blok, di-discriminated-union oleh `type`,
+  semua payload ber-`v: 1` (versioning; FE menolak `v` yang tak dikenal dengan fallback).
+- `builders.ts` — `buildDeepVizBlocks(input): DeepVizBlock[]` deterministik (§6).
+- `inject.ts` — post-processor marker (§7.3).
+- `index.ts` — re-export; tambahkan subpath bila chat-core memakai exports map.
+
+Bentuk payload (ringkas; detail final di `contract.ts`):
+
+```ts
+type DeepVizBlock =
+  | { v: 1; type: "consensus-meter"; id: string; subQuestionIndex: number;
+      question: string; n: number;                       // N = paper unik terklasifikasi
+      stances: { yes: number; possibly: number; mixed: number; no: number };
+      designByStance: Record<Stance, Partial<Record<StudyDesign, number>>> } // badge ikon per baris
+  | { v: 1; type: "results-timeline"; id: "timeline";
+      points: Array<{ n: number; year: number; citedByCount: number | null }> }
+  | { v: 1; type: "top-contributors"; id: "contributors";
+      authors: Array<{ name: string; papers: number[] }>;   // papers = nomor sitasi [n]
+      venues: Array<{ name: string; papers: number[] }> }
+  | { v: 1; type: "claims-evidence"; id: "claims";
+      claims: Array<{ text: string; reasoning: string; papers: number[];
+        score: number;                                    // 0..10, deterministik (§6.4)
+        label: "strong" | "moderate" | "limited" }> }
+  | { v: 1; type: "gaps-matrix"; id: "gaps";
+      rows: string[];                                     // outcomes (≤5)
+      cols: ["meta_sysrev", "rct", "observational", "other"];
+      cells: number[][] }                                  // count paper unik
+  | { v: 1; type: "open-questions"; id: "open-questions";
+      items: Array<{ question: string; why: string }> };
+```
+
+Catatan: `papers: number[]` memakai nomor sitasi `[n]` global run — FE me-resolve ke
+kartu sumber lewat `CitationProvider` yang SUDAH membungkus laporan (reuse penuh,
+tanpa duplikasi data kartu di payload).
+
+## 5. Lapisan DB & services
+
+### 5.1 Migration `0027` — kolom baru `research_sources`
+
+```sql
+ALTER TABLE research_sources
+  ADD COLUMN cited_by_count integer,        -- OpenAlex cited_by_count / Crossref is-referenced-by-count
+  ADD COLUMN topics_json    text,           -- topik provider (fallback outcomes; JSON array string)
+  ADD COLUMN stance         text,           -- hasil klasifikasi (nullable; CHECK di bawah)
+  ADD COLUMN study_design   text,           -- idem
+  ADD COLUMN outcomes_json  text;           -- idem (JSON array string, ≤3)
+-- CHECK: stance in ('yes','possibly','mixed','no','not_applicable')
+-- CHECK: study_design in ('meta_analysis','systematic_review','rct','observational','review','other')
+```
+
+Semua nullable — jalur chat biasa & run lama tak tersentuh. Ikuti pola migration-collision
+(file fresh `0027_*`, jangan edit migration lama). Setelah `db:migrate`: **full-restart
+dev** (gotcha proses basi reusePort).
+
+### 5.2 `packages/db` — `ResearchSourceRepo`
+
+- `setClassification(db, updates: Array<{ id; stance; studyDesign; outcomesJson }>)` —
+  batch update by id, pola sama `setImages`/`setCitationNumbers`.
+- Tipe `ResearchSource` ikut kolom baru otomatis (inferSelect).
+
+### 5.3 `packages/services/src/research`
+
+- `openalex.ts` — `metadataJson` SUDAH memuat `citedByCount` + `topics`; tak berubah.
+- `crossref.ts` — tambahkan `citedByCount: work["is-referenced-by-count"]` ke `metadataJson`.
+- `index.ts`:
+  - `candidateCitationMeta` → tambah `citedByCount: number | null` dan `topics: string[]`
+    (best-effort parse, pola sama authors/year/venue).
+  - `persistSources` → map ke kolom `cited_by_count`, `topics_json`.
+  - `ResearchSourceItem` + `toResearchSourceItem` → expose `citedByCount`, `topics`,
+    `stance`, `studyDesign`, `outcomes` (parse JSON defensif, pola `parseAuthorsJson`).
+  - `setSourceClassification(db, updates)` — wrapper repo untuk step analyze.
+- **Build dist**: perubahan services/db dikonsumsi agent dari `dist/` → `bun run build:dist`
+  sebelum smoke (gotcha FE type via Eden juga butuh ini bila route API berubah — di plan
+  ini route API TIDAK berubah).
+
+## 6. Builders deterministik (`chat-core/deep-viz/builders.ts`)
+
+Input: daftar item terklasifikasi
+`{ n, subQuestionIndex, title, authors, year, venue, citedByCount, evidenceStrength, stance, studyDesign, outcomes }`
+(unik per pasangan `n × subQuestionIndex`), plus `subQuestions`, `claims`, `openQuestions`,
+`subQuestionAnswerable` dari step analyze.
+
+### 6.1 `consensus-meter` (per sub-pertanyaan)
+- Hanya untuk subQ dengan `answerable: true` (pertanyaan berbentuk dapat dijawab
+  ya/tidak — dinilai LLM di analyze).
+- Populasi: paper unik `n` milik subQ itu, exclude `not_applicable`.
+- **Ambang: N ≥ 5**, dan minimal 2 stance berbeda (meter 100% satu warna tak informatif
+  → tetap tampil, tapi N < 5 di-drop).
+- `designByStance` = hitungan design per stance → badge ikon kecil ala gambar 1.
+
+### 6.2 `results-timeline`
+- Titik: paper unik `n` dengan `year` non-null. **Ambang: ≥ 4 titik dan ≥ 2 tahun berbeda.**
+- `citedByCount` null dibiarkan null (FE render ukuran default).
+
+### 6.3 `top-contributors`
+- Author dinormalisasi exact `display_name`; masuk daftar bila muncul di **≥ 2 paper unik**;
+  top 3 by count, tiebreak total `citedByCount`. Venue idem. Kosong dua-duanya → blok drop.
+
+### 6.4 `claims-evidence`
+- Teks klaim + reasoning + `papers[n]` dari LLM; **skor deterministik**:
+  `score = Σ paper pendukung (bobot design × multiplier evidenceStrength)`,
+  design: meta_analysis/systematic_review 3.0, rct 2.5, observational 1.5, review/other 1.0;
+  evidenceStrength: strong ×1.0, medium ×0.75, weak ×0.5. Clamp 0..10 (meter 10 segmen).
+- Label: `score ≥ 6` strong, `≥ 3` moderate, sisanya limited.
+- Klaim yang mengutip `n` di luar inventaris → `n` itu dibuang; klaim tanpa paper valid → drop.
+
+### 6.5 `gaps-matrix`
+- Baris: outcomes ternormalisasi (lowercase-trim; gabungkan via kesamaan exact) top ≤ 5
+  by jumlah paper; fallback `topics` provider bila LLM outcomes kosong.
+- Kolom tetap 4 bucket design. Sel = count paper unik. **Ambang: ≥ 2 baris dan ≥ 8 paper.**
+
+### 6.6 `open-questions`
+- Pass-through 2–4 item LLM. Selalu layak bila non-kosong.
+
+Semua builder mengembalikan `null` bila ambang tak terpenuhi → blok tak pernah
+ditawarkan ke writer. **Unit test lengkap di chat-core** (runner sudah ada): kasus
+ambang, dedupe, skor, klaim dengan `n` liar, input kosong.
+
+## 7. Workflow agent (`apps/agent/src/mastra/workflows/deep-research.ts`)
+
+### 7.1 Step baru `analyze-sources` (antara `assign-citations` dan `verify-citations`)
+
+- Skema: `CitedSchema` → `AnalyzedSchema = CitedSchema + { sourceInsights, vizBlocks }`;
+  `verify-citations` dan `synthesize` meneruskan field baru (extend skema mereka).
+- Eksekusi (`retries: 1`, best-effort total):
+  1. `ResearchService.listTurnSources(db, { threadId, turnId: runId })` → baris ber-nomor.
+  2. Susun unit klasifikasi = pasangan unik `n × subQuestionIndex` (cap **60**; lebih →
+     prioritaskan evidenceStrength strong, log jumlah yang di-drop). Chunk ~20 unit
+     per panggilan LLM.
+  3. Panggilan LLM: pola persis `draft-plan` — agent generate `toolChoice:"none"` +
+     `structuredOutput: structuredOutputOpts(AnalyzeOutputSchema)`. Prompt berisi:
+     pertanyaan utama, daftar subQ, inventaris bernomor (judul+snippet+tahun+venue),
+     dan teks counter-evidence (bahan claims jujur + open questions).
+     ```ts
+     const AnalyzeOutputSchema = z.object({
+       insights: z.array(z.object({
+         n: z.number().int().min(1),
+         subQuestionIndex: z.number().int().min(0),
+         stance: z.enum(["yes","possibly","mixed","no","not_applicable"]),
+         studyDesign: z.enum(["meta_analysis","systematic_review","rct","observational","review","other"]),
+         outcomes: z.array(z.string()).max(3),
+       })),
+       subQuestionAnswerable: z.array(z.object({
+         subQuestionIndex: z.number().int(), answerable: z.boolean() })),
+       claims: z.array(z.object({
+         text: z.string(), reasoning: z.string(),
+         papers: z.array(z.number().int()) })).min(3).max(6),
+       openQuestions: z.array(z.object({
+         question: z.string(), why: z.string() })).min(2).max(4),
+     });
+     ```
+     Instruksi stance: "posisi TEMUAN paper terhadap sub-pertanyaan, berdasar
+     judul+abstrak/snippet; ragu → `mixed`; tak menjawab → `not_applicable`".
+  4. Persist klasifikasi ke `research_sources` (best-effort, `setSourceClassification`) —
+     kegagalan DB tak menggagalkan step.
+  5. `buildDeepVizBlocks(...)` → `vizBlocks` masuk state workflow.
+  6. `emitDetail(writer, { kind: "analyze", ... })` di awal ("Mengklasifikasikan N sumber…")
+     dan akhir (ringkasan: berapa blok layak) — paritas pola IMP-9; perlu menambah varian
+     `kind` di union detail FE (`timeline-types.ts`) + baris panel proses.
+- **Durabilitas**: panggilan generate langsung (bukan `runDeepSubagentTask`) mengikuti
+  preseden draft-plan; restart run mengulang step ini (biaya kecil, output deterministik-ish).
+  JANGAN membungkus ke deep-tasks di v1 (`structuredOutput` belum lewat jalur task; catat
+  sebagai perbaikan menyusul bila terbukti mahal saat restart).
+- **Kegagalan total** (kedua attempt): `sourceInsights = null`, `vizBlocks = []` →
+  laporan polos. JANGAN throw pasca-billing (paritas CFG-4).
+
+### 7.2 Kontrak writer di `synthesisPrompt`
+
+Tambahkan seksi (hanya bila `vizBlocks.length > 0`):
+
+```
+## Blok visual tersedia (WAJIB ditempatkan)
+Berikut blok visual yang SUDAH dihitung dari data. Sisipkan penandanya di laporan,
+masing-masing pada BARIS TERSENDIRI, persis: {{viz:<id>}}
+- {{viz:consensus-q2}} — meter konsensus untuk sub-pertanyaan 3 (N=19)
+- {{viz:timeline}} — timeline publikasi 2017–2026 (23 paper)
+- …
+Aturan penempatan (gaya artikel ilmiah):
+- Meter konsensus: TEPAT setelah paragraf yang menyimpulkan sub-pertanyaan terkait.
+- Timeline & kontributor: di bagian karakteristik/peta literatur (biasanya awal
+  pembahasan), timeline dulu, dipisah minimal satu paragraf.
+- Tabel klaim & bukti: di bagian sintesis bukti, sebelum kesimpulan.
+- Gaps matrix lalu open questions: di bagian keterbatasan/arah riset ke depan,
+  setelah kesimpulan utama.
+- JANGAN dua penanda berurutan tanpa paragraf prosa di antaranya; setiap blok
+  diantar kalimat yang merujuknya (mis. "Gambar berikut merangkum sebaran temuan…").
+- JANGAN mengarang penanda lain, JANGAN menulis blok ```aqsha:viz sendiri,
+  JANGAN mengubah data.
+```
+
+`id` blok: `consensus-q<index>`, `timeline`, `contributors`, `claims`, `gaps`,
+`open-questions`.
+
+### 7.3 Post-processor (di step `synthesize`, setelah `out.text`; `chat-core/deep-viz/inject.ts`)
+
+Urutan operasi pada `report` (pure function `injectVizBlocks(report, vizBlocks)`):
+1. **Strip** semua fenced block ```` ```aqsha:viz … ``` ```` yang ditulis model (anti-forgery §2.4).
+2. Ganti tiap baris marker `/^\s*\{\{viz:([a-z0-9-]+)\}\}\s*$/` dengan fenced block JSON
+   blok ber-`id` sama. Marker `id` tak dikenal → hapus barisnya. Marker duplikat →
+   kemunculan pertama menang, sisanya dihapus.
+3. Blok yang TIDAK ditempatkan writer: `consensus-q*` dan `claims` di-append di akhir
+   laporan di bawah heading `### Lampiran visual` (blok inti tak boleh hilang);
+   `timeline`/`contributors`/`gaps`/`open-questions` yang tak ditaruh → di-drop
+   (nilai kontekstualnya rendah bila writer tak merujuknya). Log jumlah yang di-append/drop.
+4. Validasi ringan: dua fence bersebelahan tanpa teks di antaranya → sisipkan baris
+   kosong (kosmetik; aturan utamanya sudah di prompt).
+
+Hasil injeksi dipakai sebagai `report` yang mengalir ke `persist-report` (tak ada step
+baru; retry synthesize mengulang injeksi — idempoten karena pure).
+
+### 7.4 `persist-report`
+
+- `deepProcess.viz = vizBlocks` (fallback DB-independen + bahan panel proses, paritas
+  `deepProcess.sources`). Ukuran kecil (< beberapa KB).
+
+## 8. Frontend (`apps/web`)
+
+### 8.1 Jalur render — pola persis pill sitasi
+
+- File baru `features/threads/lib/viz-markdown.ts`: rehype plugin yang mencari
+  `pre > code` ber-class `language-aqsha:viz`, mengganti node `pre` dengan element
+  kustom `deepviz` ber-atribut `payload` (string JSON). Berjalan SETELAH sanitize —
+  gabungkan di `citation-markdown.ts`: `reportRehypePlugins = [...defaultRehypePlugins,
+  citationRehypePlugin, vizRehypePlugin]` (satu pipeline modul-level yang stabil;
+  `Response` ganti referensi ke ini). Karena node `pre>code` diganti sebelum mapping
+  komponen, plugin `code` Streamdown tak pernah menyentuhnya.
+- `message.tsx`: daftarkan `deepviz: DeepVizMarkdownComponent` di `streamdownComponents`.
+
+### 8.2 Komponen `features/threads/components/deep-viz/`
+
+- `viz-block.tsx` — dispatcher: `safeParse` payload dengan zod contract chat-core;
+  gagal parse / `v` tak dikenal / type tak dikenal → kotak fallback ringkas
+  ("Visual tidak dapat dimuat") + expander teks JSON; saat teks masih streaming/terpotong
+  → skeleton. Bungkus error boundary.
+- `consensus-meter.tsx` — bar stacked (div flex, warna token: hijau/kuning/oranye/merah),
+  legend per stance (dot + label + persen + badge design ala gambar 1), kapsul
+  "X% paper mengindikasikan 'Ya/Tidak'" (stance dominan), chip `N = x`.
+- `results-timeline.tsx` — SVG scatter in-house (tanpa lib chart baru): x=tahun,
+  jitter vertikal deterministik (hash `n`), ukuran marker 3 kelas by kuantil
+  `citedByCount`, label `n` di marker; klik marker → popover kartu sumber via
+  `CitationProvider` (reuse `CitationMarkdownComponent`/`InlineCitation`).
+- `top-contributors.tsx` — tabel dua seksi (Authors/Journals) ala gambar 3; kolom
+  Papers = pill sitasi `[n]` reuse komponen pill (+`+n more` bila > 3).
+- `claims-evidence.tsx` — tabel 4 kolom ala gambar 4; strength = meter 10 segmen
+  (hijau strong / kuning moderate / abu limited) + label; Papers = pill `[n]`.
+- `gaps-matrix.tsx` — tabel heatmap; intensitas sel = skala biru dari count
+  (normalisasi per-matrix); baris/kolom sticky, wrapper `overflow-x-auto` (mobile).
+- `open-questions.tsx` — kartu pertanyaan + kolom "Mengapa penting" ala gambar 6;
+  tombol panah per kartu = prefill composer `/deep <question>` (pakai kanal draft
+  composer yang ada — verifikasi mekanisme saat implementasi; kalau butuh kanal baru,
+  tunda tombolnya ke follow-up, jangan bengkakkan slice ini).
+- Semua caption ber-prefix `FIGURE n` kecil ala Consensus → penomoran berurutan
+  per-laporan (context counter sederhana di provider pesan).
+- **Sebelum menulis komponen chart: load skill `dataviz`** (palet kategorikal stance,
+  aksesibilitas dark/light). Ikon dari `@aqsha/ui/icons` (JANGAN lucide langsung).
+  Copy sentence case (aturan copywriting no-uppercase).
+
+### 8.3 Panel proses `/deep`
+
+- `timeline-types.ts` + `deep-search-cards.tsx`/detail: tambah varian detail
+  `kind: "analyze"` (baris "Analisis bukti: N sumber diklasifikasikan, M blok visual").
+
+## 9. Ambang & kelayakan (rangkuman)
+
+| Blok | Syarat tampil |
+|---|---|
+| consensus-meter | subQ answerable, N ≥ 5, ≥ 2 stance berbeda |
+| results-timeline | ≥ 4 paper ber-tahun, ≥ 2 tahun berbeda |
+| top-contributors | ≥ 1 author ATAU venue dengan ≥ 2 paper |
+| claims-evidence | ≥ 3 klaim valid (papers non-kosong pasca-sanitasi) |
+| gaps-matrix | ≥ 2 baris outcome, ≥ 8 paper unik |
+| open-questions | ≥ 2 item |
+
+Run kecil (mis. 6 sumber) secara alami hanya memunculkan 1–2 blok — laporan tidak
+pernah "di-spam" visual.
+
+## 10. Biaya, billing, batasan
+
+- +1–3 panggilan LLM per run (klasifikasi, ~2–4k token/panggilan) — ditanggung kredit
+  deep run yang sudah didebit di plan-gate; TANPA jenis billing baru. Opsional: catat
+  usage ledger `deep_analyze` rate 0 (paritas `citation_verify`) — keputusan terbuka §13.
+- Batasan diakui di UI: klasifikasi berbasis judul+abstrak/snippet (bukan full-text) —
+  caption meter mencantumkan "berdasar abstrak" (kejujuran ilmiah). Full-text stance =
+  kandidat fase sandbox.
+
+## 11. Testing
+
+1. **Unit (chat-core)**: builders §6 (ambang, skor, dedupe, `n` liar), `injectVizBlocks`
+   §7.3 (strip fence liar, replace, duplikat, append blok inti, drop marker asing).
+2. **Unit (services)**: `candidateCitationMeta` extended; persist kolom baru
+   (itest DB yang ada; ingat itests billing pakai `--timeout 25000` bila tersentuh).
+3. **Workflow (agent, manual/smoke)**: run `/deep` di dev — verifikasi: (a) laporan
+   memuat fence `aqsha:viz` di posisi selang-seling; (b) refresh mid-run & pasca-selesai
+   tetap merender blok (durable); (c) run dengan sumber minim → tanpa blok, tanpa error.
+4. **FE**: typecheck + verifikasi visual dark/light + mobile (blok lebar dalam
+   `overflow-x-auto`); payload korup manual → fallback.
+5. **Regression**: chat biasa (non-deep) tak berubah; pill `[n]` tetap jalan
+   (pipeline rehype digabung — uji keduanya dalam satu laporan).
+
+## 12. Urutan implementasi
+
+| Fase | Isi | Sentuhan |
+|---|---|---|
+| A | Migration 0027 + persist `citedByCount`/`topics` + read model + build:dist | db, services |
+| B | Kontrak + builders + injector + unit tests | chat-core |
+| C | Step `analyze-sources` + extend skema + prompt writer + injeksi + `deepProcess.viz` | agent |
+| D | Rehype `deepviz` + 6 komponen + panel proses `kind:"analyze"` | web |
+| E | Smoke E2E `/deep` (3 skenario: kaya-sumber, minim-sumber, refresh mid-run) + rapikan | semua |
+
+A–B bisa paralel dengan D (kontrak disepakati dulu di B). C bergantung A+B.
+Estimasi kasar: A ~0.5 hari, B ~1 hari, C ~1 hari, D ~1.5–2 hari, E ~0.5 hari.
+
+## 13. Keputusan terbuka (default bila tak dijawab)
+
+1. **Usage ledger `deep_analyze` rate 0** untuk observabilitas? *(default: ya, murah)*
+2. **Model step analyze**: model writer tier run (lite/pro) atau selalu lite? *(default:
+   selalu lite — tugas klasifikasi, hemat)*
+3. **Tombol panah open-questions → prefill `/deep`** masuk slice ini atau follow-up?
+   *(default: follow-up bila kanal composer perlu kerja baru)*
+4. **`sampleSize` per paper** ikut diekstrak? *(default: tidak di v1 — akurasi dari
+   snippet rendah; tambah saat full-text/sandbox)*
+
+## 14. Di luar scope (fase sandbox, plan terpisah)
+
+Forest plot / pooled effect size, verifikasi statistik klaim (recompute CI/p),
+integrasi dataset user (.sav), export chart PNG ke .docx/PDF.

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -4,11 +4,15 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./deep-viz": "./src/deep-viz.ts"
   },
   "scripts": {
     "test": "bun test --timeout 30000",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "bun-types": "^1.3.13",

--- a/packages/chat-core/src/deep-viz.ts
+++ b/packages/chat-core/src/deep-viz.ts
@@ -1,0 +1,744 @@
+/**
+ * @aqsha/chat-core/deep-viz — kontrak + builder + injector blok visual berbasis bukti
+ * untuk laporan `/deep` (evidence viz ala Consensus, tanpa sandbox).
+ *
+ * File entry MANDIRI kedua chat-core (subpath `./deep-viz` di exports map): sama seperti
+ * `index.ts`, TANPA relative import supaya aman di-bundle konsumen (runtime agent Node +
+ * web). Satu-satunya dependency adalah `zod` (paket npm ter-compile, bundler-safe; versi
+ * dipin sama dengan apps/web + apps/agent).
+ *
+ * Prinsip:
+ * - Angka TIDAK pernah ditulis LLM — semua agregat dihitung `buildDeepVizBlocks`
+ *   deterministik; LLM hanya klasifikasi per paper + memilih POSISI blok via marker.
+ * - Laporan markdown self-contained — blok di-embed sebagai fenced block ```aqsha:viz
+ *   berisi JSON satu baris; FE mem-parse dengan `deepVizBlockSchema` (fallback bila korup).
+ * - Anti-pemalsuan — `injectVizBlocks` MEMBUANG semua fence `aqsha:viz` tulisan model
+ *   sebelum injeksi.
+ *
+ * Union stance/study design WAJIB sinkron dengan CHECK kolom `research_sources`
+ * (`packages/db/src/schema/researchSources.ts`) — chat-core tak boleh depend db (dipakai
+ * web), jadi sinkronisasi dijaga test lintas-paket di `packages/services`.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Kontrak — zod schema + type per blok (payload ber-`v: 1` untuk versioning)
+// ---------------------------------------------------------------------------
+
+/** Stance yang tampil di meter (tanpa `not_applicable` — di-exclude saat agregasi). */
+export const DEEP_VIZ_STANCES = ["yes", "possibly", "mixed", "no"] as const;
+export type DeepVizStance = (typeof DEEP_VIZ_STANCES)[number];
+
+/** Hasil klasifikasi per paper (superset stance meter). */
+export const DEEP_VIZ_CLASSIFIED_STANCES = [...DEEP_VIZ_STANCES, "not_applicable"] as const;
+export type DeepVizClassifiedStance = (typeof DEEP_VIZ_CLASSIFIED_STANCES)[number];
+
+export const DEEP_VIZ_STUDY_DESIGNS = [
+  "meta_analysis",
+  "systematic_review",
+  "rct",
+  "observational",
+  "review",
+  "other",
+] as const;
+export type DeepVizStudyDesign = (typeof DEEP_VIZ_STUDY_DESIGNS)[number];
+
+/** Bucket kolom gaps-matrix (agregasi 6 design → 4 kolom). */
+export const DEEP_VIZ_DESIGN_BUCKETS = ["meta_sysrev", "rct", "observational", "other"] as const;
+export type DeepVizDesignBucket = (typeof DEEP_VIZ_DESIGN_BUCKETS)[number];
+
+export type DeepVizEvidenceStrength = "strong" | "medium" | "weak";
+
+const countSchema = z.number().int().min(0);
+
+/**
+ * Nomor urut "Gambar n" — di-stamp `injectVizBlocks` sesuai urutan blok pada dokumen
+ * final. Optional untuk kompat laporan lama yang dipersist sebelum field ini ada.
+ */
+const figureSchema = z.number().int().min(1).optional();
+
+/** Partial<Record<DeepVizStudyDesign, number>> — badge ikon design per baris stance. */
+const designCountsSchema = z.object({
+  meta_analysis: countSchema.optional(),
+  systematic_review: countSchema.optional(),
+  rct: countSchema.optional(),
+  observational: countSchema.optional(),
+  review: countSchema.optional(),
+  other: countSchema.optional(),
+});
+
+export const consensusMeterBlockSchema = z.object({
+  v: z.literal(1),
+  type: z.literal("consensus-meter"),
+  id: z.string(),
+  figure: figureSchema,
+  subQuestionIndex: z.number().int().min(0),
+  question: z.string(),
+  /** N = paper unik terklasifikasi (exclude `not_applicable`). */
+  n: countSchema,
+  stances: z.object({
+    yes: countSchema,
+    possibly: countSchema,
+    mixed: countSchema,
+    no: countSchema,
+  }),
+  designByStance: z.object({
+    yes: designCountsSchema,
+    possibly: designCountsSchema,
+    mixed: designCountsSchema,
+    no: designCountsSchema,
+  }),
+});
+
+export const resultsTimelineBlockSchema = z.object({
+  v: z.literal(1),
+  type: z.literal("results-timeline"),
+  id: z.literal("timeline"),
+  figure: figureSchema,
+  points: z.array(
+    z.object({
+      /** Nomor sitasi [n] global run — FE resolve ke kartu sumber via CitationProvider. */
+      n: z.number().int().min(1),
+      year: z.number().int(),
+      citedByCount: z.number().int().min(0).nullable(),
+    }),
+  ),
+});
+
+export const topContributorsBlockSchema = z.object({
+  v: z.literal(1),
+  type: z.literal("top-contributors"),
+  id: z.literal("contributors"),
+  figure: figureSchema,
+  authors: z.array(z.object({ name: z.string(), papers: z.array(z.number().int().min(1)) })),
+  venues: z.array(z.object({ name: z.string(), papers: z.array(z.number().int().min(1)) })),
+});
+
+export const claimsEvidenceBlockSchema = z.object({
+  v: z.literal(1),
+  type: z.literal("claims-evidence"),
+  id: z.literal("claims"),
+  figure: figureSchema,
+  claims: z.array(
+    z.object({
+      text: z.string(),
+      reasoning: z.string(),
+      papers: z.array(z.number().int().min(1)),
+      /** 0..10, deterministik (bobot design × multiplier evidenceStrength). */
+      score: z.number().min(0).max(10),
+      label: z.enum(["strong", "moderate", "limited"]),
+    }),
+  ),
+});
+
+export const gapsMatrixBlockSchema = z.object({
+  v: z.literal(1),
+  type: z.literal("gaps-matrix"),
+  id: z.literal("gaps"),
+  figure: figureSchema,
+  /** Outcome ternormalisasi (≤5 baris). */
+  rows: z.array(z.string()),
+  cols: z.tuple([
+    z.literal("meta_sysrev"),
+    z.literal("rct"),
+    z.literal("observational"),
+    z.literal("other"),
+  ]),
+  /** cells[row][col] = count paper unik. */
+  cells: z.array(z.array(countSchema)),
+});
+
+export const openQuestionsBlockSchema = z.object({
+  v: z.literal(1),
+  type: z.literal("open-questions"),
+  id: z.literal("open-questions"),
+  figure: figureSchema,
+  items: z.array(z.object({ question: z.string(), why: z.string() })),
+});
+
+export const deepVizBlockSchema = z.discriminatedUnion("type", [
+  consensusMeterBlockSchema,
+  resultsTimelineBlockSchema,
+  topContributorsBlockSchema,
+  claimsEvidenceBlockSchema,
+  gapsMatrixBlockSchema,
+  openQuestionsBlockSchema,
+]);
+
+export type ConsensusMeterBlock = z.infer<typeof consensusMeterBlockSchema>;
+export type ResultsTimelineBlock = z.infer<typeof resultsTimelineBlockSchema>;
+export type TopContributorsBlock = z.infer<typeof topContributorsBlockSchema>;
+export type ClaimsEvidenceBlock = z.infer<typeof claimsEvidenceBlockSchema>;
+export type GapsMatrixBlock = z.infer<typeof gapsMatrixBlockSchema>;
+export type OpenQuestionsBlock = z.infer<typeof openQuestionsBlockSchema>;
+export type DeepVizBlock = z.infer<typeof deepVizBlockSchema>;
+
+/**
+ * Parse payload fenced block `aqsha:viz` (string JSON) → blok tervalidasi, atau `null`
+ * bila JSON korup / `v` tak dikenal / `type` tak dikenal (FE render fallback ringkas).
+ */
+export function parseDeepVizBlock(payload: string): DeepVizBlock | null {
+  try {
+    const parsed = deepVizBlockSchema.safeParse(JSON.parse(payload));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Builders deterministik — input klasifikasi → blok yang MEMENUHI ambang saja
+// ---------------------------------------------------------------------------
+
+/**
+ * Satu unit klasifikasi = pasangan unik `n × subQuestionIndex` (duplikat → kemunculan
+ * pertama menang). `stance`/`studyDesign` null = unit belum/gagal diklasifikasi.
+ */
+export type DeepVizSourceInput = {
+  n: number;
+  subQuestionIndex: number | null;
+  title: string;
+  authors: string[];
+  year: number | null;
+  venue: string | null;
+  citedByCount: number | null;
+  evidenceStrength: DeepVizEvidenceStrength;
+  stance: DeepVizClassifiedStance | null;
+  studyDesign: DeepVizStudyDesign | null;
+  outcomes: string[];
+  /** Topik provider — fallback baris gaps-matrix bila `outcomes` LLM kosong. */
+  topics: string[];
+};
+
+export type DeepVizClaimInput = { text: string; reasoning: string; papers: number[] };
+export type DeepVizOpenQuestionInput = { question: string; why: string };
+
+export type BuildDeepVizInput = {
+  /** Sub-pertanyaan run, indeks = subQuestionIndex. */
+  subQuestions: string[];
+  sources: DeepVizSourceInput[];
+  /** Penilaian LLM: subQ berbentuk dapat dijawab ya/tidak (syarat consensus-meter). */
+  subQuestionAnswerable: Array<{ subQuestionIndex: number; answerable: boolean }>;
+  claims: DeepVizClaimInput[];
+  openQuestions: DeepVizOpenQuestionInput[];
+};
+
+const CONSENSUS_MIN_PAPERS = 5;
+const TIMELINE_MIN_POINTS = 4;
+const TIMELINE_MIN_YEARS = 2;
+const CONTRIBUTOR_MIN_PAPERS = 2;
+const CONTRIBUTOR_TOP = 3;
+const CLAIMS_MIN_VALID = 3;
+const GAPS_MAX_ROWS = 5;
+const GAPS_MIN_ROWS = 2;
+const GAPS_MIN_PAPERS = 8;
+const OPEN_QUESTIONS_MIN = 2;
+const OPEN_QUESTIONS_MAX = 4;
+
+const DESIGN_WEIGHT: Record<DeepVizStudyDesign, number> = {
+  meta_analysis: 3.0,
+  systematic_review: 3.0,
+  rct: 2.5,
+  observational: 1.5,
+  review: 1.0,
+  other: 1.0,
+};
+
+const STRENGTH_MULTIPLIER: Record<DeepVizEvidenceStrength, number> = {
+  strong: 1.0,
+  medium: 0.75,
+  weak: 0.5,
+};
+
+const DESIGN_TO_BUCKET: Record<DeepVizStudyDesign, DeepVizDesignBucket> = {
+  meta_analysis: "meta_sysrev",
+  systematic_review: "meta_sysrev",
+  rct: "rct",
+  observational: "observational",
+  review: "other",
+  other: "other",
+};
+
+/** Profil satu paper unik `n` — hasil merge semua unit klasifikasi paper itu. */
+type PaperProfile = {
+  n: number;
+  year: number | null;
+  venue: string | null;
+  citedByCount: number | null;
+  authors: string[];
+  evidenceStrength: DeepVizEvidenceStrength;
+  studyDesign: DeepVizStudyDesign | null;
+  outcomes: string[];
+  topics: string[];
+};
+
+function collapseLabel(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** Dedupe unit by `n × subQuestionIndex` (kemunculan pertama menang). */
+function dedupeUnits(sources: DeepVizSourceInput[]): DeepVizSourceInput[] {
+  const seen = new Set<string>();
+  const units: DeepVizSourceInput[] = [];
+  for (const source of sources) {
+    const key = `${source.n}:${source.subQuestionIndex ?? "-"}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    units.push(source);
+  }
+  return units;
+}
+
+/** Merge unit-unit satu paper → profil per `n` (first-non-null menang; outcomes/topics di-union). */
+function paperProfiles(units: DeepVizSourceInput[]): Map<number, PaperProfile> {
+  const byN = new Map<number, PaperProfile>();
+  for (const unit of units) {
+    const existing = byN.get(unit.n);
+    if (!existing) {
+      byN.set(unit.n, {
+        n: unit.n,
+        year: unit.year,
+        venue: unit.venue !== null ? collapseLabel(unit.venue) || null : null,
+        citedByCount: unit.citedByCount,
+        authors: unit.authors.map(collapseLabel).filter(Boolean),
+        evidenceStrength: unit.evidenceStrength,
+        studyDesign: unit.studyDesign,
+        outcomes: unit.outcomes.map(collapseLabel).filter(Boolean),
+        topics: unit.topics.map(collapseLabel).filter(Boolean),
+      });
+      continue;
+    }
+    existing.year ??= unit.year;
+    existing.venue ??= unit.venue !== null ? collapseLabel(unit.venue) || null : null;
+    existing.citedByCount ??= unit.citedByCount;
+    if (existing.authors.length === 0) {
+      existing.authors = unit.authors.map(collapseLabel).filter(Boolean);
+    }
+    existing.studyDesign ??= unit.studyDesign;
+    for (const outcome of unit.outcomes.map(collapseLabel).filter(Boolean)) {
+      if (!existing.outcomes.includes(outcome)) existing.outcomes.push(outcome);
+    }
+    for (const topic of unit.topics.map(collapseLabel).filter(Boolean)) {
+      if (!existing.topics.includes(topic)) existing.topics.push(topic);
+    }
+  }
+  return byN;
+}
+
+function buildConsensusMeters(
+  units: DeepVizSourceInput[],
+  subQuestions: string[],
+  answerable: Array<{ subQuestionIndex: number; answerable: boolean }>,
+): ConsensusMeterBlock[] {
+  const answerableSet = new Set(
+    answerable.filter((entry) => entry.answerable).map((entry) => entry.subQuestionIndex),
+  );
+  const blocks: ConsensusMeterBlock[] = [];
+  for (let index = 0; index < subQuestions.length; index++) {
+    if (!answerableSet.has(index)) continue;
+    const question = collapseLabel(subQuestions[index] ?? "");
+    if (!question) continue;
+    const classified = units.filter(
+      (unit) =>
+        unit.subQuestionIndex === index &&
+        unit.stance !== null &&
+        unit.stance !== "not_applicable",
+    );
+    if (classified.length < CONSENSUS_MIN_PAPERS) continue;
+    const stances = { yes: 0, possibly: 0, mixed: 0, no: 0 };
+    const designByStance: ConsensusMeterBlock["designByStance"] = {
+      yes: {},
+      possibly: {},
+      mixed: {},
+      no: {},
+    };
+    for (const unit of classified) {
+      const stance = unit.stance as DeepVizStance;
+      stances[stance] += 1;
+      const design = unit.studyDesign ?? "other";
+      designByStance[stance][design] = (designByStance[stance][design] ?? 0) + 1;
+    }
+    const distinctStances = DEEP_VIZ_STANCES.filter((stance) => stances[stance] > 0).length;
+    if (distinctStances < 2) continue;
+    blocks.push({
+      v: 1,
+      type: "consensus-meter",
+      id: `consensus-q${index}`,
+      subQuestionIndex: index,
+      question,
+      n: classified.length,
+      stances,
+      designByStance,
+    });
+  }
+  return blocks;
+}
+
+function buildResultsTimeline(papers: Map<number, PaperProfile>): ResultsTimelineBlock | null {
+  const points = [...papers.values()]
+    .filter((paper) => paper.year !== null)
+    .map((paper) => ({
+      n: paper.n,
+      year: paper.year as number,
+      citedByCount:
+        paper.citedByCount !== null && paper.citedByCount >= 0 ? paper.citedByCount : null,
+    }))
+    .sort((a, b) => a.year - b.year || a.n - b.n);
+  if (points.length < TIMELINE_MIN_POINTS) return null;
+  if (new Set(points.map((point) => point.year)).size < TIMELINE_MIN_YEARS) return null;
+  return { v: 1, type: "results-timeline", id: "timeline", points };
+}
+
+function topEntries(byName: Map<string, Set<number>>, papers: Map<number, PaperProfile>) {
+  return [...byName.entries()]
+    .filter(([, ns]) => ns.size >= CONTRIBUTOR_MIN_PAPERS)
+    .map(([name, ns]) => ({
+      name,
+      papers: [...ns].sort((a, b) => a - b),
+      totalCited: [...ns].reduce((sum, n) => sum + (papers.get(n)?.citedByCount ?? 0), 0),
+    }))
+    .sort(
+      (a, b) =>
+        b.papers.length - a.papers.length ||
+        b.totalCited - a.totalCited ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, CONTRIBUTOR_TOP)
+    .map(({ name, papers: ns }) => ({ name, papers: ns }));
+}
+
+function buildTopContributors(papers: Map<number, PaperProfile>): TopContributorsBlock | null {
+  const byAuthor = new Map<string, Set<number>>();
+  const byVenue = new Map<string, Set<number>>();
+  for (const paper of papers.values()) {
+    for (const author of paper.authors) {
+      if (!byAuthor.has(author)) byAuthor.set(author, new Set());
+      byAuthor.get(author)?.add(paper.n);
+    }
+    if (paper.venue) {
+      if (!byVenue.has(paper.venue)) byVenue.set(paper.venue, new Set());
+      byVenue.get(paper.venue)?.add(paper.n);
+    }
+  }
+  const authors = topEntries(byAuthor, papers);
+  const venues = topEntries(byVenue, papers);
+  if (authors.length === 0 && venues.length === 0) return null;
+  return { v: 1, type: "top-contributors", id: "contributors", authors, venues };
+}
+
+function claimScore(ns: number[], papers: Map<number, PaperProfile>): number {
+  const raw = ns.reduce((sum, n) => {
+    const paper = papers.get(n);
+    if (!paper) return sum;
+    const weight = DESIGN_WEIGHT[paper.studyDesign ?? "other"];
+    return sum + weight * STRENGTH_MULTIPLIER[paper.evidenceStrength];
+  }, 0);
+  return Math.round(Math.min(10, Math.max(0, raw)) * 10) / 10;
+}
+
+function buildClaimsEvidence(
+  claims: DeepVizClaimInput[],
+  papers: Map<number, PaperProfile>,
+): ClaimsEvidenceBlock | null {
+  const sanitized: ClaimsEvidenceBlock["claims"] = [];
+  for (const claim of claims) {
+    const text = collapseLabel(claim.text);
+    if (!text) continue;
+    // `n` di luar inventaris dibuang; duplikat di-dedupe; klaim tanpa paper valid → drop.
+    const ns = [...new Set(claim.papers)].filter((n) => papers.has(n)).sort((a, b) => a - b);
+    if (ns.length === 0) continue;
+    const score = claimScore(ns, papers);
+    sanitized.push({
+      text,
+      reasoning: collapseLabel(claim.reasoning),
+      papers: ns,
+      score,
+      label: score >= 6 ? "strong" : score >= 3 ? "moderate" : "limited",
+    });
+  }
+  if (sanitized.length < CLAIMS_MIN_VALID) return null;
+  return { v: 1, type: "claims-evidence", id: "claims", claims: sanitized };
+}
+
+function buildGapsMatrix(papers: Map<number, PaperProfile>): GapsMatrixBlock | null {
+  // Tag per paper: outcomes LLM, fallback topics provider. Normalisasi lowercase-trim
+  // untuk merge; label tampil = kemunculan pertama.
+  const labelByKey = new Map<string, string>();
+  const papersByKey = new Map<string, Set<number>>();
+  const taggedPapers = new Set<number>();
+  for (const paper of papers.values()) {
+    const tags = paper.outcomes.length > 0 ? paper.outcomes : paper.topics;
+    if (tags.length === 0) continue;
+    taggedPapers.add(paper.n);
+    for (const tag of tags) {
+      const key = tag.toLowerCase();
+      if (!labelByKey.has(key)) labelByKey.set(key, tag);
+      if (!papersByKey.has(key)) papersByKey.set(key, new Set());
+      papersByKey.get(key)?.add(paper.n);
+    }
+  }
+  if (taggedPapers.size < GAPS_MIN_PAPERS) return null;
+  const rowKeys = [...papersByKey.entries()]
+    .sort(
+      (a, b) =>
+        b[1].size - a[1].size || (labelByKey.get(a[0]) ?? "").localeCompare(labelByKey.get(b[0]) ?? ""),
+    )
+    .slice(0, GAPS_MAX_ROWS)
+    .map(([key]) => key);
+  if (rowKeys.length < GAPS_MIN_ROWS) return null;
+  const cells = rowKeys.map((key) => {
+    const counts: Record<DeepVizDesignBucket, number> = {
+      meta_sysrev: 0,
+      rct: 0,
+      observational: 0,
+      other: 0,
+    };
+    for (const n of papersByKey.get(key) ?? []) {
+      const design = papers.get(n)?.studyDesign;
+      counts[design ? DESIGN_TO_BUCKET[design] : "other"] += 1;
+    }
+    return DEEP_VIZ_DESIGN_BUCKETS.map((bucket) => counts[bucket]);
+  });
+  return {
+    v: 1,
+    type: "gaps-matrix",
+    id: "gaps",
+    rows: rowKeys.map((key) => labelByKey.get(key) ?? key),
+    cols: ["meta_sysrev", "rct", "observational", "other"],
+    cells,
+  };
+}
+
+function buildOpenQuestions(items: DeepVizOpenQuestionInput[]): OpenQuestionsBlock | null {
+  const sanitized = items
+    .map((item) => ({ question: collapseLabel(item.question), why: collapseLabel(item.why) }))
+    .filter((item) => item.question.length > 0)
+    .slice(0, OPEN_QUESTIONS_MAX);
+  if (sanitized.length < OPEN_QUESTIONS_MIN) return null;
+  return { v: 1, type: "open-questions", id: "open-questions", items: sanitized };
+}
+
+/**
+ * Susun semua blok viz yang MEMENUHI ambang minimum data per tipe blok dari hasil
+ * klasifikasi step `analyze-sources`. Deterministik penuh (tanpa Date/random). Urutan
+ * output = urutan daftar id di prompt writer: consensus-q* (indeks naik), timeline,
+ * contributors, claims, gaps, open-questions.
+ */
+export function buildDeepVizBlocks(input: BuildDeepVizInput): DeepVizBlock[] {
+  const units = dedupeUnits(input.sources);
+  const papers = paperProfiles(units);
+  const blocks: Array<DeepVizBlock | null> = [
+    ...buildConsensusMeters(units, input.subQuestions, input.subQuestionAnswerable),
+    buildResultsTimeline(papers),
+    buildTopContributors(papers),
+    buildClaimsEvidence(input.claims, papers),
+    buildGapsMatrix(papers),
+    buildOpenQuestions(input.openQuestions),
+  ];
+  return blocks.filter((block): block is DeepVizBlock => block !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Injector — marker writer `{{viz:<id>}}` → fenced block JSON (post-process synthesize)
+// ---------------------------------------------------------------------------
+
+export type InjectVizResult = {
+  report: string;
+  /** Id blok yang ditempatkan writer via marker. */
+  placedIds: string[];
+  /** Id blok inti (consensus-q* dan claims) yang tak ditaruh writer → di-append di lampiran. */
+  appendedIds: string[];
+  /** Id blok non-inti yang tak ditaruh writer → di-drop. */
+  droppedIds: string[];
+  /** Jumlah fence `aqsha:viz` tulisan model yang dibuang (anti-forgery). */
+  strippedFenceCount: number;
+  /** Jumlah baris marker tak dikenal/duplikat yang dihapus. */
+  removedMarkerCount: number;
+};
+
+/**
+ * Baris marker penempatan blok. Toleran terhadap penyimpangan kecil writer dari format
+ * `{{viz:<id>}}` polos: boleh berawalan bullet list dan berakhiran tanda baca ringan.
+ */
+const MARKER_LINE = /^\s*(?:[-*+]\s+)?\{\{viz:([a-z0-9-]+)\}\}\s*[.,;:]?\s*$/;
+/** Token marker di posisi mana pun — jaring pengaman agar token mentah tak pernah bocor ke user. */
+const MARKER_INLINE = /\{\{viz:[a-z0-9-]+\}\}/g;
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+const VIZ_APPENDIX_HEADING = "### Lampiran visual";
+
+/** Blok yang wajib tampil walau writer tak menaruh markernya. */
+function isCoreBlock(block: DeepVizBlock): boolean {
+  return block.type === "consensus-meter" || block.type === "claims-evidence";
+}
+
+type FenceState = { char: string; length: number };
+
+/**
+ * Penutup fence per CommonMark: karakter sama, panjang run ≥ pembuka, tanpa info string.
+ * Tanpa aturan panjang, baris ``` di dalam fence ```` akan salah dianggap penutup dan
+ * isi contoh kode ikut diproses injector.
+ */
+function closesFence(fenceMatch: RegExpMatchArray, fence: FenceState): boolean {
+  const run = fenceMatch[1] ?? "";
+  return (
+    run[0] === fence.char && run.length >= fence.length && (fenceMatch[2] ?? "").trim() === ""
+  );
+}
+
+/** Fenced block `aqsha:viz` self-contained (JSON satu baris → aman dari fence-break). */
+export function vizBlockToFence(block: DeepVizBlock): string {
+  return ["```aqsha:viz", JSON.stringify(block), "```"].join("\n");
+}
+
+/**
+ * Kolaps baris kosong beruntun (≥2) menjadi satu baris kosong, HANYA di luar fence —
+ * isi code block tulisan writer harus lolos verbatim.
+ */
+function collapseBlankRuns(lines: string[]): string[] {
+  const out: string[] = [];
+  let fence: FenceState | null = null;
+  let blankRun = 0;
+  for (const line of lines) {
+    const fenceMatch = line.match(FENCE_OPEN);
+    if (fence) {
+      out.push(line);
+      if (fenceMatch && closesFence(fenceMatch, fence)) fence = null;
+      continue;
+    }
+    if (fenceMatch) {
+      const run = fenceMatch[1] ?? "```";
+      fence = { char: run[0] ?? "`", length: run.length };
+      blankRun = 0;
+      out.push(line);
+      continue;
+    }
+    if (line.trim() === "") {
+      blankRun += 1;
+      if (blankRun > 1) continue;
+      out.push("");
+      continue;
+    }
+    blankRun = 0;
+    out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Post-processor laporan synthesize — pure & idempoten (retry synthesize mengulang
+ * injeksi dengan hasil sama):
+ * 1. STRIP semua fence `aqsha:viz` tulisan model (anti-forgery; fence tanpa penutup
+ *    di-strip sampai akhir teks).
+ * 2. Ganti baris marker `{{viz:<id>}}` → fenced block JSON blok ber-id sama. Marker
+ *    tak dikenal → baris dihapus; duplikat → kemunculan pertama menang. Marker di dalam
+ *    fence code lain TIDAK disentuh; token marker yang terselip di tengah kalimat
+ *    dihapus dari teksnya (blok inti tetap muncul via lampiran).
+ * 3. Blok inti (consensus-q*, claims) yang tak ditempatkan → append di bawah
+ *    `### Lampiran visual`; blok lain yang tak ditempatkan → drop.
+ * 4. Setiap blok yang ditulis diberi nomor `figure` berurutan sesuai posisinya di
+ *    dokumen final — sumber tunggal penomoran "Gambar n" di FE.
+ */
+export function injectVizBlocks(report: string, blocks: DeepVizBlock[]): InjectVizResult {
+  const blockById = new Map(blocks.map((block) => [block.id, block]));
+  const placedIds: string[] = [];
+  let strippedFenceCount = 0;
+  let removedMarkerCount = 0;
+  let figureCount = 0;
+
+  const stampFence = (block: DeepVizBlock): string => {
+    figureCount += 1;
+    return vizBlockToFence({ ...block, figure: figureCount });
+  };
+
+  const outLines: string[] = [];
+  let insideFence: FenceState | null = null;
+  let strippingViz: FenceState | null = null;
+  for (const line of report.split("\n")) {
+    const fenceMatch = line.match(FENCE_OPEN);
+    if (strippingViz) {
+      // Dalam fence aqsha:viz liar: buang sampai fence penutup (atau EOF).
+      if (fenceMatch && closesFence(fenceMatch, strippingViz)) strippingViz = null;
+      continue;
+    }
+    if (insideFence) {
+      outLines.push(line);
+      if (fenceMatch && closesFence(fenceMatch, insideFence)) insideFence = null;
+      continue;
+    }
+    if (fenceMatch) {
+      const run = fenceMatch[1] ?? "```";
+      const state: FenceState = { char: run[0] ?? "`", length: run.length };
+      const info = (fenceMatch[2] ?? "").trim();
+      if (info.toLowerCase().startsWith("aqsha:viz")) {
+        strippingViz = state;
+        strippedFenceCount += 1;
+        continue;
+      }
+      // Fence tanpa info string bisa pembuka atau penutup nyasar — perlakukan sebagai pembuka.
+      insideFence = state;
+      outLines.push(line);
+      continue;
+    }
+    const markerMatch = line.match(MARKER_LINE);
+    if (markerMatch) {
+      const id = markerMatch[1] ?? "";
+      const block = blockById.get(id);
+      if (!block || placedIds.includes(id)) {
+        removedMarkerCount += 1;
+        continue;
+      }
+      placedIds.push(id);
+      outLines.push("", stampFence(block), "");
+      continue;
+    }
+    if (line.includes("{{viz:")) {
+      // Token marker terselip di tengah teks (bukan baris marker valid): buang tokennya
+      // saja supaya `{{viz:...}}` mentah tak pernah tampil ke user.
+      const withoutMarkers = line.replace(MARKER_INLINE, "");
+      if (withoutMarkers !== line) {
+        removedMarkerCount += 1;
+        const cleaned = withoutMarkers.replace(/[ \t]{2,}/g, " ").trimEnd();
+        if (cleaned.trim() !== "") outLines.push(cleaned);
+        continue;
+      }
+    }
+    outLines.push(line);
+  }
+
+  // Blok yang tak ditempatkan writer: inti di-append, sisanya drop.
+  const appendedIds: string[] = [];
+  const droppedIds: string[] = [];
+  const appendixFences: string[] = [];
+  for (const block of blocks) {
+    if (placedIds.includes(block.id)) continue;
+    if (isCoreBlock(block)) {
+      appendedIds.push(block.id);
+      appendixFences.push(stampFence(block));
+    } else {
+      droppedIds.push(block.id);
+    }
+  }
+
+  let resultLines = outLines;
+  if (appendixFences.length > 0) {
+    while (resultLines.length > 0 && resultLines[resultLines.length - 1]?.trim() === "") {
+      resultLines = resultLines.slice(0, -1);
+    }
+    resultLines = [...resultLines, "", VIZ_APPENDIX_HEADING, "", appendixFences.join("\n\n"), ""];
+  }
+  const result = collapseBlankRuns(resultLines).join("\n");
+
+  return { report: result, placedIds, appendedIds, droppedIds, strippedFenceCount, removedMarkerCount };
+}
+
+/**
+ * Ringkasan analisis bukti untuk panel proses — SATU sumber wording untuk emit live di
+ * workflow agent dan rekonstruksi riwayat di web, supaya baris yang sama tidak berganti
+ * kalimat antara live-stream dan refresh/replay.
+ */
+export function formatDeepAnalyzeSummary(classifiedCount: number, blockIds: string[]): string {
+  const head = `Analisis bukti: ${classifiedCount} unit sumber diklasifikasikan`;
+  if (blockIds.length === 0) return `${head}; belum ada blok visual yang memenuhi ambang.`;
+  return `${head}; ${blockIds.length} blok visual layak (${blockIds.join(", ")}).`;
+}

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -1,12 +1,14 @@
 /**
- * @aqsha/chat-core — logika MURNI chat Astra (Fase 6), zero-dep & SATU FILE
- * (tanpa relative import).
+ * @aqsha/chat-core — logika MURNI chat Astra (Fase 6). Tiap entry (subpath exports
+ * map) = SATU file mandiri TANPA relative import: `index.ts` (ini) dan
+ * `deep-viz.ts` (`@aqsha/chat-core/deep-viz`, evidence viz laporan `/deep`).
  *
  * Kenapa paket sendiri: konsumen ter-bundle (runtime agent Node) TIDAK bisa
  * mengonsumsi paket workspace TS-mentah dengan relative-import tanpa ekstensi
  * (`@aqsha/db`/`@aqsha/services`) — bundler gagal resolve, dan runtime Node tak
- * bisa import `.ts` mentah bila di-externalize. Paket satu-file tanpa relative
- * import aman di-bundle. Helper murni di sini dipakai BERSAMA oleh web, api, dan
+ * bisa import `.ts` mentah bila di-externalize. File entry mandiri tanpa relative
+ * import aman di-bundle; dependency npm ter-compile (hanya `zod`, dipin sama dgn
+ * web/agent) juga aman. Helper murni di sini dipakai BERSAMA oleh web, api, dan
  * agent + unit test → SATU SSOT, tanpa duplikasi.
  *
  * Struktur tabel SSOT = `packages/db` (migrasi).

--- a/packages/chat-core/test/deep-viz.test.ts
+++ b/packages/chat-core/test/deep-viz.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Unit deep-viz — builders (ambang, dedupe, skor, `n` liar, input kosong) + injectVizBlocks
+ * (strip fence liar, replace marker, duplikat, append blok inti, drop marker asing,
+ * penomoran figure, fence-awareness) + parseDeepVizBlock (fallback payload korup).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  type BuildDeepVizInput,
+  buildDeepVizBlocks,
+  type ClaimsEvidenceBlock,
+  type ConsensusMeterBlock,
+  type DeepVizBlock,
+  type DeepVizSourceInput,
+  type GapsMatrixBlock,
+  injectVizBlocks,
+  parseDeepVizBlock,
+  type ResultsTimelineBlock,
+  type TopContributorsBlock,
+  vizBlockToFence,
+} from "../src/deep-viz";
+
+function src(over: Partial<DeepVizSourceInput> & { n: number }): DeepVizSourceInput {
+  return {
+    subQuestionIndex: 0,
+    title: `Paper ${over.n}`,
+    authors: [],
+    year: null,
+    venue: null,
+    citedByCount: null,
+    evidenceStrength: "medium",
+    stance: null,
+    studyDesign: null,
+    outcomes: [],
+    topics: [],
+    ...over,
+  };
+}
+
+function input(over: Partial<BuildDeepVizInput> = {}): BuildDeepVizInput {
+  return {
+    subQuestions: ["Apakah X meningkatkan Y?"],
+    sources: [],
+    subQuestionAnswerable: [{ subQuestionIndex: 0, answerable: true }],
+    claims: [],
+    openQuestions: [],
+    ...over,
+  };
+}
+
+function findBlock<T extends DeepVizBlock["type"]>(blocks: DeepVizBlock[], type: T) {
+  return blocks.find((b) => b.type === type);
+}
+
+describe("buildDeepVizBlocks — input kosong & ambang", () => {
+  test("input kosong → tanpa blok sama sekali", () => {
+    expect(buildDeepVizBlocks(input())).toEqual([]);
+  });
+
+  test("consensus-meter: N ≥ 5 + ≥ 2 stance → tampil; N = 4 → drop", () => {
+    const five = [
+      src({ n: 1, stance: "yes", studyDesign: "rct" }),
+      src({ n: 2, stance: "yes", studyDesign: "meta_analysis" }),
+      src({ n: 3, stance: "yes" }),
+      src({ n: 4, stance: "no", studyDesign: "observational" }),
+      src({ n: 5, stance: "mixed" }),
+    ];
+    const blocks = buildDeepVizBlocks(input({ sources: five }));
+    const meter = findBlock(blocks, "consensus-meter") as ConsensusMeterBlock;
+    expect(meter).toBeDefined();
+    expect(meter.id).toBe("consensus-q0");
+    expect(meter.n).toBe(5);
+    expect(meter.stances).toEqual({ yes: 3, possibly: 0, mixed: 1, no: 1 });
+    // Design null → bucket badge `other`.
+    expect(meter.designByStance.yes).toEqual({ rct: 1, meta_analysis: 1, other: 1 });
+
+    const four = buildDeepVizBlocks(input({ sources: five.slice(0, 4) }));
+    expect(findBlock(four, "consensus-meter")).toBeUndefined();
+  });
+
+  test("consensus-meter: satu stance seragam / subQ tak answerable / not_applicable → drop", () => {
+    const uniform = Array.from({ length: 6 }, (_, i) => src({ n: i + 1, stance: "yes" }));
+    expect(findBlock(buildDeepVizBlocks(input({ sources: uniform })), "consensus-meter")).toBeUndefined();
+
+    const mixed = [
+      src({ n: 1, stance: "yes" }),
+      src({ n: 2, stance: "yes" }),
+      src({ n: 3, stance: "no" }),
+      src({ n: 4, stance: "no" }),
+      // not_applicable TIDAK masuk populasi N.
+      src({ n: 5, stance: "not_applicable" }),
+      src({ n: 6, stance: "possibly" }),
+    ];
+    const meter = findBlock(
+      buildDeepVizBlocks(input({ sources: mixed })),
+      "consensus-meter",
+    ) as ConsensusMeterBlock;
+    expect(meter.n).toBe(5);
+
+    const notAnswerable = buildDeepVizBlocks(
+      input({ sources: mixed, subQuestionAnswerable: [{ subQuestionIndex: 0, answerable: false }] }),
+    );
+    expect(findBlock(notAnswerable, "consensus-meter")).toBeUndefined();
+  });
+
+  test("dedupe unit n×subQ: kemunculan pertama menang", () => {
+    const sources = [
+      src({ n: 1, stance: "yes" }),
+      src({ n: 1, stance: "no" }), // duplikat unit → diabaikan
+      src({ n: 2, stance: "yes" }),
+      src({ n: 3, stance: "yes" }),
+      src({ n: 4, stance: "no" }),
+      src({ n: 5, stance: "no" }),
+    ];
+    const meter = findBlock(
+      buildDeepVizBlocks(input({ sources })),
+      "consensus-meter",
+    ) as ConsensusMeterBlock;
+    expect(meter.n).toBe(5);
+    expect(meter.stances.yes).toBe(3);
+    expect(meter.stances.no).toBe(2);
+  });
+
+  test("results-timeline: ≥ 4 titik ber-tahun + ≥ 2 tahun → tampil terurut; 1 tahun → drop", () => {
+    const sources = [
+      src({ n: 1, year: 2020, citedByCount: 10 }),
+      src({ n: 2, year: 2019 }),
+      src({ n: 3, year: 2020, citedByCount: 3 }),
+      src({ n: 4, year: 2024, citedByCount: 99 }),
+      src({ n: 5, year: null }), // tanpa tahun → bukan titik
+    ];
+    const timeline = findBlock(
+      buildDeepVizBlocks(input({ sources })),
+      "results-timeline",
+    ) as ResultsTimelineBlock;
+    expect(timeline.points.map((p) => p.n)).toEqual([2, 1, 3, 4]);
+    expect(timeline.points[0]?.citedByCount).toBe(null);
+
+    const sameYear = Array.from({ length: 4 }, (_, i) => src({ n: i + 1, year: 2020 }));
+    expect(findBlock(buildDeepVizBlocks(input({ sources: sameYear })), "results-timeline")).toBeUndefined();
+  });
+
+  test("top-contributors: hanya ≥ 2 paper unik, top 3, tiebreak total sitasi", () => {
+    const sources = [
+      src({ n: 1, authors: ["Alice", "Bob"], venue: "Nature", citedByCount: 5 }),
+      src({ n: 2, authors: ["Alice", "Carol"], venue: "Nature", citedByCount: 7 }),
+      src({ n: 3, authors: ["Bob"], venue: "Science", citedByCount: 100 }),
+      src({ n: 4, authors: ["Dave"], venue: "Science" }),
+      src({ n: 5, authors: ["Eve"] }),
+    ];
+    const contributors = findBlock(
+      buildDeepVizBlocks(input({ sources })),
+      "top-contributors",
+    ) as TopContributorsBlock;
+    // Alice (n1,n2, 12 sitasi) vs Bob (n1,n3, 105 sitasi) → Bob duluan; Eve/Dave/Carol (1 paper) tak masuk.
+    expect(contributors.authors.map((a) => a.name)).toEqual(["Bob", "Alice"]);
+    expect(contributors.authors[0]?.papers).toEqual([1, 3]);
+    expect(contributors.venues.map((v) => v.name)).toEqual(["Science", "Nature"]);
+
+    const solo = [src({ n: 1, authors: ["Alice"], venue: "Nature" })];
+    expect(findBlock(buildDeepVizBlocks(input({ sources: solo })), "top-contributors")).toBeUndefined();
+  });
+});
+
+describe("buildDeepVizBlocks — claims (skor deterministik + n liar)", () => {
+  const papers = [
+    src({ n: 1, studyDesign: "meta_analysis", evidenceStrength: "strong" }), // 3.0
+    src({ n: 2, studyDesign: "rct", evidenceStrength: "medium" }), // 1.875
+    src({ n: 3, studyDesign: "observational", evidenceStrength: "weak" }), // 0.75
+    src({ n: 4 }), // design null → other 1.0 × medium 0.75 = 0.75
+  ];
+
+  test("skor = Σ bobot design × multiplier strength; label by ambang; n liar dibuang", () => {
+    const blocks = buildDeepVizBlocks(
+      input({
+        sources: papers,
+        claims: [
+          { text: "K1", reasoning: "R1", papers: [1, 2, 3] }, // 5.625 → 5.6 moderate
+          { text: "K2", reasoning: "R2", papers: [1, 1, 99] }, // dedupe + 99 liar → [1] = 3.0 moderate
+          { text: "K3", reasoning: "R3", papers: [3, 4] }, // 1.5 limited
+          { text: "K4", reasoning: "R4", papers: [99] }, // tanpa paper valid → drop
+        ],
+      }),
+    );
+    const claims = (findBlock(blocks, "claims-evidence") as ClaimsEvidenceBlock).claims;
+    expect(claims.length).toBe(3);
+    expect(claims[0]).toMatchObject({ text: "K1", papers: [1, 2, 3], score: 5.6, label: "moderate" });
+    expect(claims[1]).toMatchObject({ text: "K2", papers: [1], score: 3, label: "moderate" });
+    expect(claims[2]).toMatchObject({ text: "K3", papers: [3, 4], score: 1.5, label: "limited" });
+  });
+
+  test("skor clamp 10 + label strong; < 3 klaim valid → blok drop", () => {
+    const metas = Array.from({ length: 5 }, (_, i) =>
+      src({ n: i + 1, studyDesign: "meta_analysis", evidenceStrength: "strong" }),
+    );
+    const blocks = buildDeepVizBlocks(
+      input({
+        sources: metas,
+        claims: [
+          { text: "Kuat", reasoning: "", papers: [1, 2, 3, 4, 5] }, // 15 → clamp 10
+          { text: "K2", reasoning: "", papers: [1] },
+          { text: "K3", reasoning: "", papers: [2] },
+        ],
+      }),
+    );
+    const claims = (findBlock(blocks, "claims-evidence") as ClaimsEvidenceBlock).claims;
+    expect(claims[0]).toMatchObject({ score: 10, label: "strong" });
+
+    const tooFew = buildDeepVizBlocks(
+      input({ sources: metas, claims: [{ text: "K1", reasoning: "", papers: [1] }] }),
+    );
+    expect(findBlock(tooFew, "claims-evidence")).toBeUndefined();
+  });
+});
+
+describe("buildDeepVizBlocks — gaps-matrix & open-questions", () => {
+  test("gaps: ≥ 8 paper + ≥ 2 baris → pivot; fallback topics; merge case-insensitive", () => {
+    const sources = [
+      src({ n: 1, outcomes: ["Mortality"], studyDesign: "rct" }),
+      src({ n: 2, outcomes: ["mortality"], studyDesign: "meta_analysis" }), // merge dgn Mortality
+      src({ n: 3, outcomes: ["Mortality", "Quality of life"], studyDesign: "rct" }),
+      src({ n: 4, outcomes: ["Quality of life"], studyDesign: "observational" }),
+      src({ n: 5, outcomes: ["Quality of life"] }), // design null → kolom other
+      src({ n: 6, outcomes: [], topics: ["Cost"] }), // fallback topics
+      src({ n: 7, outcomes: ["Mortality"], studyDesign: "systematic_review" }),
+      src({ n: 8, outcomes: ["Cost"], studyDesign: "review" }), // review → bucket other
+    ];
+    const gaps = findBlock(buildDeepVizBlocks(input({ sources })), "gaps-matrix") as GapsMatrixBlock;
+    expect(gaps.rows).toEqual(["Mortality", "Quality of life", "Cost"]);
+    expect(gaps.cols).toEqual(["meta_sysrev", "rct", "observational", "other"]);
+    // Mortality: meta(2)+sysrev(7)=2, rct(1,3)=2; QoL: rct(3)=1, obs(4)=1, other(5)=1; Cost: other(6,8)=2.
+    expect(gaps.cells).toEqual([
+      [2, 2, 0, 0],
+      [0, 1, 1, 1],
+      [0, 0, 0, 2],
+    ]);
+
+    const tooFew = buildDeepVizBlocks(input({ sources: sources.slice(0, 7) }));
+    expect(findBlock(tooFew, "gaps-matrix")).toBeUndefined();
+  });
+
+  test("open-questions: pass-through 2–4; < 2 → drop; > 4 → cap", () => {
+    const items = Array.from({ length: 6 }, (_, i) => ({ question: `Q${i}`, why: `W${i}` }));
+    const blocks = buildDeepVizBlocks(input({ openQuestions: items }));
+    const open = findBlock(blocks, "open-questions");
+    expect(open?.type === "open-questions" && open.items.length).toBe(4);
+
+    const one = buildDeepVizBlocks(input({ openQuestions: [items[0]!] }));
+    expect(findBlock(one, "open-questions")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+const meterBlock: DeepVizBlock = {
+  v: 1,
+  type: "consensus-meter",
+  id: "consensus-q0",
+  subQuestionIndex: 0,
+  question: "Apakah X?",
+  n: 5,
+  stances: { yes: 3, possibly: 0, mixed: 1, no: 1 },
+  designByStance: { yes: { rct: 2, other: 1 }, possibly: {}, mixed: { other: 1 }, no: { observational: 1 } },
+};
+const timelineBlock: DeepVizBlock = {
+  v: 1,
+  type: "results-timeline",
+  id: "timeline",
+  points: [{ n: 1, year: 2020, citedByCount: 10 }],
+};
+const claimsBlock: DeepVizBlock = {
+  v: 1,
+  type: "claims-evidence",
+  id: "claims",
+  claims: [{ text: "K", reasoning: "R", papers: [1], score: 3, label: "moderate" }],
+};
+
+describe("injectVizBlocks", () => {
+  test("replace marker → fenced JSON; marker asing dihapus; duplikat: pertama menang", () => {
+    const report = [
+      "## Temuan",
+      "Paragraf pembuka.",
+      "{{viz:consensus-q0}}",
+      "Paragraf lanjutan.",
+      "{{viz:tidak-dikenal}}",
+      "{{viz:consensus-q0}}",
+      "Penutup.",
+    ].join("\n");
+    const out = injectVizBlocks(report, [meterBlock]);
+    expect(out.placedIds).toEqual(["consensus-q0"]);
+    expect(out.removedMarkerCount).toBe(2);
+    expect(out.report).toContain("```aqsha:viz");
+    expect(out.report).not.toContain("{{viz:");
+    // Payload di fence harus parse balik ke blok yang sama + nomor figure hasil stamping.
+    const payload = out.report.match(/```aqsha:viz\n(.*)\n```/)?.[1] ?? "";
+    expect(parseDeepVizBlock(payload)).toEqual({ ...meterBlock, figure: 1 });
+    // Hanya satu fence (duplikat tak diinjeksi dua kali).
+    expect(out.report.match(/```aqsha:viz/g)?.length).toBe(1);
+  });
+
+  test("anti-forgery: fence aqsha:viz tulisan model di-strip (termasuk tanpa penutup)", () => {
+    const forged = [
+      "Teks.",
+      "```aqsha:viz",
+      '{"v":1,"type":"open-questions","id":"open-questions","items":[]}',
+      "```",
+      "Tengah.",
+      "{{viz:timeline}}",
+      "Akhir.",
+      "```aqsha:viz",
+      '{"palsu":true}',
+    ].join("\n");
+    const out = injectVizBlocks(forged, [timelineBlock]);
+    expect(out.strippedFenceCount).toBe(2);
+    expect(out.report).not.toContain("palsu");
+    expect(out.report).not.toContain("open-questions");
+    expect(out.report).toContain("Tengah.");
+    // Marker sah tetap diganti fence hasil injeksi.
+    expect(out.report.match(/```aqsha:viz/g)?.length).toBe(1);
+    expect(out.placedIds).toEqual(["timeline"]);
+  });
+
+  test("blok inti tak ditaruh → append Lampiran visual; non-inti tak ditaruh → drop", () => {
+    const out = injectVizBlocks("Laporan tanpa marker.", [meterBlock, claimsBlock, timelineBlock]);
+    expect(out.appendedIds).toEqual(["consensus-q0", "claims"]);
+    expect(out.droppedIds).toEqual(["timeline"]);
+    expect(out.report).toContain("### Lampiran visual");
+    expect(out.report.match(/```aqsha:viz/g)?.length).toBe(2);
+    expect(out.report.indexOf("Laporan tanpa marker.")).toBeLessThan(out.report.indexOf("### Lampiran visual"));
+  });
+
+  test("marker di dalam fence code biasa TIDAK disentuh; dua marker berdampingan dipisah baris kosong", () => {
+    const report = [
+      "```js",
+      "{{viz:timeline}}",
+      "```",
+      "{{viz:consensus-q0}}",
+      "{{viz:claims}}",
+    ].join("\n");
+    const out = injectVizBlocks(report, [meterBlock, claimsBlock, timelineBlock]);
+    // Marker di fence js utuh; timeline tak ditaruh (dan non-inti) → drop.
+    expect(out.report).toContain("{{viz:timeline}}");
+    expect(out.placedIds).toEqual(["consensus-q0", "claims"]);
+    expect(out.droppedIds).toEqual(["timeline"]);
+    // Tak ada fence penutup yang langsung disusul fence pembuka.
+    expect(out.report).not.toContain("```\n```aqsha:viz");
+  });
+
+  test("idempoten terhadap retry: injeksi ulang dari laporan mentah menghasilkan output sama", () => {
+    const raw = "Isi.\n{{viz:claims}}\nAkhir.";
+    const first = injectVizBlocks(raw, [claimsBlock]);
+    const second = injectVizBlocks(raw, [claimsBlock]);
+    expect(second.report).toBe(first.report);
+  });
+
+  test("nomor figure berurutan: marker sesuai urutan dokumen, lampiran melanjutkan", () => {
+    const report = ["Awal.", "{{viz:timeline}}", "Tengah.", "{{viz:claims}}", "Akhir."].join("\n");
+    const out = injectVizBlocks(report, [meterBlock, claimsBlock, timelineBlock]);
+    const payloads = [...out.report.matchAll(/```aqsha:viz\n(.*)\n```/g)].map((m) =>
+      parseDeepVizBlock(m[1] ?? ""),
+    );
+    // timeline (marker 1) → 1, claims (marker 2) → 2, consensus (lampiran) → 3.
+    expect(payloads.map((b) => [b?.id, b?.figure])).toEqual([
+      ["timeline", 1],
+      ["claims", 2],
+      ["consensus-q0", 3],
+    ]);
+  });
+
+  test("baris kosong beruntun DI DALAM fence code dipertahankan; di luar dikolaps", () => {
+    const report = ["```python", "def a():", "    pass", "", "", "def b():", "    pass", "```", "Teks.", "", "", "", "Akhir."].join("\n");
+    const out = injectVizBlocks(report, []);
+    expect(out.report).toContain("    pass\n\n\ndef b():");
+    expect(out.report).toContain("Teks.\n\nAkhir.");
+  });
+
+  test("fence 4-backtick: baris ``` di dalamnya BUKAN penutup — marker di dalamnya utuh", () => {
+    const report = ["````md", "```", "{{viz:claims}}", "```", "````", "{{viz:claims}}"].join("\n");
+    const out = injectVizBlocks(report, [claimsBlock]);
+    // Marker pertama ada di dalam fence 4-backtick → tak disentuh; marker kedua diganti fence.
+    expect(out.report).toContain("```\n{{viz:claims}}\n```");
+    expect(out.placedIds).toEqual(["claims"]);
+    expect(out.report.match(/```aqsha:viz/g)?.length).toBe(1);
+  });
+
+  test("marker berbullet ditoleransi; token marker inline di tengah kalimat dibuang", () => {
+    const report = ["- {{viz:claims}}", "Sebaran dirangkum {{viz:consensus-q0}} berikut."].join("\n");
+    const out = injectVizBlocks(report, [meterBlock, claimsBlock]);
+    expect(out.placedIds).toEqual(["claims"]);
+    expect(out.report).not.toContain("{{viz:");
+    expect(out.report).toContain("Sebaran dirangkum berikut.");
+    // Blok inti yang token-nya dibuang tetap tampil via lampiran.
+    expect(out.appendedIds).toEqual(["consensus-q0"]);
+  });
+});
+
+describe("parseDeepVizBlock — fallback payload korup", () => {
+  test("JSON korup / v asing / type asing → null; payload valid → blok", () => {
+    expect(parseDeepVizBlock("{bukan json")).toBe(null);
+    expect(parseDeepVizBlock(JSON.stringify({ ...timelineBlock, v: 2 }))).toBe(null);
+    expect(parseDeepVizBlock(JSON.stringify({ ...timelineBlock, type: "unknown" }))).toBe(null);
+    expect(parseDeepVizBlock(JSON.stringify(timelineBlock))).toEqual(timelineBlock);
+    // Round-trip via fence helper.
+    const fence = vizBlockToFence(meterBlock);
+    const payload = fence.split("\n")[1] ?? "";
+    expect(parseDeepVizBlock(payload)).toEqual(meterBlock);
+  });
+});

--- a/packages/db/migrations/0027_milky_wolfpack.sql
+++ b/packages/db/migrations/0027_milky_wolfpack.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "research_sources" ADD COLUMN "cited_by_count" integer;--> statement-breakpoint
+ALTER TABLE "research_sources" ADD COLUMN "topics_json" text;--> statement-breakpoint
+ALTER TABLE "research_sources" ADD COLUMN "stance" text;--> statement-breakpoint
+ALTER TABLE "research_sources" ADD COLUMN "study_design" text;--> statement-breakpoint
+ALTER TABLE "research_sources" ADD COLUMN "outcomes_json" text;--> statement-breakpoint
+ALTER TABLE "research_sources" ADD CONSTRAINT "research_sources_stance_check" CHECK ("research_sources"."stance" is null or "research_sources"."stance" in ('yes', 'possibly', 'mixed', 'no', 'not_applicable'));--> statement-breakpoint
+ALTER TABLE "research_sources" ADD CONSTRAINT "research_sources_study_design_check" CHECK ("research_sources"."study_design" is null or "research_sources"."study_design" in ('meta_analysis', 'systematic_review', 'rct', 'observational', 'review', 'other'));

--- a/packages/db/migrations/meta/0027_snapshot.json
+++ b/packages/db/migrations/meta/0027_snapshot.json
@@ -1,0 +1,4113 @@
+{
+  "id": "83f72ffe-3fdf-4cf1-b240-9a1ed507e5ef",
+  "prevId": "3527238f-27e1-435f-ace5-3f5e534ca4ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_completed_at": {
+          "name": "deletion_completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_status": {
+          "name": "deletion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "users_by_email": {
+          "name": "users_by_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_deletion_status_check": {
+          "name": "users_deletion_status_check",
+          "value": "\"users\".\"deletion_status\" in ('active', 'deleting', 'deleted', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workspaces_by_owner_status_updated": {
+          "name": "workspaces_by_owner_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_by_owner_updated": {
+          "name": "workspaces_by_owner_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_users_owner_user_id_fk": {
+          "name": "workspaces_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspaces_status_check": {
+          "name": "workspaces_status_check",
+          "value": "\"workspaces\".\"status\" in ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_folders": {
+      "name": "workspace_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_folders_by_owner_workspace_status_updated": {
+          "name": "workspace_folders_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_folders_by_owner_workspace_name": {
+          "name": "workspace_folders_by_owner_workspace_name",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_folders_owner_user_id_users_owner_user_id_fk": {
+          "name": "workspace_folders_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "workspace_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_folders_workspace_id_workspaces_id_fk": {
+          "name": "workspace_folders_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_folders",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_folders_status_check": {
+          "name": "workspace_folders_status_check",
+          "value": "\"workspace_folders\".\"status\" in ('active', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_about_source": {
+          "name": "heard_about_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_about_other": {
+          "name": "heard_about_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_onboarding_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_onboarding_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_agent_preferences": {
+      "name": "user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "answer_language": {
+          "name": "answer_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citation_style": {
+          "name": "citation_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_style": {
+          "name": "response_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_instruction": {
+          "name": "custom_instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_agent_preferences_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_agent_preferences_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_agent_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_agent_preferences_answer_language_check": {
+          "name": "user_agent_preferences_answer_language_check",
+          "value": "\"user_agent_preferences\".\"answer_language\" is null or \"user_agent_preferences\".\"answer_language\" in ('id', 'en')"
+        },
+        "user_agent_preferences_citation_style_check": {
+          "name": "user_agent_preferences_citation_style_check",
+          "value": "\"user_agent_preferences\".\"citation_style\" is null or \"user_agent_preferences\".\"citation_style\" in ('apa7', 'mla', 'chicago', 'ieee', 'vancouver', 'harvard')"
+        },
+        "user_agent_preferences_response_style_check": {
+          "name": "user_agent_preferences_response_style_check",
+          "value": "\"user_agent_preferences\".\"response_style\" is null or \"user_agent_preferences\".\"response_style\" in ('ringkas', 'seimbang', 'lengkap')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_feed_interests": {
+      "name": "user_feed_interests",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feed_interests_owner_user_id_users_owner_user_id_fk": {
+          "name": "user_feed_interests_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "user_feed_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_feed_interests_owner_user_id_topic_pk": {
+          "name": "user_feed_interests_owner_user_id_topic_pk",
+          "columns": [
+            "owner_user_id",
+            "topic"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_family": {
+          "name": "artifact_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexing_status": {
+          "name": "indexing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_indexed'"
+        },
+        "indexing_failure_reason": {
+          "name": "indexing_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_document_kind": {
+          "name": "detected_document_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_r2_key": {
+          "name": "storage_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rag_entry_id": {
+          "name": "rag_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text_preview": {
+          "name": "plain_text_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifacts_by_owner_status_updated": {
+          "name": "artifacts_by_owner_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_workspace_status_updated": {
+          "name": "artifacts_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_workspace_folder_status_updated": {
+          "name": "artifacts_by_owner_workspace_folder_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_thread_created": {
+          "name": "artifacts_by_owner_thread_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_by_owner_thread_source_status_created": {
+          "name": "artifacts_by_owner_thread_source_status_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifacts_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_workspace_id_workspaces_id_fk": {
+          "name": "artifacts_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifacts_folder_id_workspace_folders_id_fk": {
+          "name": "artifacts_folder_id_workspace_folders_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "workspace_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifacts_artifact_type_check": {
+          "name": "artifacts_artifact_type_check",
+          "value": "\"artifacts\".\"artifact_type\" in ('markdown', 'plain_text', 'pdf', 'docx', 'html', 'svg', 'mermaid', 'json', 'csv', 'code', 'url')"
+        },
+        "artifacts_artifact_family_check": {
+          "name": "artifacts_artifact_family_check",
+          "value": "\"artifacts\".\"artifact_family\" in ('text', 'file', 'interactive', 'visual', 'data', 'link')"
+        },
+        "artifacts_source_check": {
+          "name": "artifacts_source_check",
+          "value": "\"artifacts\".\"source\" in ('manual', 'upload', 'agent', 'url')"
+        },
+        "artifacts_indexing_status_check": {
+          "name": "artifacts_indexing_status_check",
+          "value": "\"artifacts\".\"indexing_status\" in ('not_indexed', 'pending', 'ready', 'failed')"
+        },
+        "artifacts_detected_document_kind_check": {
+          "name": "artifacts_detected_document_kind_check",
+          "value": "\"artifacts\".\"detected_document_kind\" is null or \"artifacts\".\"detected_document_kind\" in ('generic', 'scholarly_paper')"
+        },
+        "artifacts_status_check": {
+          "name": "artifacts_status_check",
+          "value": "\"artifacts\".\"status\" in ('active', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_contents": {
+      "name": "artifact_contents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks_json": {
+          "name": "blocks_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text": {
+          "name": "plain_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_text": {
+          "name": "context_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_text_r2_key": {
+          "name": "plain_text_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocks_json_r2_key": {
+          "name": "blocks_json_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown_r2_key": {
+          "name": "markdown_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_contents_by_owner_artifact": {
+          "name": "artifact_contents_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_contents_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_contents_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_contents_workspace_id_workspaces_id_fk": {
+          "name": "artifact_contents_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_contents_artifact_id_artifacts_id_fk": {
+          "name": "artifact_contents_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_contents",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_extractions": {
+      "name": "artifact_extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractor": {
+          "name": "extractor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_extractions_by_owner_artifact_extractor": {
+          "name": "artifact_extractions_by_owner_artifact_extractor",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extractor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_extractions_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_extractions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_extractions_artifact_id_artifacts_id_fk": {
+          "name": "artifact_extractions_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_extractions_workspace_id_workspaces_id_fk": {
+          "name": "artifact_extractions_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_extractions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_extractions_extractor_check": {
+          "name": "artifact_extractions_extractor_check",
+          "value": "\"artifact_extractions\".\"extractor\" in ('pdf_text', 'docx_text', 'url_reader')"
+        },
+        "artifact_extractions_status_check": {
+          "name": "artifact_extractions_status_check",
+          "value": "\"artifact_extractions\".\"status\" in ('pending', 'running', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_paper_metadata": {
+      "name": "artifact_paper_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliations": {
+          "name": "affiliations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal": {
+          "name": "journal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_status": {
+          "name": "oa_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_status": {
+          "name": "pdf_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_paper_metadata_by_owner_artifact": {
+          "name": "artifact_paper_metadata_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_paper_metadata_by_owner_workspace_updated": {
+          "name": "artifact_paper_metadata_by_owner_workspace_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_paper_metadata_by_owner_doi": {
+          "name": "artifact_paper_metadata_by_owner_doi",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_paper_metadata_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_paper_metadata_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_paper_metadata_artifact_id_artifacts_id_fk": {
+          "name": "artifact_paper_metadata_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_paper_metadata_workspace_id_workspaces_id_fk": {
+          "name": "artifact_paper_metadata_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_paper_metadata",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_paper_metadata_metadata_source_check": {
+          "name": "artifact_paper_metadata_metadata_source_check",
+          "value": "\"artifact_paper_metadata\".\"metadata_source\" in ('crossref', 'openalex', 'arxiv', 'datacite', 'semantic_scholar', 'manual', 'llm')"
+        },
+        "artifact_paper_metadata_pdf_status_check": {
+          "name": "artifact_paper_metadata_pdf_status_check",
+          "value": "\"artifact_paper_metadata\".\"pdf_status\" is null or \"artifact_paper_metadata\".\"pdf_status\" in ('downloaded', 'no_oa_available')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_urls": {
+      "name": "artifact_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_text": {
+          "name": "readable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_text": {
+          "name": "context_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_text_r2_key": {
+          "name": "readable_text_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_urls_by_owner_workspace_normalized_url": {
+          "name": "artifact_urls_by_owner_workspace_normalized_url",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_urls_by_owner_artifact": {
+          "name": "artifact_urls_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_urls_by_owner_workspace_status_updated": {
+          "name": "artifact_urls_by_owner_workspace_status_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_urls_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_urls_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_urls_workspace_id_workspaces_id_fk": {
+          "name": "artifact_urls_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_urls_artifact_id_artifacts_id_fk": {
+          "name": "artifact_urls_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_urls",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_urls_status_check": {
+          "name": "artifact_urls_status_check",
+          "value": "\"artifact_urls\".\"status\" in ('pending', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.artifact_embeddings": {
+      "name": "artifact_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_tsv": {
+          "name": "content_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(content, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_embeddings_by_owner_artifact": {
+          "name": "artifact_embeddings_by_owner_artifact",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_embeddings_embedding_hnsw": {
+          "name": "artifact_embeddings_embedding_hnsw",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "artifact_embeddings_content_gin": {
+          "name": "artifact_embeddings_content_gin",
+          "columns": [
+            {
+              "expression": "content_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_embeddings_owner_user_id_users_owner_user_id_fk": {
+          "name": "artifact_embeddings_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifact_embeddings_artifact_id_artifacts_id_fk": {
+          "name": "artifact_embeddings_artifact_id_artifacts_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artifact_embeddings_workspace_id_workspaces_id_fk": {
+          "name": "artifact_embeddings_workspace_id_workspaces_id_fk",
+          "tableFrom": "artifact_embeddings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_status": {
+          "name": "title_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lite'"
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_threads_by_owner_activity": {
+          "name": "chat_threads_by_owner_activity",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_threads_pinned_by_owner": {
+          "name": "chat_threads_pinned_by_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_owner_user_id_users_owner_user_id_fk": {
+          "name": "chat_threads_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_threads_status_check": {
+          "name": "chat_threads_status_check",
+          "value": "\"chat_threads\".\"status\" in ('idle', 'streaming', 'failed')"
+        },
+        "chat_threads_title_status_check": {
+          "name": "chat_threads_title_status_check",
+          "value": "\"chat_threads\".\"title_status\" is null or \"chat_threads\".\"title_status\" in ('generating', 'ready')"
+        },
+        "chat_threads_agent_kind_check": {
+          "name": "chat_threads_agent_kind_check",
+          "value": "\"chat_threads\".\"agent_kind\" in ('lite', 'pro')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.research_sources": {
+      "name": "research_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citation_number": {
+          "name": "citation_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_strength": {
+          "name": "evidence_strength",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovery_query": {
+          "name": "discovery_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_question_index": {
+          "name": "sub_question_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_question_text": {
+          "name": "sub_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors_json": {
+          "name": "authors_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics_json": {
+          "name": "topics_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance": {
+          "name": "stance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "study_design": {
+          "name": "study_design",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomes_json": {
+          "name": "outcomes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "research_sources_by_thread": {
+          "name": "research_sources_by_thread",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "research_sources_thread_turn_locator": {
+          "name": "research_sources_thread_turn_locator",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "research_sources_thread_id_chat_threads_id_fk": {
+          "name": "research_sources_thread_id_chat_threads_id_fk",
+          "tableFrom": "research_sources",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "research_sources_owner_user_id_users_owner_user_id_fk": {
+          "name": "research_sources_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "research_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "research_sources_origin_check": {
+          "name": "research_sources_origin_check",
+          "value": "\"research_sources\".\"origin\" in ('web', 'arxiv', 'doi')"
+        },
+        "research_sources_evidence_strength_check": {
+          "name": "research_sources_evidence_strength_check",
+          "value": "\"research_sources\".\"evidence_strength\" in ('strong', 'medium', 'weak')"
+        },
+        "research_sources_stance_check": {
+          "name": "research_sources_stance_check",
+          "value": "\"research_sources\".\"stance\" is null or \"research_sources\".\"stance\" in ('yes', 'possibly', 'mixed', 'no', 'not_applicable')"
+        },
+        "research_sources_study_design_check": {
+          "name": "research_sources_study_design_check",
+          "value": "\"research_sources\".\"study_design\" is null or \"research_sources\".\"study_design\" in ('meta_analysis', 'systematic_review', 'rct', 'observational', 'review', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.explore_papers": {
+      "name": "explore_papers",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arxiv_id": {
+          "name": "arxiv_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openalex_id": {
+          "name": "openalex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_access": {
+          "name": "is_open_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "explore_papers_by_doi": {
+          "name": "explore_papers_by_doi",
+          "columns": [
+            {
+              "expression": "doi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "explore_papers_provider_check": {
+          "name": "explore_papers_provider_check",
+          "value": "\"explore_papers\".\"provider\" in ('OpenAlex', 'arXiv', 'Exa', 'Jina', 'Crossref')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tldr": {
+          "name": "tldr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tldr_id": {
+          "name": "tldr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_id": {
+          "name": "title_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_url": {
+          "name": "resolved_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_text": {
+          "name": "article_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrich_attempts": {
+          "name": "enrich_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_key": {
+          "name": "paper_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_access": {
+          "name": "is_open_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "trend_score": {
+          "name": "trend_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retraction_status": {
+          "name": "retraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_claim": {
+          "name": "primary_claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance_supporting": {
+          "name": "stance_supporting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stance_contrasting": {
+          "name": "stance_contrasting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sparkline": {
+          "name": "sparkline",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_at": {
+          "name": "order_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "feed_items_by_dedupe_key": {
+          "name": "feed_items_by_dedupe_key",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_kind_trend": {
+          "name": "feed_items_by_kind_trend",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trend_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_kind_published": {
+          "name": "feed_items_by_kind_published",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_order": {
+          "name": "feed_items_by_order",
+          "columns": [
+            {
+              "expression": "order_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_by_paper_key": {
+          "name": "feed_items_by_paper_key",
+          "columns": [
+            {
+              "expression": "paper_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_search_gin": {
+          "name": "feed_items_search_gin",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_items_kind_check": {
+          "name": "feed_items_kind_check",
+          "value": "\"feed_items\".\"kind\" in ('paper', 'news', 'claim', 'topic', 'idea')"
+        },
+        "feed_items_provider_check": {
+          "name": "feed_items_provider_check",
+          "value": "\"feed_items\".\"provider\" in ('openalex', 'exa_news', 'gdelt', 'google_factcheck', 'turnbackhoax')"
+        },
+        "feed_items_retraction_status_check": {
+          "name": "feed_items_retraction_status_check",
+          "value": "\"feed_items\".\"retraction_status\" is null or \"feed_items\".\"retraction_status\" in ('none', 'concern', 'retracted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_sources": {
+      "name": "feed_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cadence_minutes": {
+          "name": "cadence_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_params_json": {
+          "name": "query_params_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feed_sources_by_provider": {
+          "name": "feed_sources_by_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_sources_provider_check": {
+          "name": "feed_sources_provider_check",
+          "value": "\"feed_sources\".\"provider\" in ('openalex', 'exa_news', 'gdelt', 'google_factcheck', 'turnbackhoax')"
+        },
+        "feed_sources_last_status_check": {
+          "name": "feed_sources_last_status_check",
+          "value": "\"feed_sources\".\"last_status\" is null or \"feed_sources\".\"last_status\" in ('ready', 'empty', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_feed_items": {
+      "name": "saved_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "saved_feed_items_by_owner_item": {
+          "name": "saved_feed_items_by_owner_item",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_feed_items_by_owner_created": {
+          "name": "saved_feed_items_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_feed_items_owner_user_id_users_owner_user_id_fk": {
+          "name": "saved_feed_items_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "saved_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "saved_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "saved_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hidden_feed_items": {
+      "name": "hidden_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "hidden_feed_items_by_owner_item": {
+          "name": "hidden_feed_items_by_owner_item",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hidden_feed_items_by_owner_created": {
+          "name": "hidden_feed_items_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hidden_feed_items_owner_user_id_users_owner_user_id_fk": {
+          "name": "hidden_feed_items_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "hidden_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hidden_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "hidden_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "hidden_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_interactions": {
+      "name": "feed_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feed_interactions_by_owner_item_kind": {
+          "name": "feed_interactions_by_owner_item_kind",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feed_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_by_owner_created": {
+          "name": "feed_interactions_by_owner_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_interactions_owner_user_id_users_owner_user_id_fk": {
+          "name": "feed_interactions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "feed_interactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_interactions_feed_item_id_feed_items_id_fk": {
+          "name": "feed_interactions_feed_item_id_feed_items_id_fk",
+          "tableFrom": "feed_interactions",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_interactions_kind_check": {
+          "name": "feed_interactions_kind_check",
+          "value": "\"feed_interactions\".\"kind\" in ('save', 'hide', 'research', 'open_evidence')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.domain_reliability": {
+      "name": "domain_reliability",
+      "schema": "",
+      "columns": {
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unreliable": {
+          "name": "unreliable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "domain_reliability_by_unreliable": {
+          "name": "domain_reliability_by_unreliable",
+          "columns": [
+            {
+              "expression": "unreliable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_subscriptions": {
+      "name": "billing_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_product_id": {
+          "name": "provider_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_subscriptions_by_provider": {
+          "name": "billing_subscriptions_by_provider",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_subscriptions_by_owner_updated": {
+          "name": "billing_subscriptions_by_owner_updated",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscriptions_owner_user_id_users_owner_user_id_fk": {
+          "name": "billing_subscriptions_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "billing_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_subscriptions_plan_check": {
+          "name": "billing_subscriptions_plan_check",
+          "value": "\"billing_subscriptions\".\"plan_key\" in ('starter', 'plus', 'ultra')"
+        },
+        "billing_subscriptions_interval_check": {
+          "name": "billing_subscriptions_interval_check",
+          "value": "\"billing_subscriptions\".\"billing_interval\" in ('month', 'year')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_pending_webhooks": {
+      "name": "billing_pending_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_entitlements": {
+      "name": "admin_entitlements",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_entitlements_owner_user_id_users_owner_user_id_fk": {
+          "name": "admin_entitlements_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "admin_entitlements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_credit_periods": {
+      "name": "billing_credit_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_limit": {
+          "name": "credits_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spend_ceiling_cents": {
+          "name": "spend_ceiling_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_credit_periods_by_owner_period": {
+          "name": "billing_credit_periods_by_owner_period",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_credit_periods_owner_user_id_users_owner_user_id_fk": {
+          "name": "billing_credit_periods_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "billing_credit_periods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_usage_ledger": {
+      "name": "provider_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "provider_usage_ledger_by_owner_idempotency_key": {
+          "name": "provider_usage_ledger_by_owner_idempotency_key",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_usage_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_usage_ledger_by_owner_feature_created": {
+          "name": "provider_usage_ledger_by_owner_feature_created",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_usage_ledger_owner_user_id_users_owner_user_id_fk": {
+          "name": "provider_usage_ledger_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "provider_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_usage_ledger_feature_check": {
+          "name": "provider_usage_ledger_feature_check",
+          "value": "\"provider_usage_ledger\".\"feature\" in ('normal_chat', 'pro_chat', 'cited_answer', 'deep_research', 'external_search', 'sandbox_compute', 'citation_verify', 'doc_ai_edit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_daily_rollup": {
+      "name": "usage_daily_rollup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "feature_counts": {
+          "name": "feature_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "usage_daily_rollup_by_owner_date": {
+          "name": "usage_daily_rollup_by_owner_date",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_daily_rollup_owner_user_id_users_owner_user_id_fk": {
+          "name": "usage_daily_rollup_owner_user_id_users_owner_user_id_fk",
+          "tableFrom": "usage_daily_rollup",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "owner_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1783000143390,
       "tag": "0026_broad_surge",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1783428331630,
+      "tag": "0027_milky_wolfpack",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/researchSourceRepo.ts
+++ b/packages/db/src/repositories/researchSourceRepo.ts
@@ -2,12 +2,14 @@ import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import {
   type NewResearchSource,
   type ResearchSource,
+  type ResearchSourceStance,
+  type ResearchSourceStudyDesign,
   researchSources,
 } from "../schema/researchSources";
 import type { DbOrTx } from "../types";
 
 /**
- * Repo research_sources (Slice 6.4) — query Drizzle saja, tanpa business rule.
+ * Repo research_sources — query Drizzle saja, tanpa business rule.
  *
  * `insertMany` IDEMPOTEN: `onConflictDoNothing` pada unique
  * (`thread_id`,`turn_id`,`locator`) supaya step tool riset yang RE-RUN saat resume
@@ -32,7 +34,7 @@ export const ResearchSourceRepo = {
       .orderBy(asc(researchSources.createdAt), asc(researchSources.id));
   },
 
-  /** Sumber satu run deep (turn_id = workflow runId) — untuk penomoran sitasi `[n]` (G4). */
+  /** Sumber satu run deep (turn_id = workflow runId) — untuk penomoran sitasi `[n]`. */
   async listByThreadTurn(db: DbOrTx, threadId: string, turnId: string): Promise<ResearchSource[]> {
     return await db
       .select()
@@ -72,6 +74,40 @@ export const ResearchSourceRepo = {
     await db
       .update(researchSources)
       .set({ imageUrl: sql`case ${cases} end` })
+      .where(
+        inArray(
+          researchSources.id,
+          updates.map((u) => u.id),
+        ),
+      );
+  },
+
+  /**
+   * Set hasil klasifikasi evidence viz (stance/study_design/outcomes_json) batch via satu
+   * UPDATE…CASE per kolom — pola sama `setCitationNumbers`/`setImages` (≤60 baris per run deep).
+   */
+  async setClassification(
+    db: DbOrTx,
+    updates: Array<{
+      id: string;
+      stance: ResearchSourceStance;
+      studyDesign: ResearchSourceStudyDesign;
+      outcomesJson: string | null;
+    }>,
+  ): Promise<void> {
+    if (updates.length === 0) return;
+    const caseFor = (value: (u: (typeof updates)[number]) => string | null) =>
+      sql`case ${sql.join(
+        updates.map((u) => sql`when ${researchSources.id} = ${u.id} then ${value(u)}::text`),
+        sql` `,
+      )} end`;
+    await db
+      .update(researchSources)
+      .set({
+        stance: caseFor((u) => u.stance),
+        studyDesign: caseFor((u) => u.studyDesign),
+        outcomesJson: caseFor((u) => u.outcomesJson),
+      })
       .where(
         inArray(
           researchSources.id,

--- a/packages/db/src/schema/researchSources.ts
+++ b/packages/db/src/schema/researchSources.ts
@@ -4,16 +4,16 @@ import { chatThreads } from "./chatThreads";
 import { users } from "./users";
 
 /**
- * research_sources — bukti web/arxiv/doi yang dikumpulkan tool riset Astra (Fase 6,
- * Slice 6.4). Satu row per kandidat sumber yang dipersist saat `search_web` /
+ * research_sources — bukti web/arxiv/doi yang dikumpulkan tool riset Astra.
+ * Satu row per kandidat sumber yang dipersist saat `search_web` /
  * `search_arxiv` / `lookup_doi` berjalan, di-scope ke percakapan (`thread_id`) dan
- * giliran (`turn_id`). V2 TIDAK punya konsep `runId` (V1 Convex) → key by
- * `thread_id + turn_id`.
+ * giliran (`turn_id`) → key by `thread_id + turn_id`. Pada run `/deep`,
+ * `turn_id` diisi workflow runId.
  *
  * - `origin` text + CHECK (web|arxiv|doi) — kelas sumber.
- * - `evidence_strength` text + CHECK (strong|medium|weak) — port dari ExternalCandidate V1.
- * - `citation_number` opsional — penomoran [n] global ditunda ke P7 (citation verify, D-H);
- *   di 6.4 dibiarkan null, panel Sources menomori berdasar urutan.
+ * - `evidence_strength` text + CHECK (strong|medium|weak) — taksiran kekuatan bukti kandidat.
+ * - `citation_number` opsional — nomor sitasi [n] global: jalur chat mengisinya saat persist,
+ *   run `/deep` mengisinya belakangan via step `assign-citations` (dedup lintas sub-pertanyaan).
  * - `sub_question_index`/`sub_question_text` opsional — asosiasi sumber ke sub-pertanyaan riset
  *   `/deep` (di-set step `search-literature` via RequestContext) → FE mengelompokkan kartu per
  *   sub-agen pencarian. Null di jalur chat biasa (bukan `/deep`).
@@ -21,7 +21,7 @@ import { users } from "./users";
  *   untuk kartu sumber. Favicon + domain TIDAK disimpan (diturunkan client-side dari `url`).
  * - Idempotensi insert: unique (`thread_id`,`turn_id`,`locator`) → step tool yang RE-RUN
  *   saat resume durable tak menggandakan baris (ON CONFLICT DO NOTHING di repo).
- * - timestamp epoch-ms (`bigint`) seragam dengan tabel V2 lain.
+ * - timestamp epoch-ms (`bigint`) seragam dengan tabel lain di skema ini.
  */
 export const researchSources = pgTable(
   "research_sources",
@@ -48,12 +48,24 @@ export const researchSources = pgTable(
     subQuestionIndex: integer("sub_question_index"),
     subQuestionText: text("sub_question_text"),
     imageUrl: text("image_url"),
-    // Metadata sitasi terstruktur (CTX-8): authors (JSON array string, maks 3), tahun, venue —
+    // Metadata sitasi terstruktur: authors (JSON array string, maks 3), tahun, venue —
     // diekstrak dari `metadataJson` provider saat persist → inventory [n] + verify_identifiers
     // menerima author/year asli, bukan mengarang. Nullable (provider web sering tanpa metadata).
     authorsJson: text("authors_json"),
     year: integer("year"),
     venue: text("venue"),
+    // Kolom metadata + klasifikasi evidence viz `/deep` (migration `0027_milky_wolfpack`;
+    // CHECK `research_sources_stance_check`/`research_sources_study_design_check` di bawah).
+    // `cited_by_count`/`topics_json` diisi saat persist dari metadata provider (OpenAlex
+    // `cited_by_count`+`topics`, Crossref `is-referenced-by-count`);
+    // `stance`/`study_design`/`outcomes_json` diisi step
+    // `analyze-sources` (klasifikasi LLM, best-effort). Semua nullable — jalur chat biasa
+    // dan run lama tak tersentuh.
+    citedByCount: integer("cited_by_count"),
+    topicsJson: text("topics_json"),
+    stance: text("stance"),
+    studyDesign: text("study_design"),
+    outcomesJson: text("outcomes_json"),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
   },
   (t) => [
@@ -62,6 +74,14 @@ export const researchSources = pgTable(
       "research_sources_evidence_strength_check",
       sql`${t.evidenceStrength} in ('strong', 'medium', 'weak')`,
     ),
+    check(
+      "research_sources_stance_check",
+      sql`${t.stance} is null or ${t.stance} in ('yes', 'possibly', 'mixed', 'no', 'not_applicable')`,
+    ),
+    check(
+      "research_sources_study_design_check",
+      sql`${t.studyDesign} is null or ${t.studyDesign} in ('meta_analysis', 'systematic_review', 'rct', 'observational', 'review', 'other')`,
+    ),
     index("research_sources_by_thread").on(t.threadId, t.createdAt),
     uniqueIndex("research_sources_thread_turn_locator").on(t.threadId, t.turnId, t.locator),
   ],
@@ -69,3 +89,28 @@ export const researchSources = pgTable(
 
 export type ResearchSource = typeof researchSources.$inferSelect;
 export type NewResearchSource = typeof researchSources.$inferInsert;
+
+/**
+ * Nilai valid kolom `stance`/`study_design` — WAJIB sama persis dengan CHECK constraint di atas
+ * (dan migration yang menurunkannya). Kontrak viz `@aqsha/chat-core/deep-viz` memuat vocab yang
+ * sama; chat-core tak boleh depend db (dipakai web) dan sebaliknya, jadi kesamaannya ditegakkan
+ * test lintas-paket di `packages/services` (depend keduanya) — bukan disinkron manual.
+ */
+export const RESEARCH_SOURCE_STANCES = [
+  "yes",
+  "possibly",
+  "mixed",
+  "no",
+  "not_applicable",
+] as const;
+export type ResearchSourceStance = (typeof RESEARCH_SOURCE_STANCES)[number];
+
+export const RESEARCH_SOURCE_STUDY_DESIGNS = [
+  "meta_analysis",
+  "systematic_review",
+  "rct",
+  "observational",
+  "review",
+  "other",
+] as const;
+export type ResearchSourceStudyDesign = (typeof RESEARCH_SOURCE_STUDY_DESIGNS)[number];

--- a/packages/db/test/chat-retrieval-repos.test.ts
+++ b/packages/db/test/chat-retrieval-repos.test.ts
@@ -159,6 +159,42 @@ describe("ResearchSourceRepo.listByThreadTurn + setCitationNumbers (penomoran si
   });
 });
 
+describe("ResearchSourceRepo.setClassification — kolom evidence viz (mig 0027)", () => {
+  itest("persist cited_by_count/topics_json saat insert + set klasifikasi batch by id", async () => {
+    const run = "run-viz";
+    const a = srcRow({
+      turnId: run,
+      locator: "https://v1.test",
+      citedByCount: 42,
+      topicsJson: JSON.stringify(["Solar energy", "Photovoltaics"]),
+    });
+    const b = srcRow({ turnId: run, locator: "https://v2.test" });
+    await ResearchSourceRepo.insertMany(db, [a, b]);
+
+    let rows = await ResearchSourceRepo.listByThreadTurn(db, T1, run);
+    const rowA = rows.find((r) => r.id === a.id);
+    const rowB = rows.find((r) => r.id === b.id);
+    expect(rowA?.citedByCount).toBe(42);
+    expect(rowA?.topicsJson).toBe(JSON.stringify(["Solar energy", "Photovoltaics"]));
+    // Sebelum step analyze: klasifikasi null (jalur chat biasa & run lama aman).
+    expect(rowA?.stance).toBe(null);
+    expect(rowB?.citedByCount).toBe(null);
+
+    await ResearchSourceRepo.setClassification(db, [
+      { id: a.id, stance: "yes", studyDesign: "rct", outcomesJson: JSON.stringify(["mortality"]) },
+      { id: b.id, stance: "not_applicable", studyDesign: "other", outcomesJson: null },
+    ]);
+    rows = await ResearchSourceRepo.listByThreadTurn(db, T1, run);
+    const afterA = rows.find((r) => r.id === a.id);
+    const afterB = rows.find((r) => r.id === b.id);
+    expect(afterA?.stance).toBe("yes");
+    expect(afterA?.studyDesign).toBe("rct");
+    expect(afterA?.outcomesJson).toBe(JSON.stringify(["mortality"]));
+    expect(afterB?.stance).toBe("not_applicable");
+    expect(afterB?.outcomesJson).toBe(null);
+  });
+});
+
 describe("ArtifactEmbeddingRepo.searchSimilar — ANN + scope threadId via JOIN", () => {
   itest("scope threadId → hanya artifact thread itu (lintas-thread excluded)", async () => {
     await seedArtifact(`${SUFFIX}-artA`, T1, 0);

--- a/packages/services/src/research/crossref.ts
+++ b/packages/services/src/research/crossref.ts
@@ -1,14 +1,14 @@
 /**
- * Crossref — Slice 6.4 + Explore live search. `lookupDoi` port V1 `lookupDoiProvider`
- * (satu work per DOI). `searchCrossref` = keyword search (`/works?query=…`) untuk
- * mengisi ekor waterfall Explore saat query bukan DOI. Reads `contactEmail()` for
- * the polite-pool `mailto`.
+ * Provider Crossref untuk tool riset + Explore live search. `lookupDoi` mengambil
+ * satu work per DOI. `searchCrossref` = keyword search (`/works?query=…`) untuk
+ * mengisi ekor waterfall Explore saat query bukan DOI. Membaca `contactEmail()`
+ * untuk `mailto` polite-pool.
  */
 
 import { contactEmail, fetchWithRetry } from "../papers/http";
 import { normalizeDoi } from "../papers/identifiers";
 import { readCachedCandidates, writeCachedCandidates } from "./cache";
-import { collapse, normalizeKey, trimForSnippet } from "./text";
+import { collapse, normalizeKey, numberOrUndefined, trimForSnippet } from "./text";
 import {
   type ProviderSearchResult,
   type ResearchCandidate,
@@ -30,6 +30,7 @@ type CrossrefItem = {
   issued?: { "date-parts"?: number[][] };
   published?: { "date-parts"?: number[][] };
   "container-title"?: string[];
+  "is-referenced-by-count"?: number;
 };
 
 export async function lookupDoi(args: { doi: string }): Promise<ProviderSearchResult> {
@@ -132,6 +133,7 @@ function crossrefToCandidate(item: CrossrefItem): ResearchCandidate | null {
         .slice(0, 6),
       year: item.published?.["date-parts"]?.[0]?.[0] ?? item.issued?.["date-parts"]?.[0]?.[0],
       venue: item["container-title"]?.find((value) => value.trim()),
+      citedByCount: numberOrUndefined(item["is-referenced-by-count"]),
       sourceLabel: item["container-title"]?.find((value) => value.trim()) ?? "Crossref",
     }),
   };

--- a/packages/services/src/research/index.ts
+++ b/packages/services/src/research/index.ts
@@ -1,12 +1,19 @@
 /**
- * ResearchService (Slice 6.4) — web/arxiv/doi/openalex discovery for Astra's
- * read-only research tools, plus persistence + read of `research_sources` for
- * the Sources panel. Web search uses Firecrawl (`/v2/search`); Exa/Jina dropped
- * for the web lane. Citation verification (verifyCitations/verifyIdentifiers + integrity
- * engine) is deferred to P7 (D-H) — this slice is READ tools only.
+ * ResearchService — discovery web/arxiv/doi/openalex untuk tool riset read-only
+ * Astra, plus persist + read `research_sources` untuk panel Sources. Web search
+ * memakai Firecrawl (`/v2/search`). Verifikasi sitasi (verifyCitations/
+ * verifyIdentifiers + integrity engine) hidup di `CitationService` (./citation),
+ * di-re-export di bawah.
  */
 
-import { type DbOrTx, type NewResearchSource, type ResearchSource, ResearchSourceRepo } from "@aqsha/db";
+import {
+  type DbOrTx,
+  type NewResearchSource,
+  type ResearchSource,
+  ResearchSourceRepo,
+  type ResearchSourceStance,
+  type ResearchSourceStudyDesign,
+} from "@aqsha/db";
 import { fetchArticlePreview } from "../papers/articlePreview";
 import { normalizeDoi } from "../papers/identifiers";
 import { searchArxiv } from "./arxiv";
@@ -17,6 +24,8 @@ import type { ProviderSearchResult, ResearchCandidate } from "./types";
 
 export type { OpenAlexSort } from "./openalex";
 
+export type { ResearchSourceStance, ResearchSourceStudyDesign } from "@aqsha/db";
+
 export type {
   EvidenceStrength,
   ProviderSearchResult,
@@ -24,8 +33,8 @@ export type {
   ResearchOrigin,
 } from "./types";
 
-// CitationService (Slice 7.2) — citation-integrity engine, shares the same
-// `@aqsha/services/research` subpath (no new subpath; bundled by tsup entry).
+// CitationService — engine integritas sitasi; berbagi subpath
+// `@aqsha/services/research` (tanpa subpath baru; dibundel entry tsup yang sama).
 export {
   CitationService,
   type CitationInput,
@@ -35,11 +44,11 @@ export {
   type VerificationResult,
 } from "./citation";
 
-// Firecrawl reader (FEAT-1) — full-text URL → markdown untuk tool `read_url` agent; berbagi
+// Firecrawl reader — full-text URL → markdown untuk tool `read_url` agent; berbagi
 // subpath `./research` (fisiknya di ../papers karena dipakai worker ingest juga).
 export { scrapeUrlFirecrawl, type UrlReadResult } from "../papers/firecrawl-reader";
 
-// Formatter daftar pustaka deterministik (FEAT-3) — tool `format_references` + export .bib/.ris.
+// Formatter daftar pustaka deterministik — tool `format_references` + export .bib/.ris.
 export {
   dedupeReferenceSources,
   formatApa7Reference,
@@ -81,42 +90,63 @@ export type ResearchSourceItem = {
   subQuestionText: string | null;
   /** OG image (best-effort) untuk kartu sumber (null bila tak ada/belum di-enrich). */
   imageUrl: string | null;
-  /** Penulis (maks 3, dari metadata provider) — untuk inventory sitasi + verifikasi (CTX-8). */
+  /** Penulis (maks 3, dari metadata provider) — untuk inventory sitasi + verifikasi. */
   authors: string[];
   /** Tahun publikasi (null bila provider tak memberi). */
   year: number | null;
   /** Venue/jurnal (null bila provider tak memberi). */
   venue: string | null;
+  /** Jumlah sitasi provider (OpenAlex/Crossref) — bahan evidence viz (null bila tak ada). */
+  citedByCount: number | null;
+  /** Topik provider (OpenAlex) — fallback baris gaps-matrix bila outcomes LLM kosong. */
+  topics: string[];
+  /** Stance temuan paper thd sub-pertanyaan (klasifikasi step analyze; null sebelum/di luar deep). */
+  stance: ResearchSourceStance | null;
+  /** Desain studi (klasifikasi step analyze; null sebelum/di luar deep). */
+  studyDesign: ResearchSourceStudyDesign | null;
+  /** Outcome yang diukur paper (≤3, klasifikasi step analyze; [] bila belum diklasifikasi). */
+  outcomes: string[];
   createdAt: number;
 };
 
 /**
  * Ekstrak authors/year/venue dari `candidate.metadataJson` (blob provider). Dipakai persist
- * (kolom terstruktur `research_sources`) + output tool riset (CTX-8: model harus MENERIMA
- * metadata sitasi, bukan hanya tersimpan di DB). Best-effort: blob korup → kosong.
+ * (kolom terstruktur `research_sources`) + output tool riset (model harus MENERIMA
+ * metadata sitasi di hasil tool, bukan hanya tersimpan di DB). Best-effort: blob korup → kosong.
  */
 export function candidateCitationMeta(candidate: ResearchCandidate): {
   authors: string[];
   year: number | null;
   venue: string | null;
+  citedByCount: number | null;
+  topics: string[];
 } {
-  if (!candidate.metadataJson) return { authors: [], year: null, venue: null };
+  const empty = { authors: [], year: null, venue: null, citedByCount: null, topics: [] };
+  if (!candidate.metadataJson) return empty;
   try {
     const meta = JSON.parse(candidate.metadataJson) as {
       authors?: unknown;
       year?: unknown;
       venue?: unknown;
+      citedByCount?: unknown;
+      topics?: unknown;
     };
-    const authors = Array.isArray(meta.authors)
-      ? meta.authors.filter((a): a is string => typeof a === "string" && a.length > 0).slice(0, 3)
-      : [];
+    const stringArray = (value: unknown, max: number) =>
+      Array.isArray(value)
+        ? value.filter((v): v is string => typeof v === "string" && v.length > 0).slice(0, max)
+        : [];
     return {
-      authors,
+      authors: stringArray(meta.authors, 3),
       year: typeof meta.year === "number" && Number.isFinite(meta.year) ? meta.year : null,
       venue: typeof meta.venue === "string" && meta.venue.length > 0 ? meta.venue : null,
+      citedByCount:
+        typeof meta.citedByCount === "number" && Number.isFinite(meta.citedByCount)
+          ? meta.citedByCount
+          : null,
+      topics: stringArray(meta.topics, 5),
     };
   } catch {
-    return { authors: [], year: null, venue: null };
+    return empty;
   }
 }
 
@@ -143,7 +173,7 @@ export const ResearchService = {
 
   /**
    * Pencarian karya akademik (OpenAlex). Hasil DISKRIMINATIF (`ok:false` = provider error).
-   * Filter FEAT-2: rentang tahun terbit, bahasa (ISO 639-1, mis. `id` untuk jurnal Indonesia),
+   * Filter opsional: rentang tahun terbit, bahasa (ISO 639-1, mis. `id` untuk jurnal Indonesia),
    * dan sort (`relevance`|`cited_by`|`newest`).
    */
   searchOpenAlex(args: {
@@ -206,10 +236,37 @@ export const ResearchService = {
         authorsJson: meta.authors.length > 0 ? JSON.stringify(meta.authors) : null,
         year: meta.year,
         venue: meta.venue,
+        citedByCount: meta.citedByCount,
+        topicsJson: meta.topics.length > 0 ? JSON.stringify(meta.topics) : null,
         createdAt: input.now,
       };
     });
     await ResearchSourceRepo.insertMany(db, rows);
+  },
+
+  /**
+   * Persist hasil klasifikasi evidence viz (step `analyze-sources` `/deep`) batch by id.
+   * Best-effort di pemanggil — kegagalan DB tak boleh menggagalkan step (blok viz tetap
+   * dibangun dari state workflow; kolom hanya fallback/observabilitas).
+   */
+  async setSourceClassification(
+    db: DbOrTx,
+    updates: Array<{
+      id: string;
+      stance: ResearchSourceStance;
+      studyDesign: ResearchSourceStudyDesign;
+      outcomes: string[];
+    }>,
+  ): Promise<void> {
+    await ResearchSourceRepo.setClassification(
+      db,
+      updates.map((u) => ({
+        id: u.id,
+        stance: u.stance,
+        studyDesign: u.studyDesign,
+        outcomesJson: u.outcomes.length > 0 ? JSON.stringify(u.outcomes.slice(0, 3)) : null,
+      })),
+    );
   },
 
   /**
@@ -237,7 +294,7 @@ export const ResearchService = {
   },
 
   /**
-   * Nomori sumber satu run deep (`turnId` = workflow runId) → `citation_number` 1..N (G4).
+   * Nomori sumber satu run deep (`turnId` = workflow runId) → `citation_number` 1..N.
    * Dedupe paper yang sama lintas sub-pertanyaan/penyedia via kunci `normalizeDoi ?? arxivId ??
    * locator` (baris berbeda dgn DOI/URL beda dapat NOMOR SAMA). Dipanggil step `assign-citations`
    * SEBELUM verify/synthesize → writer mengutip `[n]` global yang stabil. Mengembalikan item
@@ -285,15 +342,20 @@ function toResearchSourceItem(r: ResearchSource): ResearchSourceItem {
     subQuestionIndex: r.subQuestionIndex,
     subQuestionText: r.subQuestionText,
     imageUrl: r.imageUrl,
-    authors: parseAuthorsJson(r.authorsJson),
+    authors: parseStringArrayJson(r.authorsJson),
     year: r.year,
     venue: r.venue,
+    citedByCount: r.citedByCount,
+    topics: parseStringArrayJson(r.topicsJson),
+    stance: (r.stance as ResearchSourceStance | null) ?? null,
+    studyDesign: (r.studyDesign as ResearchSourceStudyDesign | null) ?? null,
+    outcomes: parseStringArrayJson(r.outcomesJson),
     createdAt: r.createdAt,
   };
 }
 
-/** Parse kolom `authors_json` (array string) — blob korup/legacy null → []. */
-function parseAuthorsJson(raw: string | null): string[] {
+/** Parse kolom JSON array-of-string (`authors_json`/`topics_json`/`outcomes_json`) — blob korup/legacy null → []. */
+function parseStringArrayJson(raw: string | null): string[] {
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);

--- a/packages/services/test/research-meta.test.ts
+++ b/packages/services/test/research-meta.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit `candidateCitationMeta` — ekstraksi metadata sitasi + evidence viz (citedByCount,
+ * topics) dari `metadataJson` provider. Pure (tanpa DB/HTTP). Plus test sinkronisasi vocab
+ * stance/study-design lintas-paket (chat-core ↔ db) — services depend keduanya, jadi test
+ * ini penjaga agar CHECK kolom dan kontrak viz tak drift diam-diam.
+ */
+import { DEEP_VIZ_CLASSIFIED_STANCES, DEEP_VIZ_STUDY_DESIGNS } from "@aqsha/chat-core/deep-viz";
+import { RESEARCH_SOURCE_STANCES, RESEARCH_SOURCE_STUDY_DESIGNS } from "@aqsha/db";
+import { describe, expect, test } from "bun:test";
+import { candidateCitationMeta, type ResearchCandidate } from "../src/research";
+
+describe("vocab stance/study-design — sinkron lintas-paket", () => {
+  test("chat-core deep-viz ↔ CHECK kolom research_sources", () => {
+    expect([...DEEP_VIZ_CLASSIFIED_STANCES]).toEqual([...RESEARCH_SOURCE_STANCES]);
+    expect([...DEEP_VIZ_STUDY_DESIGNS]).toEqual([...RESEARCH_SOURCE_STUDY_DESIGNS]);
+  });
+});
+
+function candidate(metadataJson?: string): ResearchCandidate {
+  return {
+    origin: "doi",
+    provider: "openalex",
+    evidenceStrength: "strong",
+    title: "Paper",
+    locator: "10.1234/x",
+    snippet: "abstrak",
+    metadataJson,
+  };
+}
+
+describe("candidateCitationMeta — kolom evidence viz (mig 0027)", () => {
+  test("blob OpenAlex lengkap → authors ≤3, year, venue, citedByCount, topics ≤5", () => {
+    const meta = candidateCitationMeta(
+      candidate(
+        JSON.stringify({
+          authors: ["A", "B", "C", "D"],
+          year: 2021,
+          venue: "Nature Energy",
+          citedByCount: 128,
+          topics: ["T1", "T2", "T3", "T4", "T5", "T6"],
+        }),
+      ),
+    );
+    expect(meta.authors).toEqual(["A", "B", "C"]);
+    expect(meta.year).toBe(2021);
+    expect(meta.venue).toBe("Nature Energy");
+    expect(meta.citedByCount).toBe(128);
+    expect(meta.topics).toEqual(["T1", "T2", "T3", "T4", "T5"]);
+  });
+
+  test("citedByCount/topics tak valid → null/[] (defensif, blob provider tak terkontrol)", () => {
+    const meta = candidateCitationMeta(
+      candidate(JSON.stringify({ citedByCount: "128", topics: [1, "", "Valid"] })),
+    );
+    expect(meta.citedByCount).toBe(null);
+    expect(meta.topics).toEqual(["Valid"]);
+  });
+
+  test("tanpa metadataJson / blob korup → kosong seluruhnya", () => {
+    for (const c of [candidate(undefined), candidate("{bukan json")]) {
+      const meta = candidateCitationMeta(c);
+      expect(meta).toEqual({ authors: [], year: null, venue: null, citedByCount: null, topics: [] });
+    }
+  });
+});

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -19,6 +19,7 @@ import {
   Camera01Icon,
   Cancel01Icon,
   CancelCircleIcon,
+  ChartColumnIcon as HugeChartColumnIcon,
   ChartUpIcon,
   CheckIcon as HugeCheckIcon,
   CheckmarkCircle02Icon,
@@ -39,12 +40,14 @@ import {
   Download01Icon,
   ExpandParagraphIcon as HugeExpandParagraphIcon,
   ExternalLinkIcon as HugeExternalLinkIcon,
+  EyeIcon as HugeEyeIcon,
   FavouriteIcon,
   File01Icon,
   FileDownloadIcon,
   FileScriptIcon,
   FilterIcon as HugeFilterIcon,
   Flag01Icon,
+  FlaskConicalIcon as HugeFlaskConicalIcon,
   Folder01Icon,
   FolderTreeIcon as HugeFolderTreeIcon,
   GaugeIcon as HugeGaugeIcon,
@@ -97,6 +100,7 @@ import {
   Upload01Icon,
   CloudUploadIcon,
   UserIcon,
+  UserMultipleIcon,
   Wrench01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -139,6 +143,7 @@ export const BookmarkIcon = createIcon(Bookmark01Icon);
 export const BracesIcon = createIcon(HugeBracesIcon);
 export const CalendarRangeIcon = createIcon(Calendar03Icon);
 export const CameraIcon = createIcon(Camera01Icon);
+export const ChartColumnIcon = createIcon(HugeChartColumnIcon);
 export const Check = createIcon(HugeCheckIcon);
 export const CheckCircle2 = createIcon(CheckmarkCircle02Icon);
 export const CheckIcon = createIcon(HugeCheckIcon);
@@ -163,6 +168,7 @@ export const DollarSign = createIcon(Dollar01Icon);
 export const DownloadIcon = createIcon(Download01Icon);
 export const ExternalLinkIcon = createIcon(HugeExternalLinkIcon);
 export const ExpandParagraphIcon = createIcon(HugeExpandParagraphIcon);
+export const EyeIcon = createIcon(HugeEyeIcon);
 export const FileDownIcon = createIcon(FileDownloadIcon);
 export const FileIcon = createIcon(File01Icon);
 export const FileText = createIcon(FileScriptIcon);
@@ -170,6 +176,7 @@ export const FileTextIcon = createIcon(FileScriptIcon);
 export const FilterIcon = createIcon(HugeFilterIcon);
 export const Flag = createIcon(Flag01Icon);
 export const FlagIcon = createIcon(Flag01Icon);
+export const FlaskConicalIcon = createIcon(HugeFlaskConicalIcon);
 export const FolderIcon = createIcon(Folder01Icon);
 export const FolderTreeIcon = createIcon(HugeFolderTreeIcon);
 export const GaugeIcon = createIcon(HugeGaugeIcon);
@@ -238,6 +245,7 @@ export const TrendingUpIcon = createIcon(ChartUpIcon);
 export const UploadCloudIcon = createIcon(CloudUploadIcon);
 export const UploadIcon = createIcon(Upload01Icon);
 export const UserRoundIcon = createIcon(UserIcon);
+export const UsersRoundIcon = createIcon(UserMultipleIcon);
 export const WrenchIcon = createIcon(Wrench01Icon);
 export const RotateCcwIcon = createIcon(ArrowReloadHorizontalIcon);
 export const XCircleIcon = createIcon(CancelCircleIcon);


### PR DESCRIPTION
## Ringkasan

Menambahkan **evidence visualization** untuk laporan `/deep` (deep research) — blok visual berbasis bukti ala Consensus, tanpa sandbox. Angka **tidak pernah** ditulis LLM: semua agregat dihitung deterministik dari state workflow; LLM hanya mengklasifikasi tiap paper dan memilih posisi blok via marker.

## Perubahan per lapisan

- **db** (`feat(db)`) — kolom baru `research_sources`: `cited_by_count`, `topics_json`, `stance`, `study_design`, `outcomes_json` (semua nullable → jalur chat & run lama tak tersentuh) + CHECK `stance`/`study_design`. Migration `0027_milky_wolfpack`. Repo `setClassification` (UPDATE…CASE batch) + vocab const sebagai SSOT selaras CHECK.
- **chat-core** (`feat(chat-core)`) — entry mandiri kedua `./deep-viz`: kontrak zod per blok (consensus meter, results timeline, top contributors, claims-evidence, gaps matrix, open questions), `buildDeepVizBlocks` deterministik, dan `injectVizBlocks` anti-pemalsuan (buang fence `aqsha:viz` tulisan model). Dep `zod` dipin sama dgn web/agent.
- **services** (`feat(services)`) — `candidateCitationMeta` ekstrak `citedByCount` (OpenAlex/Crossref `is-referenced-by-count`) + `topics`; `setSourceClassification` best-effort persist klasifikasi. Test lintas-paket menjaga vocab `@aqsha/db` CHECK == `@aqsha/chat-core/deep-viz`.
- **agent** (`feat(agent)`) — step `analyze-sources`: klasifikasi per-paper via LLM (best-effort), bangun blok viz dari state workflow, injeksi fenced block ke laporan. Ringkasan (`vizBlockIds` + `analyzedSourceCount`) dipersist ke metadata `deepProcess` supaya baris proses bertahan setelah refresh.
- **web** (`feat(web)`) — komponen `deep-viz` + `VizFigureProvider` sebagai gate anti-pemalsuan (fence `aqsha:viz` hanya jadi figur di laporan `/deep`; chat biasa → code block). Parse via `viz-markdown`, prose CSS hormati `.not-prose`, ikon baru di `@aqsha/ui/icons`.

## Catatan deploy

⚠️ **Migration `0027` baru dijalankan di DEV — PROD belum.** Jalankan `db:migrate` ke PROD sebelum rilis.

## Test

- `packages/db` — repo `setClassification` + kolom baru
- `packages/chat-core` — kontrak/builder/injector `deep-viz`
- `packages/services` — enrich metadata + sinkronisasi vocab lintas-paket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
