### PR TITLE
fix(deep+web): audit /deep stuck+stop & freeze navigasi 2026-07-08

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -28,6 +28,7 @@ AQSHA_LITE_MODEL=gpt-5.4-mini
 # (mis. model non-penalaran gpt-4o / gateway tanpa Responses). Lite default `low`, Pro default `high`.
 # AQSHA_LITE_REASONING_EFFORT=low
 # AQSHA_PRO_REASONING_EFFORT=high
+# AQSHA_PRO_SEARCH_REASONING_EFFORT=medium  # effort Pro KHUSUS subagent literature-searcher /deep (fase fan-out termahal).
 # AQSHA_REASONING_SUMMARY=auto      # auto|concise|detailed — bentuk ringkasan penalaran yang dirender.
 # Jendela context (token) model Lite — dipakai `TokenLimiterProcessor` (batas input ~75%).
 # Default 128000 bila kosong. Mastra tak meresolve katalog model, jadi set sesuai model gateway.

--- a/apps/agent/src/mastra/model.ts
+++ b/apps/agent/src/mastra/model.ts
@@ -73,6 +73,17 @@ export const proProviderOptions = reasoningProviderOptions(
 );
 
 /**
+ * Pro KHUSUS subagent pencarian literatur `/deep` (`literature-searcher`): tetap model Pro
+ * (kualitas pemilihan query & seleksi sumber), tapi effort diturunkan — search adalah fase
+ * fan-out terbanyak-panggilan sekaligus terlama di run (≤8 sub-Q × maxSteps 8), tugasnya
+ * orkestrasi tool + ekstraksi snippet, bukan penalaran dalam; effort `high` di sana mahal dan
+ * lambat tanpa gain sepadan. `AQSHA_PRO_SEARCH_REASONING_EFFORT` (default `medium`).
+ */
+export const proSearchProviderOptions = reasoningProviderOptions(
+  process.env.AQSHA_PRO_SEARCH_REASONING_EFFORT ?? "medium",
+);
+
+/**
  * Tier billing EFEKTIF dari tier yang DIMINTA: Pro hanya saat model Pro benar-benar disetel
  * (`PRO_MODEL_CONFIGURED`) — tanpa `AQSHA_PRO_MODEL`, output Pro setara Lite (lihat `proModel`/
  * `proProviderOptions`), jadi bebankan tarif Lite supaya adil. SATU sumber aturan downgrade (dipakai

--- a/apps/agent/src/mastra/tools/format-references.ts
+++ b/apps/agent/src/mastra/tools/format-references.ts
@@ -1,5 +1,5 @@
 import {
-  dedupeReferenceSources,
+  dedupeCitableReferenceSources,
   formatApa7Reference,
   ResearchService,
   sortForReferenceList,
@@ -37,7 +37,7 @@ export const formatReferences = createTool({
       };
     }
     const wanted = input.citations && input.citations.length > 0 ? new Set(input.citations) : null;
-    const deduped = dedupeReferenceSources(items).filter(
+    const deduped = dedupeCitableReferenceSources(items).filter(
       (s) => !wanted || (s.citationNumber !== null && wanted.has(s.citationNumber)),
     );
     if (deduped.length === 0) {

--- a/apps/agent/src/mastra/workflows/deep-research.ts
+++ b/apps/agent/src/mastra/workflows/deep-research.ts
@@ -20,6 +20,7 @@ import { estimateCredits } from "@aqsha/services/plan";
 import { SendQuotaService } from "@aqsha/services/quota";
 import {
   CitationService,
+  evidenceStrengthRank,
   ResearchService,
   type IntegrityStatus,
   type VerificationResult,
@@ -711,7 +712,7 @@ function clarifyPrompt(input: z.infer<typeof InputSchema>): string {
 }
 
 function searcherPrompt(subQuestion: string, input: Planned): string {
-  return `Topik riset utama: ${input.question}\n\nSub-pertanyaan yang HARUS kamu jawab dengan literatur:\n${subQuestion}\n\nCari bukti terkuat dan kembalikan tiap sumber berguna dengan: judul, identifier (DOI/arXiv/URL), penulis + tahun bila tersedia, extract bukti 2-4 kalimat, dan rating kekuatan. JANGAN menomori sumber dan JANGAN menulis penanda [n] — penomoran sitasi global dilakukan belakangan.`;
+  return `Topik riset utama: ${input.question}\n\nSub-pertanyaan yang HARUS kamu jawab dengan literatur:\n${subQuestion}\n\nCari bukti terkuat dan kembalikan tiap sumber berguna dengan: judul, identifier (DOI/arXiv/URL), penulis + tahun bila tersedia, extract bukti 2-4 kalimat, dan rating kekuatan. Kurasi ketat: laporkan MAKSIMAL ~${SEARCHER_REPORT_TARGET} sumber TERKUAT yang benar-benar menjawab sub-pertanyaan — jangan menyetor ulang semua hasil tool. JANGAN menomori sumber dan JANGAN menulis penanda [n] — penomoran sitasi global dilakukan belakangan.`;
 }
 
 function counterPrompt(input: Searched): string {
@@ -1269,8 +1270,26 @@ const counterEvidenceStep = createStep({
 
 /** Clamp snippet per baris inventory (codepoint-safe via `messagePreview`). */
 const INVENTORY_SNIPPET_MAX_CHARS = 240;
+/** Lantai alokasi snippet adaptif — di bawah ini snippet tak informatif, fallback greedy. */
+const INVENTORY_SNIPPET_MIN_CHARS = 80;
 /** Budget total inventory — melewati ini, baris berikutnya tanpa snippet (identitas [n] tetap). */
 const INVENTORY_CHAR_BUDGET = 48_000;
+/** Pemisah snippet di baris inventory — panjangnya ikut dihitung alokasi adaptif. */
+const INVENTORY_SNIPPET_SEP = " — ";
+/**
+ * ISSUE-5: cap paper BERNOMOR per sub-pertanyaan. Tool search mem-persist SEMUA hasilnya (run
+ * nyata: 257 baris utk 6 sub-Q — 3–4× kapasitas analyze/synthesize hilir), jadi kurasi via prompt
+ * searcher saja tak cukup — seleksi deterministik terjadi saat penomoran (prioritas
+ * `evidenceStrength`; baris tersisih tetap tersimpan di DB, hanya tak dikutip). ≤8 sub-Q × 20 =
+ * ≤160 paper bernomor + bukti tandingan (selalu lolos) — muat di budget inventory (alokasi snippet
+ * adaptif di bawah); run maksimal masih melewati `ANALYZE_UNIT_CAP` (unit terlemah di-drop, ter-log).
+ */
+const NUMBERED_SOURCES_PER_SUBQ_CAP = 20;
+/**
+ * Target kurasi yang DIMINTA ke searcher via prompt — satu funnel dengan cap penomoran di atas:
+ * target < cap supaya seleksi deterministik jarang memotong; ubah cap → tinjau target ini juga.
+ */
+const SEARCHER_REPORT_TARGET = 15;
 
 /**
  * 5. assignCitations — nomori `research_sources` run ini (turnId=runId) → `citation_number` 1..N
@@ -1288,43 +1307,92 @@ const assignCitationsStep = createStep({
     const items = await ResearchService.assignCitationNumbers(getServiceDb(), {
       threadId: inputData.threadId,
       turnId: runId,
+      perSubQuestionCap: NUMBERED_SOURCES_PER_SUBQ_CAP,
     });
     const numbered = items.filter((s) => s.citationNumber !== null);
+    if (items.length > numbered.length) {
+      console.log(
+        `[deep-research] assign-citations run=${runId}: ${items.length - numbered.length}/${items.length} baris tersisih cap penomoran ${NUMBERED_SOURCES_PER_SUBQ_CAP}/sub-Q (tetap tersimpan di DB, tak dikutip)`,
+      );
+    }
     // Baris inventory bawa authors/year/venue → verify_identifiers + daftar pustaka APA
     // bekerja dari metadata asli provider, bukan karangan model.
     //
     // BERBATAS (temuan produksi run yang macet): run kaya-sumber (262 baris) dengan snippet penuh per baris
     // menggelembungkan prompt sintesis sampai ~400KB (~100k token) → panggilan penulis merangkak
     // melampaui timeout task 15 menit, dan tiap retry mewarisi prompt beracun yang sama → run
-    // "macet" permanen. Snippet per baris di-clamp; setelah budget total tersentuh, baris
-    // berikutnya ditulis TANPA snippet — identitas `[n] judul (meta) — identifier` tetap utuh
-    // sehingga SEMUA nomor sitasi tetap bisa dikutip writer.
-    let inventoryChars = 0;
-    let snippetlessRows = 0;
-    const numberedInventory = numbered
-      .map((s) => {
-        const meta = [
-          s.authors.length > 0 ? s.authors.join(", ") : null,
-          s.year !== null ? String(s.year) : null,
-          s.venue,
-        ]
-          .filter(Boolean)
-          .join("; ");
-        const withinBudget = inventoryChars < INVENTORY_CHAR_BUDGET;
-        if (s.snippet && !withinBudget) snippetlessRows += 1;
-        const snippet =
-          s.snippet && withinBudget ? ` — ${messagePreview(s.snippet, INVENTORY_SNIPPET_MAX_CHARS)}` : "";
-        const line = `[${s.citationNumber}] ${s.title}${meta ? ` (${meta})` : ""} — ${
+    // "macet" permanen. Identitas `[n] judul (meta) — identifier` selalu utuh sehingga SEMUA nomor
+    // sitasi tetap bisa dikutip writer; hanya snippet yang tunduk budget.
+    //
+    // ISSUE-5, alokasi snippet ADAPTIF: urutan inventory = urutan nomor sitasi, BUKAN kekuatan
+    // bukti — skema first-come lama memberi baris awal snippet 240 char penuh dan ekor tanpa
+    // snippet sama sekali. Kini sisa budget (setelah baris dasar) dibagi rata semua baris
+    // bersnippet; bila jatah per baris < lantai 80 char (run patologis), fallback ke greedy lama
+    // sebagai backstop insiden 400KB.
+    const baseLines = numbered.map((s) => {
+      const meta = [
+        s.authors.length > 0 ? s.authors.join(", ") : null,
+        s.year !== null ? String(s.year) : null,
+        s.venue,
+      ]
+        .filter(Boolean)
+        .join("; ");
+      return {
+        head: `[${s.citationNumber}] ${s.title}${meta ? ` (${meta})` : ""} — ${
           s.doi ?? s.arxivId ?? s.url ?? s.locator
-        }${snippet} (${s.evidenceStrength})`;
-        inventoryChars += line.length + 1;
-        return line;
-      })
-      .join("\n");
-    if (snippetlessRows > 0) {
-      console.log(
-        `[deep-research] assign-citations run=${runId}: inventory menyentuh budget ${INVENTORY_CHAR_BUDGET} char — ${snippetlessRows} baris ditulis tanpa snippet`,
-      );
+        }`,
+        tail: ` (${s.evidenceStrength})`,
+        snippet: s.snippet,
+      };
+    });
+    const baseChars = baseLines.reduce((sum, l) => sum + l.head.length + l.tail.length + 1, 0);
+    const rowsWithSnippet = baseLines.filter((l) => l.snippet).length;
+    const evenAlloc =
+      rowsWithSnippet > 0
+        ? Math.floor((INVENTORY_CHAR_BUDGET - baseChars) / rowsWithSnippet) -
+          INVENTORY_SNIPPET_SEP.length
+        : 0;
+    const adaptiveSnippetChars =
+      evenAlloc >= INVENTORY_SNIPPET_MIN_CHARS
+        ? Math.min(INVENTORY_SNIPPET_MAX_CHARS, evenAlloc)
+        : null;
+    let numberedInventory: string;
+    if (adaptiveSnippetChars !== null) {
+      // Mode adaptif: tiap baris bersnippet dapat jatah rata — total dijamin ≤ budget by construction.
+      numberedInventory = baseLines
+        .map((l) =>
+          l.snippet
+            ? `${l.head}${INVENTORY_SNIPPET_SEP}${messagePreview(l.snippet, adaptiveSnippetChars)}${l.tail}`
+            : `${l.head}${l.tail}`,
+        )
+        .join("\n");
+      if (adaptiveSnippetChars < INVENTORY_SNIPPET_MAX_CHARS) {
+        console.log(
+          `[deep-research] assign-citations run=${runId}: snippet inventory dialokasikan adaptif ${adaptiveSnippetChars} char/baris (${rowsWithSnippet} baris)`,
+        );
+      }
+    } else {
+      // Mode greedy (backstop run patologis, jatah rata < lantai): baris awal snippet penuh,
+      // setelah budget tersentuh baris berikutnya tanpa snippet.
+      let inventoryChars = 0;
+      let snippetlessRows = 0;
+      numberedInventory = baseLines
+        .map((l) => {
+          const includeSnippet = Boolean(l.snippet) && inventoryChars < INVENTORY_CHAR_BUDGET;
+          if (l.snippet && !includeSnippet) snippetlessRows += 1;
+          const snippet = includeSnippet
+            ? `${INVENTORY_SNIPPET_SEP}${messagePreview(l.snippet as string, INVENTORY_SNIPPET_MAX_CHARS)}`
+            : "";
+          const line = `${l.head}${snippet}${l.tail}`;
+          inventoryChars += line.length + 1;
+          return line;
+        })
+        .join("\n");
+      if (snippetlessRows > 0) {
+        console.log(
+          `[deep-research] assign-citations run=${runId}: inventory menyentuh budget ${INVENTORY_CHAR_BUDGET} char — ${snippetlessRows} baris ditulis tanpa snippet (fallback greedy)`,
+        );
+      }
     }
     // Jumlah sitasi unik [n] (dedupe by DOI/arXiv/locator) — sumber penomoran ditampilkan FE.
     const uniqueCitations = new Set(numbered.map((s) => s.citationNumber)).size;
@@ -1363,15 +1431,16 @@ const assignCitationsStep = createStep({
   },
 });
 
-/** Cap unit klasifikasi per run (lebih → prioritaskan evidenceStrength kuat, sisanya di-drop). */
-const ANALYZE_UNIT_CAP = 60;
+/**
+ * Cap unit klasifikasi per run (lebih → prioritaskan evidenceStrength kuat, sisanya di-drop,
+ * ter-log). ISSUE-5: 60 → 100 — klasifikasi chunked 20 unit/panggilan model lite, jadi biayanya
+ * maksimal +2 panggilan lite. Run maksimal (8 sub-Q × cap penomoran 20) tetap bisa menghasilkan
+ * ≤160 unit → hingga 60 unit TERLEMAH masih di-drop; trade-off biaya yang disengaja — dampaknya
+ * hanya klasifikasi viz best-effort kurang lengkap (baris tetap bernomor & bisa dikutip).
+ */
+const ANALYZE_UNIT_CAP = 100;
 /** Unit per panggilan LLM klasifikasi. */
 const ANALYZE_CHUNK_SIZE = 20;
-const ANALYZE_STRENGTH_PRIORITY: Record<AnalyzeUnit["evidenceStrength"], number> = {
-  strong: 0,
-  medium: 1,
-  weak: 2,
-};
 
 /**
  * 5b. analyzeSources — klasifikasi stance/design/outcomes per unit `[n]×subQ` (LLM structuredOutput
@@ -1423,7 +1492,7 @@ const analyzeSourcesStep = createStep({
       }
       const allUnits = [...unitByKey.values()].sort(
         (a, b) =>
-          ANALYZE_STRENGTH_PRIORITY[a.evidenceStrength] - ANALYZE_STRENGTH_PRIORITY[b.evidenceStrength] ||
+          evidenceStrengthRank(a.evidenceStrength) - evidenceStrengthRank(b.evidenceStrength) ||
           a.n - b.n ||
           a.subQuestionIndex - b.subQuestionIndex,
       );

--- a/apps/agent/src/mastra/workflows/deep-tasks.ts
+++ b/apps/agent/src/mastra/workflows/deep-tasks.ts
@@ -7,7 +7,7 @@ import { counterEvidence } from "../agents/counter-evidence";
 import { deepWriter } from "../agents/deep-writer";
 import { literatureSearcher } from "../agents/literature-searcher";
 import { AQSHA_AGENT_KIND_KEY, type AgentKind } from "../lib/tool-context";
-import { liteProviderOptions, proProviderOptions } from "../model";
+import { liteProviderOptions, proProviderOptions, proSearchProviderOptions } from "../model";
 
 /**
  * Subagent `/deep` sebagai BACKGROUND TASK persisten (`mastra_background_tasks`).
@@ -55,13 +55,32 @@ type DeepTaskArgs = {
 /** Hasil task (kolom `result`) — subset output `.generate()` yang dipakai step. */
 type DeepTaskResult = { text: string; reasoningText?: string };
 
-function deepProviderOptionsFor(agentKind: AgentKind): Record<string, unknown> {
-  const opts = agentKind === "pro" ? proProviderOptions : liteProviderOptions;
+/**
+ * `providerOptions` penalaran per (tier, subagent). Run pro tetap `proModel` untuk SEMUA subagent,
+ * tapi `literature-searcher` memakai effort search yang diturunkan (`proSearchProviderOptions`) —
+ * fase fan-out terbanyak-panggilan; penalaran dalam disimpan untuk counter-evidence + writer.
+ */
+function deepProviderOptionsFor(agentKind: AgentKind, agentId: DeepTaskAgentId): Record<string, unknown> {
+  const opts =
+    agentKind === "pro"
+      ? agentId === "literature-searcher"
+        ? proSearchProviderOptions
+        : proProviderOptions
+      : liteProviderOptions;
   return opts ? { providerOptions: opts } : {};
 }
 
-/** Eksekusi sesungguhnya — dipakai executor task DAN fallback foreground (manager mati/test env). */
-async function executeDeepGenerate(rawArgs: Record<string, unknown>): Promise<DeepTaskResult> {
+/**
+ * Eksekusi sesungguhnya — dipakai executor task DAN fallback foreground (manager mati/test env).
+ * `abortSignal` (opsional) diteruskan ke `agent.generate` supaya Stop/timeout benar-benar
+ * membatalkan panggilan LLM in-flight — bukan sekadar menandai record task `cancelled`/`timed_out`
+ * lalu membuang hasilnya. Mastra memasok signal ini via `options.abortSignal` di executor task
+ * (satu controller dgn timeout task), dan jalur foreground meneruskan `params.abortSignal`.
+ */
+async function executeDeepGenerate(
+  rawArgs: Record<string, unknown>,
+  abortSignal?: AbortSignal,
+): Promise<DeepTaskResult> {
   const args = rawArgs as DeepTaskArgs;
   const agent = DEEP_TASK_AGENTS[args.agentId];
   if (!agent) throw new Error(`deep task: unknown subagent id "${String(args.agentId)}"`);
@@ -69,16 +88,22 @@ async function executeDeepGenerate(rawArgs: Record<string, unknown>): Promise<De
   const agentKind: AgentKind = rc.get(AQSHA_AGENT_KIND_KEY) === "pro" ? "pro" : "lite";
   const out = await agent.generate(args.prompt, {
     requestContext: rc,
-    ...deepProviderOptionsFor(agentKind),
+    ...deepProviderOptionsFor(agentKind, args.agentId),
     ...(args.toolChoice ? { toolChoice: args.toolChoice } : {}),
+    ...(abortSignal ? { abortSignal } : {}),
   });
   const reasoning = (out.reasoningText ?? "").trim();
   return { text: out.text, ...(reasoning ? { reasoningText: reasoning } : {}) };
 }
 
-/** Executor static — satu untuk semua subagent (routing via `args.agentId`). */
+/**
+ * Executor static — satu untuk semua subagent (routing via `args.agentId`). Parameter kedua
+ * (`ToolExecutor` options) membawa `abortSignal` yang di-abort Mastra saat `manager.cancel()`
+ * ATAU saat task melewati `timeoutMs` — diteruskan ke `agent.generate` agar generasi berhenti.
+ */
 const deepTaskExecutor = {
-  execute: (args: Record<string, unknown>) => executeDeepGenerate(args),
+  execute: (args: Record<string, unknown>, options?: { abortSignal?: AbortSignal }) =>
+    executeDeepGenerate(args, options?.abortSignal),
 };
 
 /**
@@ -189,7 +214,7 @@ export async function runDeepSubagentTask(params: {
   abortSignal?: AbortSignal;
 }): Promise<DeepTaskResult> {
   const manager = params.mastra?.backgroundTaskManager;
-  if (!manager) return executeDeepGenerate(params.args);
+  if (!manager) return executeDeepGenerate(params.args, params.abortSignal);
   if (params.abortSignal?.aborted) throw new Error("deep task dibatalkan: run di-cancel");
 
   let toolCallId = params.toolCallId;
@@ -256,18 +281,18 @@ export async function runDeepSubagentTask(params: {
     timeoutMs: params.timeoutMs,
     context: { executor: deepTaskExecutor },
   });
-  // Run di-cancel → tutup task yang baru di-dispatch. KOOPERATIF & JUJUR: cancel menandai
-  // record `cancelled` + wait di bawah keluar dini via status terminal itu, tapi `agent.generate`
-  // in-flight TIDAK menerima signal (args task wajib JSON-serializable, tanpa closure) — panggilan
-  // LLM yang sudah jalan bisa tuntas internal lalu hasilnya dibuang. Kebocoran debit `search_*`
-  // mengecil (task antre/berikutnya tak pernah mulai), tidak nol.
+  // Run di-cancel → tutup task yang baru di-dispatch. `manager.cancel()` (dipicu handle.cancel())
+  // men-abort controller task di `activeAbortControllers`; controller itu diteruskan Mastra ke
+  // executor sebagai `options.abortSignal` → `deepTaskExecutor` mengopernya ke `agent.generate`,
+  // jadi panggilan LLM in-flight IKUT ter-abort (generasi berhenti, kredit `search_*` tak
+  // terlanjur habis). Wait di bawah tetap keluar dini via status terminal `cancelled`.
   const onAbort = () => void handle.cancel().catch(() => {});
   params.abortSignal?.addEventListener("abort", onAbort, { once: true });
   // Tutup jendela race tersisa (abort mendarat di antara cek ulang di atas dan addEventListener).
   if (params.abortSignal?.aborted) onAbort();
   try {
     const { fallbackToSync } = await handle.dispatch();
-    if (fallbackToSync) return executeDeepGenerate(params.args);
+    if (fallbackToSync) return executeDeepGenerate(params.args, params.abortSignal);
     const done = await handle.waitForCompletion({ timeoutMs: params.timeoutMs + STALE_WAIT_MARGIN_MS });
     if (done.status !== "completed") {
       throw new Error(

--- a/apps/api/src/routes/threads.ts
+++ b/apps/api/src/routes/threads.ts
@@ -5,7 +5,7 @@ import {
   ThreadService,
 } from "@aqsha/services";
 import {
-  dedupeReferenceSources,
+  dedupeCitableReferenceSources,
   formatBibtex,
   formatRis,
   sortForReferenceList,
@@ -136,7 +136,7 @@ export const threads = new Elysia({ prefix: "/threads" })
       const { db } = getDb();
       await ThreadService.assertOwner(db, ownerUserId, params.id);
       const items = await ResearchService.listThreadSources(db, params.id);
-      const sources = sortForReferenceList(dedupeReferenceSources(items));
+      const sources = sortForReferenceList(dedupeCitableReferenceSources(items));
       const format = query.format === "ris" ? "ris" : "bibtex";
       return {
         format,

--- a/apps/web/app/app/(product)/explore/[paperRef]/loading.tsx
+++ b/apps/web/app/app/(product)/explore/[paperRef]/loading.tsx
@@ -1,0 +1,9 @@
+import { AppLoadingOverlay } from "@/components/app-loading-overlay";
+
+// Boundary loading khusus segmen `[paperRef]` — pola sama dgn `threads/[threadId]/loading.tsx`:
+// segmen dynamic di-instantiate ulang tiap param berubah (paper -> paper terkait), sehingga
+// boundary `(product)/loading.tsx` di atasnya tidak menangkapnya. Overlay `variant="absolute"`
+// mengisi SidebarInset (parent `relative`).
+export default function ExplorePaperLoading() {
+  return <AppLoadingOverlay label="Memuat..." variant="absolute" />;
+}

--- a/apps/web/app/app/(product)/explore/n/[id]/loading.tsx
+++ b/apps/web/app/app/(product)/explore/n/[id]/loading.tsx
@@ -1,0 +1,9 @@
+import { AppLoadingOverlay } from "@/components/app-loading-overlay";
+
+// Boundary loading khusus segmen `n/[id]` — pola sama dgn `threads/[threadId]/loading.tsx`:
+// segmen dynamic di-instantiate ulang tiap param berubah, sehingga boundary
+// `(product)/loading.tsx` di atasnya tidak menangkapnya. Overlay `variant="absolute"`
+// mengisi SidebarInset (parent `relative`).
+export default function ExploreNewsLoading() {
+  return <AppLoadingOverlay label="Memuat..." variant="absolute" />;
+}

--- a/apps/web/app/app/(product)/loading.tsx
+++ b/apps/web/app/app/(product)/loading.tsx
@@ -1,0 +1,11 @@
+import { AppLoadingOverlay } from "@/components/app-loading-overlay";
+
+// Boundary loading untuk navigasi antar-segmen di bawah `(product)/layout`
+// (home <-> thread <-> workspaces <-> explore). Diletakkan tepat di bawah
+// layout supaya menjadi entry point Suspense saat pindah rute — tanpa ini,
+// prefetch <Link> ke rute dynamic di-skip dan navigasi menahan halaman lama
+// sampai RSC server selesai. Overlay mengisi SidebarInset (parent `relative`),
+// jadi sidebar tetap interaktif dan hanya area konten yang tertutup.
+export default function ProductLoading() {
+  return <AppLoadingOverlay label="Memuat..." variant="absolute" />;
+}

--- a/apps/web/app/app/(product)/page.tsx
+++ b/apps/web/app/app/(product)/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import { ThreadShell } from "@/components/thread-shell";
 import { createPageMetadata } from "@/lib/metadata";
 
@@ -6,8 +5,6 @@ export const metadata = createPageMetadata({
   title: "Threads",
   description: "Continue research conversations and manage active inquiry threads in Aqsha.",
 });
-
-export const dynamic = "force-dynamic";
 
 export default function HomePage() {
   return <ThreadShell />;

--- a/apps/web/app/app/(product)/threads/[threadId]/loading.tsx
+++ b/apps/web/app/app/(product)/threads/[threadId]/loading.tsx
@@ -1,0 +1,9 @@
+import { AppLoadingOverlay } from "@/components/app-loading-overlay";
+
+// Boundary loading khusus segmen `[threadId]`. Segmen dynamic ini
+// di-instantiate ulang tiap kali param berubah (thread -> thread lain),
+// sehingga boundary `(product)/loading.tsx` di atasnya tidak menangkapnya.
+// Overlay `variant="absolute"` mengisi SidebarInset (parent `relative`).
+export default function ThreadDetailLoading() {
+  return <AppLoadingOverlay label="Memuat..." variant="absolute" />;
+}

--- a/apps/web/app/app/(product)/workspaces/[workspaceId]/loading.tsx
+++ b/apps/web/app/app/(product)/workspaces/[workspaceId]/loading.tsx
@@ -1,0 +1,9 @@
+import { AppLoadingOverlay } from "@/components/app-loading-overlay";
+
+// Boundary loading khusus segmen `[workspaceId]` — pola sama dgn `threads/[threadId]/loading.tsx`:
+// segmen dynamic di-instantiate ulang tiap param berubah (workspace -> workspace lain), sehingga
+// boundary `(product)/loading.tsx` di atasnya tidak menangkapnya. Overlay `variant="absolute"`
+// mengisi SidebarInset (parent `relative`).
+export default function WorkspaceDetailLoading() {
+  return <AppLoadingOverlay label="Memuat..." variant="absolute" />;
+}

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -11,8 +11,9 @@ import { useWorkspaceIndexData } from "@/features/workspaces/api/use-workspaces-
 // explore). Hoisting the left navigation here — instead of re-rendering it inside
 // each page shell — means the sidebar stays mounted across navigations (no
 // remount/flicker, no layout shift) and the sidebar data is fetched once. Pages
-// render only their content into SidebarInset, so route-level loading.tsx fills
-// the content area without covering the nav.
+// render only their content into SidebarInset, which is `relative` so the
+// route-level `(product)/loading.tsx` boundary (AppLoadingOverlay
+// variant="absolute") fills just the content area without covering the nav.
 export function AppShell({
   defaultSidebarOpen,
   children,

--- a/apps/web/features/thread-experience/components/mastra-chat-thread-surface.tsx
+++ b/apps/web/features/thread-experience/components/mastra-chat-thread-surface.tsx
@@ -529,7 +529,7 @@ function MastraChatInner({
   // sempat restart; run `running` tak resume sendiri) → tawarkan mulai ulang dari step terakhir.
   const stalledCard = agent.deepStalled ? (
     <DeepRunNoticeCard
-      body="Riset mendalam tampak macet — tidak ada kemajuan beberapa menit terakhir."
+      body={agent.deepStalled}
       primary={{ label: "Mulai ulang", onClick: () => void agent.restartDeep() }}
       secondary={{ label: "Hentikan", onClick: agent.stop }}
     />

--- a/apps/web/features/threads/components/questions-card.tsx
+++ b/apps/web/features/threads/components/questions-card.tsx
@@ -48,6 +48,7 @@ function OptionChip({
   multi,
   onClick,
 }: {
+  /** Keycap huruf (A, B, C…) — hanya dipakai varian pilih-satu; checkbox pakai kotak-centang. */
   letter: string;
   label: string;
   description?: string;
@@ -59,7 +60,9 @@ function OptionChip({
     <button
       type="button"
       onClick={onClick}
-      aria-pressed={selected}
+      role={multi ? "checkbox" : undefined}
+      aria-checked={multi ? selected : undefined}
+      aria-pressed={multi ? undefined : selected}
       className={cn(
         "flex items-start gap-2 rounded-lg border px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         selected
@@ -67,16 +70,31 @@ function OptionChip({
           : "border-border bg-card text-foreground hover:bg-muted/40",
       )}
     >
-      <span
-        className={cn(
-          "mt-px inline-flex h-5 min-w-5 items-center justify-center rounded-[5px] border px-1 font-mono text-[10px] font-semibold leading-none",
-          selected
-            ? "border-foreground/30 bg-foreground/[0.08] text-foreground"
-            : "border-border/70 bg-background text-muted-foreground",
-        )}
-      >
-        {multi && selected ? <CheckIcon className="size-3" /> : letter}
-      </span>
+      {multi ? (
+        // Checkbox: kotak-centang (kosong → tercentang), sengaja beda dari keycap huruf pilih-satu.
+        <span
+          className={cn(
+            "mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors",
+            selected
+              ? "border-foreground bg-foreground text-background"
+              : "border-border/70 bg-background text-transparent",
+          )}
+        >
+          <CheckIcon className="size-3" />
+        </span>
+      ) : (
+        // Pilih-satu (pilihan ganda): keycap huruf A/B/C.
+        <span
+          className={cn(
+            "mt-px inline-flex h-5 min-w-5 items-center justify-center rounded-[5px] border px-1 font-mono text-[10px] font-semibold leading-none",
+            selected
+              ? "border-foreground/30 bg-foreground/[0.08] text-foreground"
+              : "border-border/70 bg-background text-muted-foreground",
+          )}
+        >
+          {letter}
+        </span>
+      )}
       <span className="min-w-0">
         <span className="block text-[13px] leading-5">{label}</span>
         {description ? (

--- a/apps/web/features/threads/lib/use-mastra-agent.ts
+++ b/apps/web/features/threads/lib/use-mastra-agent.ts
@@ -69,8 +69,10 @@ export type MastraAgent = {
   queued: QueuedSend[];
   /** Batalkan item antrean KLIEN (antrean server tak bisa dibatalkan). */
   cancelQueued: (id: string) => void;
-  /** Run `/deep` tampak macet (snapshot tak maju beberapa menit) → tawarkan mulai ulang (DUR-5). */
-  deepStalled: boolean;
+  /** Run `/deep` tampak macet (snapshot tak maju melewati ambang) → banner + mulai ulang (DUR-5).
+   *  Nilai = copy banner (per-fase menenangkan utk fase generate-berat, generik "macet" utk fase
+   *  ringan — ISSUE-4); `null` bila tak ada indikasi macet. */
+  deepStalled: string | null;
   /** Mulai ulang run `/deep` yang macet dari step aktif terakhir (`run.restart()`). */
   restartDeep: () => Promise<void>;
   /** Run `/deep` gagal pasca-billing → kartu "Coba lagi" (B1); `null` bila tak ada. */
@@ -117,6 +119,30 @@ const DEEP_WORKFLOW_ID = "deep-research";
  */
 const DEEP_STALL_MS = 300_000;
 
+/**
+ * ISSUE-4: fase generate-berat `/deep` — subagen `.generate()` panjang (menimbang bukti tandingan,
+ * menganalisis bukti, menulis sintesis) sah diam beberapa menit tanpa transisi step (run nyata:
+ * search-literature 290s, synthesize 245s, counter-evidence 228s). Untuk fase ini ambang "macet"
+ * dilonggarkan ke 9 menit + banner memakai copy per-fase yang menenangkan (bukan alarm "macet"
+ * prematur pada 5 menit).
+ */
+const DEEP_HEAVY_STALL_MS = 540_000;
+/**
+ * Copy per-fase banner untuk fase generate-berat (sentence case). Key = id step workflow
+ * `deep-research` (agent); URUTAN key = urutan workflow — `activeHeavyDeepStep` men-derive daftar
+ * step berat dari sini (satu sumber, tak ada daftar kembar yang bisa drift). search-literature
+ * ikut: run nyata 290s tanpa transisi step — nyaris menabrak ambang generik 5 menit.
+ */
+const DEEP_HEAVY_STEP_MESSAGE: Record<string, string> = {
+  "search-literature": "Astra sedang menelusuri literatur — tahap ini bisa memakan beberapa menit.",
+  "counter-evidence": "Astra sedang menimbang bukti tandingan — tahap ini bisa memakan beberapa menit.",
+  "analyze-sources": "Astra sedang menganalisis bukti — tahap ini bisa memakan beberapa menit.",
+  synthesize: "Astra sedang menyusun laporan akhir — tahap ini bisa memakan beberapa menit.",
+};
+const DEEP_HEAVY_STEPS = Object.keys(DEEP_HEAVY_STEP_MESSAGE);
+/** Copy generik fase ringan yang tak maju melewati ambang (kemungkinan snapshot beku pasca-restart). */
+const DEEP_STALL_MESSAGE = "Riset mendalam tampak macet — tidak ada kemajuan beberapa menit terakhir.";
+
 /** Run Workflow (subset client-js yang dipakai) — stream/resume/observe = `ReadableStream` chunk. */
 type DeepRun = {
   readonly runId: string;
@@ -157,6 +183,20 @@ type DeepRunSnapshot = {
   /** B3: payload `bail()` (run success) — sumber `reason` kartu notice. */
   result?: Record<string, unknown>;
 };
+
+/**
+ * ISSUE-4: step generate-berat yang sedang berjalan (status non-terminal) di snapshot poll — sumber
+ * copy per-fase + ambang macet yang dilonggarkan. Fase berat berjalan berurutan (satu aktif pada
+ * satu waktu), jadi cukup memilih yang pertama non-terminal. `null` bila step aktif bukan fase
+ * berat. (Snapshot Mastra 1.47 hanya memuat step yang SUDAH mulai — "pending"/"waiting" defensif.)
+ */
+function activeHeavyDeepStep(steps: WorkflowStepsSnapshot): string | null {
+  for (const id of DEEP_HEAVY_STEPS) {
+    const status = String(steps[id]?.status ?? "");
+    if (status === "running" || status === "pending" || status === "waiting") return id;
+  }
+  return null;
+}
 
 /**
  * B3: notice terminal dari `result` run (payload `bail()` — engine mem-persist run bail sebagai
@@ -204,22 +244,32 @@ async function* iterateStream<T>(stream: ReadableStream<T>): AsyncGenerator<T> {
 
 // Pemetaan thread→runId Workflow `/deep` aktif (localStorage) — tak ada get-run-by-thread di
 // client-js, jadi FE simpan sendiri untuk re-attach (`observe`) / rehydrate plan-gate saat refresh.
+// Fallback in-memory HANYA terisi saat `setItem` GAGAL (storage diblokir/quota): guard poll
+// `getDeepRunId(...) !== rid` membaca kunci tiap tick — tanpa fallback, set yang gagal senyap
+// membuat guard melihat `null` di tick pertama dan mematikan poll run yang masih hidup. Saat
+// localStorage sehat, fallback kosong sehingga getItem tetap otoritatif (kunci yang di-clear tab
+// lain tak tertutupi).
 const deepRunKey = (threadId: string) => `aqsha:deep-run:${threadId}`;
+const deepRunMem = new Map<string, string>();
 function getDeepRunId(threadId: string): string | null {
+  if (typeof window === "undefined") return null;
   try {
-    return typeof window !== "undefined" ? window.localStorage.getItem(deepRunKey(threadId)) : null;
+    return window.localStorage.getItem(deepRunKey(threadId)) ?? deepRunMem.get(threadId) ?? null;
   } catch {
-    return null;
+    return deepRunMem.get(threadId) ?? null;
   }
 }
 function setDeepRunId(threadId: string, runId: string): void {
   try {
     window.localStorage.setItem(deepRunKey(threadId), runId);
+    deepRunMem.delete(threadId);
   } catch {
-    /* localStorage tak tersedia → re-attach refresh dilewati (bukan fatal) */
+    /* localStorage tak tersedia → fallback in-memory menopang sesi ini; re-attach refresh dilewati */
+    deepRunMem.set(threadId, runId);
   }
 }
 function clearDeepRunId(threadId: string): void {
+  deepRunMem.delete(threadId);
   try {
     window.localStorage.removeItem(deepRunKey(threadId));
   } catch {
@@ -532,7 +582,10 @@ export function useMastraAgent(opts: {
     new Map<string, { display: string; attachmentIds?: string[] }>(),
   );
   // DUR-5: run `/deep` terdeteksi macet (snapshot tak maju) → banner affordance mulai ulang.
-  const [deepStalled, setDeepStalled] = useState(false);
+  // `null` = tak macet; string = copy banner (per-fase untuk fase berat, ISSUE-4). Sengaja string
+  // polos (bukan objek) — poll men-set ulang tiap tick 2,5 dtk selama banner tampil; identitas
+  // string membuat setState bail-out (Object.is) alih-alih re-render seluruh thread surface.
+  const [deepStalled, setDeepStalled] = useState<string | null>(null);
   // B1: run `/deep` failed → TAHAN kunci pemulihan (runId localStorage sengaja TIDAK di-clear,
   // affordance selamat refresh) + kartu "Coba lagi" (time-travel dari step gagal, tanpa debit baru).
   const [deepFailed, setDeepFailed] = useState<DeepFailure | null>(null);
@@ -848,22 +901,42 @@ export function useMastraAgent(opts: {
   // → kartu alasan (B3, dari `result` run); selainnya → clear + refresh Sumber/sidebar.
   const applyDeepTerminal = useCallback(
     (runId: string, status: string, steps: WorkflowStepsSnapshot, result?: unknown) => {
-      setDeepStalled(false);
-      deepRunRef.current = null;
+      // KEPEMILIKAN: terminal basi run LAMA bisa tiba setelah run pengganti mulai (poll 2,5 dtk
+      // run lama tetap hidup pasca-Stop — tak ada teardown; chunk finish jalur live juga bisa
+      // telat). Kunci localStorage + handle runRef hanya boleh disentuh bila masih milik run ini —
+      // tanpa guard, terminal A meng-klobber kunci/handle run B yang sedang jalan (B jadi
+      // untracked & tak bisa di-Stop).
+      const currentKey = getDeepRunId(opts.threadId);
+      const ownsKey = currentKey === null || currentKey === runId;
+      setDeepStalled(null);
+      if (deepRunRef.current === null || deepRunRef.current.runId === runId) {
+        deepRunRef.current = null;
+      }
       // Seed ikon step dari snapshot (idempoten di jalur live yang sudah menerima chunk) +
       // settle by runId (FE-7) — jangan positional, turn lain tak boleh ikut ter-settle.
       setState((s) => settleWorkflowTurn(seedWorkflowProgress(s, runId, steps), runId));
       if (status === "failed") {
         setDeepFailed(deepFailureFromSteps(runId, steps));
+        // Tegaskan ulang kunci pemulihan: race sempit "stall → failed" bisa membuat `stop()`
+        // (banner "Hentikan") meng-clear runId ≤2,5 dtk sebelum poll melihat terminal failed —
+        // tanpa ini kartu "Coba lagi" tak selamat refresh (jaminan B1). Hanya bila slot kunci
+        // masih kosong/milik run ini (jangan timpa kunci run pengganti).
+        if (ownsKey) setDeepRunId(opts.threadId, runId);
         return;
       }
       setDeepFailed(null);
       // B3: `canceled` (Stop user) dan `cancelled` di payload (tolak rencana) tetap senyap —
       // hanya bail `blocked` yang menghasilkan kartu.
       if (status === "success") setDeepNotice(deepNoticeFromResult(runId, result));
-      clearDeepRunAndRefresh();
+      if (ownsKey) {
+        clearDeepRunAndRefresh();
+      } else {
+        // Kunci milik run lain → jangan sentuh; cukup refresh Sumber/sidebar (data run ini).
+        void qc.invalidateQueries({ queryKey: queryKeys.threads.sources(opts.threadId) });
+        void qc.invalidateQueries({ queryKey: queryKeys.threads.all });
+      }
     },
-    [clearDeepRunAndRefresh],
+    [clearDeepRunAndRefresh, opts.threadId, qc],
   );
 
   // B1: rekonsiliasi terminal jalur live. `workflow-finish` TIDAK membawa status (payload hanya
@@ -1259,7 +1332,7 @@ export function useMastraAgent(opts: {
         const status = wfState.status;
         const steps = wfState.steps ?? {};
         if (status === "suspended") {
-          setDeepStalled(false);
+          setDeepStalled(null);
           // Gerbang HITL: siapkan runRef untuk resume + tampilkan kartu (G7). Bisa clarify (kartu
           // Questions) ATAU approve-plan (kartu rencana) — bedakan dari step mana yang suspended.
           deepRunRef.current ??= (await wf.createRun({
@@ -1306,12 +1379,25 @@ export function useMastraAgent(opts: {
           applyDeepTerminal(rid, status, steps, wfState.result);
           return;
         }
+        // ISSUE-1: Stop pada fase RUNNING meng-clear runId sementara poll ini masih hidup (handle
+        // client-js null → tak ada `cancelled` teardown untuk menghentikannya). runId yang
+        // hilang/berganti = turn ini sengaja dihentikan (atau digantikan run baru) → settle & keluar,
+        // JANGAN re-seed progres (itulah yang membuat tombol Stop terasa "rusak": UI settle sesaat
+        // lalu poll berikutnya menghidupkan ulang stepper). Server-side run sedang dibatalkan `stop()`.
+        if (getDeepRunId(opts.threadId) !== rid) {
+          setDeepStalled(null);
+          // Settle by runId (FE-7): turn pengganti yang mungkin sudah streaming di jendela ≤2,5
+          // dtk pasca-Stop tak boleh ikut ter-settle positional.
+          setState((s) => settleWorkflowTurn(s, rid));
+          return;
+        }
         // running / waiting / pending → render progres terkini lalu poll lagi (step-level).
         setState((s) => seedWorkflowProgress(s, rid, steps));
-        // DUR-5: progres = perubahan status step mana pun. `running` tanpa perubahan melewati
-        // ambang → tampilkan affordance mulai ulang. Ambang longgar (fase search bisa sah memakan
-        // beberapa menit tanpa transisi step) — false positive hanya memunculkan banner opsi,
-        // bukan menghentikan apa pun.
+        // DUR-5 / ISSUE-4: progres = perubahan status step mana pun. Snapshot non-terminal yang tak
+        // maju melewati ambang → banner. Fase generate-berat (`DEEP_HEAVY_STEP_MESSAGE`) sah diam
+        // beberapa menit → ambang dilonggarkan + copy per-fase yang menenangkan; fase ringan yang
+        // beku = kemungkinan snapshot mati pasca-restart (copy "macet" generik). False positive
+        // hanya memunculkan banner opsi, bukan menghentikan apa pun.
         const sig = `${status}|${Object.entries(steps)
           .map(([id, st]) => `${id}:${String(st?.status ?? "")}`)
           .sort()
@@ -1319,14 +1405,14 @@ export function useMastraAgent(opts: {
         if (sig !== progressSig) {
           progressSig = sig;
           progressAt = Date.now();
-          setDeepStalled(false);
-        } else if (
+          setDeepStalled(null);
+        } else if (status === "running" || status === "waiting" || status === "pending") {
           // A3: run bisa beku di `waiting`/`pending` juga (bukan cuma `running`) — snapshot
-          // non-terminal mana pun yang tak maju melewati ambang = macet.
-          (status === "running" || status === "waiting" || status === "pending") &&
-          Date.now() - progressAt >= DEEP_STALL_MS
-        ) {
-          setDeepStalled(true);
+          // non-terminal mana pun yang tak maju melewati ambang (per-fase) = macet.
+          const heavyStep = activeHeavyDeepStep(steps);
+          if (Date.now() - progressAt >= (heavyStep ? DEEP_HEAVY_STALL_MS : DEEP_STALL_MS)) {
+            setDeepStalled((heavyStep && DEEP_HEAVY_STEP_MESSAGE[heavyStep]) || DEEP_STALL_MESSAGE);
+          }
         }
         // Refresh sumber DUA titik: (1) sekali begitu step search-literature MUNCUL di snapshot —
         // rows `research_sources` dipersist DI TENGAH step oleh tool search, jadi kartu sub-agen
@@ -1446,7 +1532,7 @@ export function useMastraAgent(opts: {
     if (!userId) return;
     const runId = deepRunRef.current?.runId ?? getDeepRunId(opts.threadId);
     if (!runId) return;
-    setDeepStalled(false);
+    setDeepStalled(null);
     try {
       const wf = clientRef.current.getWorkflow(DEEP_WORKFLOW_ID);
       const run = (await wf.createRun({ runId, resourceId: userId })) as unknown as DeepRun;
@@ -1547,25 +1633,56 @@ export function useMastraAgent(opts: {
     // Stop akan terasa seperti tombol tak bekerja). Antrean SERVER tak bisa dibatalkan dari klien —
     // biarkan entry-nya; bubble tetap lahir saat runtime menjalankannya.
     setQueuedSends((q) => q.filter((i) => i.serverRunId !== undefined));
-    setDeepStalled(false);
+    setDeepStalled(null);
     // Kartu gagal B1 SENGAJA tak disentuh: Stop atas run lain (chat) tak boleh membuang affordance
     // pemulihan secara senyap — retry/sendDeep/regenerate/dismiss yang mengelolanya sendiri.
     const run = deepRunRef.current;
-    if (run) {
-      // FE-4: Stop saat `/deep` → cancel RUN WORKFLOW server-side. `subscription.abort()`
-      // (`POST /agents/:id/threads/abort`) hanya membatalkan run agent chat — workflow terus jalan
-      // membakar kredit sementara tombol tampak "rusak". Bersihkan runId agar poll re-attach tak
-      // menghidupkan ulang turn yang sengaja dihentikan.
-      void run.cancel().catch(() => {});
+    // Cleanup bersama kedua jalur cancel deep. Bersihkan runId → poll re-attach fase RUNNING yang
+    // masih hidup berhenti re-seed (guard `getDeepRunId(...) !== rid`) & mount berikutnya tak
+    // menghidupkan ulang turn yang dihentikan.
+    const settleDeepStop = () => {
       clearDeepRunId(opts.threadId);
       deepRunRef.current = null;
       setState((s) => settleAssistantTurn({ ...s, planGate: undefined, askGate: undefined }));
+    };
+    if (run) {
+      // FE-4: Stop saat `/deep` → cancel RUN WORKFLOW server-side. `subscription.abort()`
+      // (`POST /agents/:id/threads/abort`) hanya membatalkan run agent chat — workflow terus jalan
+      // membakar kredit sementara tombol tampak "rusak". Cancel gagal (jaringan / run sudah
+      // terminal) tak boleh bikin UI stuck — cleanup tetap jalan.
+      void run.cancel().catch(() => {});
+      settleDeepStop();
+      return;
+    }
+    // ISSUE-1: handle client-js hidup HANYA di-set cabang `suspended` re-attach (plan/clarify-gate).
+    // Saat fase RUNNING dibuka ulang/refresh/di tab lain, handle null tapi runId tetap persist di
+    // localStorage → tanpa fallback ini `stop()` jatuh ke `subRef.abort()` (khusus run chat, null di
+    // sini) = no-op, workflow terus membakar kredit. Buat handle lazily (pola cabang `suspended`).
+    // KECUALI kunci milik run FAILED yang sengaja ditahan B1 (kartu "Coba lagi"): itu bukan run
+    // hidup — Stop yang sedang menyasar run chat tak boleh terbajak membatalkannya (chat tak pernah
+    // di-abort) apalagi menghapus kunci pemulihannya.
+    const deepRunId = getDeepRunId(opts.threadId);
+    if (deepRunId && deepRunId !== deepFailed?.runId) {
+      if (userId) {
+        void clientRef.current
+          .getWorkflow(DEEP_WORKFLOW_ID)
+          .createRun({ runId: deepRunId, resourceId: userId })
+          .then((r) => (r as unknown as DeepRun).cancel())
+          .catch(() => {});
+        settleDeepStop();
+        return;
+      }
+      // Window sempit pasca-refresh: poll re-attach (runById, tanpa userId) sudah menampilkan Stop
+      // sebelum Clerk me-resolve `userId` — cancel lazy butuh `resourceId`. JANGAN hapus kunci
+      // runId di sini: tanpa cancel yang benar-benar terkirim, menghapusnya membuat run yatim
+      // (terus membakar kredit, tak bisa di-Stop ulang). Biarkan no-op; klik berikutnya (setelah
+      // userId siap) membatalkan sungguhan.
       return;
     }
     // Chat: cancel run server-side; server kirim chunk `abort` → reducer men-settle bersih (tanpa AbortError).
     void subRef.current?.abort().catch(() => {});
     setState((s) => settleAssistantTurn(s));
-  }, [opts.threadId]);
+  }, [opts.threadId, userId, deepFailed]);
 
   return {
     status: state.status,

--- a/docs/audit-deep-stuck-stop-2026-07-08.md
+++ b/docs/audit-deep-stuck-stop-2026-07-08.md
@@ -1,0 +1,174 @@
+# Audit: /deep "stuck" + Stop tidak bekerja — 2026-07-08
+
+**Thread:** `44c1550d-4dba-4f5f-909e-b0afe3ddc882` ("Implementasi AI dan ML di Pertambangan")
+**Run:** `5b3b08cc-71f5-491a-b8cf-1a78f85d14af` (workflow `deep-research`, `agentKind=pro`)
+**Owner:** `user_3FfvShyvMCFPIHD3dxHdeMCKrgm`
+**DB:** prod (postgres-prod-vps)
+**Revisi:** 2026-07-08 — setiap issue diverifikasi ulang terhadap kode + DB prod (lihat verdict per
+issue). ISSUE-3 dinyatakan TIDAK VALID, ISSUE-2 akar masalahnya dikoreksi (fix jauh lebih kecil),
+ISSUE-4 tidak terbukti terjadi di run ini. Ditambah ISSUE-6 (freeze navigasi, di luar /deep).
+
+## TL;DR
+
+Run-nya **TIDAK rusak** — selesai `success` dalam ~15 menit dan menghasilkan report 241 KB. Keluhan
+"nyangkut" = run berat + Stop yang no-op (progres muncul lagi 2,5 dtk setelah ditekan) + freeze
+navigasi (ISSUE-6). Keluhan "tidak bisa Stop" = **bug nyata** (ISSUE-1), dan abort in-flight
+(ISSUE-2) ternyata tinggal meneruskan `abortSignal` yang SUDAH dipasok Mastra. Dugaan awal
+"timestamp tersimpan salah" (eks ISSUE-3) terbukti artefak alat baca, bukan bug; dugaan "banner
+macet ikut menyesatkan" (ISSUE-4) tidak terbukti fire di run ini.
+
+### Timeline sebenarnya (kolom `*Z` / UTC — otoritatif; step timing dari snapshot context)
+
+| Waktu (UTC, 2026-07-08) | Kejadian |
+|---|---|
+| 04:18:05 | Thread + workflow dibuat |
+| 04:18:05 → 04:20:02 | `draft-clarify` → `clarify` → `draft-plan` |
+| 04:20:02 → 04:20:06 | `approve-plan` (user setujui rencana) |
+| 04:20:06 → 04:24:56 | `search-literature` — 6× `literature-searcher` subagent |
+| 04:24:56 → 04:28:44 | `counter-evidence` |
+| 04:28:44 → 04:29:02 | `assign-citations` → `analyze-sources` |
+| 04:29:02 → 04:29:19 | `verify-citations` (deterministik) |
+| 04:29:20 → 04:33:25 | `synthesize` (`deep-writer`) — report 241 KB |
+| 04:33:26 → 04:33:29 | `persist-report` (241.388 byte) → workflow **`success`** |
+
+---
+
+## Daftar Issue
+
+### ISSUE-1 — Stop /deep no-op setelah refresh (fase `running`) 🔴 HIGH — ✅ TERVERIFIKASI VALID
+- **Gejala:** Tombol Stop ditekan, workflow lanjut membakar kredit sampai selesai. UI settle
+  sesaat, lalu poll berikutnya (2,5 dtk) men-seed ulang progres → tombol terasa rusak.
+- **Akar masalah (terkonfirmasi):** `stop()`
+  (`apps/web/features/threads/lib/use-mastra-agent.ts:1545-1568`) membatalkan workflow HANYA jika
+  `deepRunRef.current` memegang handle client-js hidup (`run.cancel()`). Satu-satunya tempat
+  re-attach poll men-set handle itu adalah cabang **`suspended`** (`:1265`); cabang
+  **`running`/`waiting`/`pending`** hanya `seedWorkflowProgress` + poll ulang (`:1310`) dan
+  membiarkan `deepRunRef.current = null`. Akibatnya, thread yang dibuka ulang/refresh/di tab lain
+  selama fase running → Stop jatuh ke `subRef.current?.abort()` (hanya untuk run chat; null saat
+  re-attach /deep) → no-op.
+- **Bukti (diverifikasi DB prod):** snapshot run berakhir `success`, bukan `canceled`
+  (`run.cancel()` tak pernah jalan).
+- **Fix (dua opsi setara aman):**
+  1. Di re-attach poll cabang running/waiting/pending, seed handle — pola persis cabang suspended:
+     `deepRunRef.current ??= await wf.createRun({ runId: rid, resourceId: userId })`. Biaya: satu
+     roundtrip `createRun` per re-attach walau Stop tak pernah ditekan.
+  2. **(disarankan)** Lazy di `stop()`: bila handle null tapi `getDeepRunId(opts.threadId)` ada →
+     fire-and-forget `wf.createRun({ runId, resourceId: userId })` lalu `.cancel()`. Menutup juga
+     kasus lain di mana handle hilang tapi runId persist, tanpa biaya per-poll.
+
+### ISSUE-2 — Abort tidak menghentikan `agent.generate()` in-flight 🟠 MEDIUM — ✅ VALID, akar masalah DIKOREKSI (fix trivial, bukan arsitektural)
+- **Gejala:** Stop di tengah fase writer/subagent tetap menyelesaikan generasi LLM yang sedang
+  jalan (hasil dibuang, debit tidak nol).
+- **Akar masalah (dikoreksi):** dugaan awal "args task wajib JSON-serializable tanpa closure, jadi
+  generate tak bisa menerima signal" **salah alamat**. Mastra core 1.47 SUDAH memasok signal:
+  `manager.cancel()` pada task `running` men-abort controller di `activeAbortControllers`, dan
+  workflow internal `__background-task` meneruskannya sebagai
+  `executor.execute(task.args, { abortSignal: abortController.signal, ... })`
+  (terverifikasi di dist `@mastra/core` — `workflow-4XQ5EASL.js:90`). Mata rantai yang putus ada
+  di kode kita: `deepTaskExecutor` (`apps/agent/src/mastra/workflows/deep-tasks.ts:80-82`)
+  **membuang parameter kedua** (`execute: (args) => executeDeepGenerate(args)`).
+- **Fix (±5 baris):** teruskan signal —
+  `execute: (args, opts) => executeDeepGenerate(args, opts?.abortSignal)` lalu di
+  `executeDeepGenerate` oper ke `agent.generate(args.prompt, { abortSignal, ... })`
+  (`AgentExecutionOptions` menerimanya — `agent.types.d.ts:382`). Bonus: timeout task Mastra
+  memakai controller yang sama → generate yang melewati `timeoutMs` ikut ter-abort.
+
+### ~~ISSUE-3 — Timestamp non-tz menyimpan waktu lokal (UTC-8)~~ — ❌ TIDAK VALID (artefak alat baca, data BENAR)
+- **Verifikasi (DB prod):** cast server-side melewati parsing driver membuktikan nilai tersimpan
+  identik: `"createdAt"::text = '2026-07-08 04:20:06.076'` vs
+  `"createdAtZ"::text = '2026-07-08 04:20:06.076+00'`, dan
+  `EXTRACT(EPOCH FROM ("createdAtZ" AT TIME ZONE 'UTC' - "createdAt")) = 0` di semua baris run ini.
+  Cross-check jam independen (`chat_threads` epoch-ms) mengonfirmasi instan `*Z` benar.
+- **Penjelasan "skew 8 jam":** MCP postgres server jalan lokal di Mac (TZ UTC+8) → driver mem-parse
+  `timestamp without time zone` sebagai waktu LOKAL lalu me-render ISO UTC → tampil mundur 8 jam.
+  DB dev menunjukkan "skew" arah & besaran sama persis (mustahil bila penyebabnya timezone server
+  penulis — prod dan dev mesinnya beda). Tidak ada trigger di kedua tabel; jalur baca Mastra
+  Z-first (`row.createdAtZ || row.createdAt`) → logika timeout/sweep runtime aman.
+- **Aksi:** tidak ada perubahan kode. Higiene diagnosis: saat audit tabel `mastra_*` via MCP,
+  SELALU pakai kolom `*Z` atau cast `::text` / `AT TIME ZONE 'UTC'`. Opsional: set `TZ=UTC` pada
+  env MCP postgres server lokal supaya artefak hilang permanen.
+
+### ISSUE-4 — Banner "macet" (DUR-5) false-positive 🟡 LOW — ⚠️ RISIKO LATEN VALID, tapi TIDAK terbukti fire di run ini
+- **Verifikasi (step timing snapshot prod):** jendela diam terpanjang = `search-literature`
+  **290,6 dtk** — 9 detik di bawah `DEEP_STALL_MS = 300_000` (`use-mastra-agent.ts:118`).
+  `synthesize` 245 dtk, `counter-evidence` 228 dtk. Banner hampir pasti tidak pernah muncul di run
+  ini; "kesan nyangkut" lebih mungkin dari ISSUE-1 (Stop no-op) + ISSUE-6 (freeze navigasi) +
+  durasi run 15 menit.
+- **Tetap layak diperbaiki:** run sedikit lebih berat pasti melewati ambang (di sini tinggal 9
+  detik lagi), dan fase `synthesize`/`analyze` memang sah diam beberapa menit.
+- **Fix:** `steps` sudah tersedia di scope poll → tampilkan copy per-fase ("sedang menyusun
+  laporan…") alih-alih banner "macet" untuk step generate-berat
+  (`counter-evidence`/`analyze-sources`/`synthesize`), dan/atau ambang per-step (8–10 mnt untuk
+  fase berat, 5 mnt sisanya). Murni FE.
+
+### ISSUE-5 — Run berat: banyak sumber di-drop / inventory kena budget 🟡 LOW (observasi) — ✅ VALID, angka terverifikasi DB
+- **Verifikasi (DB prod):** run ini punya **257 sumber bernomor** dan **190 unit unik** `[n]×subQ`
+  → 190 − cap 60 = **130 unit di-drop** (`ANALYZE_UNIT_CAP`,
+  `apps/agent/src/mastra/workflows/deep-research.ts:1367`) — persis angka log. Budget inventory
+  48k (`INVENTORY_CHAR_BUDGET`, `:1273`) habis ±baris 108 → ~149 baris tanpa snippet — cocok.
+- **Catatan penting:** DB tetap menyimpan SEMUA 257 snippet — pemangkasan hanya saat menyusun
+  prompt, tidak ada kehilangan data. Bukan error; menandakan fan-out search mengumpulkan 3–4×
+  kapasitas synthesize.
+- **Arah tuning:** naikkan `ANALYZE_UNIT_CAP` bertahap (klasifikasi chunked 20 unit/panggilan lite
+  → cap 100 ≈ 2 panggilan ekstra) ATAU batasi sumber per sub-Q di hulu. Budget 48k lahir dari
+  insiden prompt 400KB yang membuat run macet permanen — jangan dinaikkan tanpa menaikkan timeout
+  task.
+
+### ISSUE-6 — Navigasi /app ↔ thread detail: URL berubah tapi visual freeze di halaman lama 🔴 HIGH (BARU, di luar /deep)
+- **Gejala:** dari detail thread klik ke `/app` (atau sebaliknya) — path di address bar berubah,
+  tapi layar tetap menampilkan halaman lama tanpa feedback; dua arah.
+- **Akar masalah (terkonfirmasi docs Next 16.2.6 terpasang):** kombinasi tiga hal —
+  1. Kedua rute **dynamic**: `/app` home ber-`export const dynamic = "force-dynamic"`
+     (`apps/web/app/app/(product)/page.tsx:10` — padahal isinya murni client shell; ada juga
+     import `redirect` mati), dan `threads/[threadId]` segment dynamic tanpa
+     `generateStaticParams`; `(product)/layout.tsx` membaca `cookies()`.
+  2. Rute dynamic tanpa `loading.tsx` → **prefetch `<Link>` di-skip total** dan klien harus
+     menunggu respons RSC server saat klik.
+  3. Satu-satunya `loading.tsx` ada di `app/app/loading.tsx` — **DI ATAS** `(product)/layout` →
+     boundary sudah ter-mount, tak pernah tampil untuk navigasi intra-produk (menampilkannya
+     berarti meng-unmount sidebar). Komentar `app-shell.tsx:14` justru mengasumsikan "route-level
+     loading.tsx fills the content area" — file itu tidak pernah dibuat.
+  Dokumentasi resminya mendeskripsikan gejala persis
+  (`node_modules/next/dist/docs/01-app/02-guides/instant-navigation.md:175`): *"the page fetches
+  uncached data with no local boundary, so the old page stays visible until the server finishes
+  rendering, making the navigation feel unresponsive."*
+- **Faktor penguat:** dev = kompilasi Turbopack on-demand per rute; thread berat (report 241KB +
+  257 pill sitasi) di-mount sinkron begitu payload tiba → main thread terblokir; saat run /deep
+  aktif, poll 2,5 dtk dapat menginterupsi/me-restart render transisi (starvation).
+- **Fix:**
+  1. Tambah `app/app/(product)/loading.tsx` (cover home ↔ thread ↔ workspaces ↔ explore) +
+     `app/app/(product)/threads/[threadId]/loading.tsx` (cover thread ↔ thread — segment
+     `[threadId]` re-instantiate per param, boundary `(product)` tidak menangkapnya). Isi:
+     skeleton area konten / `AppLoadingOverlay variant="absolute"` (sudah ada, memang dibuat untuk
+     ini). Efek per docs: prefetch parsial aktif, navigasi commit seketika, sidebar tetap
+     interaktif.
+  2. Hapus `force-dynamic` + import `redirect` mati di `(product)/page.tsx`.
+  3. Opsional/eksperimental: `unstable_instant` (hint di docs Next 16) — jangan jadikan fix utama.
+  4. Follow-up terpisah: defer/virtualisasi render laporan deep raksasa (memperpendek fase beku di
+     thread berat mana pun).
+- **Verifikasi pasca-fix:** Network tab → klik link thread: sebelum fix, request RSC pending
+  sementara layar diam; setelah fix, area konten langsung berganti skeleton saat klik.
+
+---
+
+## Non-issue (diverifikasi, tidak perlu aksi)
+- **`chat_threads.status = 'idle'` selama run** — by design. `threadProjectionProcessor` selalu
+  menulis `idle`; `streaming`/`failed` sisa kompat schema (`packages/db/src/schema/chatThreads.ts:11-12`).
+  FE tidak membaca kolom ini untuk deep. Bukan penyebab Stop gagal.
+- **Timestamp `mastra_*` non-tz** — eks ISSUE-3, lihat di atas: data tersimpan benar; "skew" murni
+  artefak driver pembaca non-UTC. Pakai kolom `*Z`/`::text` saat audit.
+- **Tidak ada akumulasi run zombie di prod** — total `deep-research`: 4 `success`, 1 `canceled`, 0
+  `running` (saat audit). Cancel PERNAH bekerja (contoh `canceled` 07-07 08:39) → mekanisme sehat saat
+  handle hidup.
+- Noise log yang bisa diabaikan: `This storage provider does not support batch creating metrics`,
+  `crossref lookup failed Crossref returned 404`.
+
+---
+
+## Prioritas eksekusi (revisi)
+1. **ISSUE-1** (fix inti "tidak bisa Stop"; FE minimal — opsi lazy di `stop()`)
+2. **ISSUE-2** (naik prioritas: ±5 baris, melengkapi ISSUE-1 — Stop benar-benar menghentikan LLM in-flight)
+3. **ISSUE-6** (dua file `loading.tsx` + hapus `force-dynamic` vestigial)
+4. **ISSUE-4** (copy per-fase + ambang per-step)
+5. **ISSUE-5** (evaluasi tuning terpisah)
+6. ~~ISSUE-3~~ dicoret — diganti catatan higiene diagnosis di Non-issue.

--- a/packages/db/src/repositories/researchSourceRepo.ts
+++ b/packages/db/src/repositories/researchSourceRepo.ts
@@ -43,10 +43,14 @@ export const ResearchSourceRepo = {
       .orderBy(asc(researchSources.createdAt), asc(researchSources.id));
   },
 
-  /** Set citation_number batch via satu UPDATE…CASE (≤60 baris per run deep). */
+  /**
+   * Set citation_number batch via satu UPDATE…CASE (ratusan baris per run deep kaya-sumber).
+   * `citationNumber: null` = baris tersisih cap penomoran (ISSUE-5) — di-NULL-kan eksplisit
+   * supaya restart run dengan seleksi berbeda tak meninggalkan nomor basi.
+   */
   async setCitationNumbers(
     db: DbOrTx,
-    updates: Array<{ id: string; citationNumber: number }>,
+    updates: Array<{ id: string; citationNumber: number | null }>,
   ): Promise<void> {
     if (updates.length === 0) return;
     const cases = sql.join(

--- a/packages/services/src/research/index.ts
+++ b/packages/services/src/research/index.ts
@@ -20,7 +20,7 @@ import { searchArxiv } from "./arxiv";
 import { lookupDoi, searchCrossref } from "./crossref";
 import { searchWebFirecrawl } from "./firecrawl";
 import { type OpenAlexSort, searchOpenAlex } from "./openalex";
-import type { ProviderSearchResult, ResearchCandidate } from "./types";
+import type { EvidenceStrength, ProviderSearchResult, ResearchCandidate } from "./types";
 
 export type { OpenAlexSort } from "./openalex";
 
@@ -50,7 +50,9 @@ export { scrapeUrlFirecrawl, type UrlReadResult } from "../papers/firecrawl-read
 
 // Formatter daftar pustaka deterministik — tool `format_references` + export .bib/.ris.
 export {
+  dedupeCitableReferenceSources,
   dedupeReferenceSources,
+  filterCitableReferenceSources,
   formatApa7Reference,
   formatBibtex,
   formatRis,
@@ -298,18 +300,27 @@ export const ResearchService = {
    * Dedupe paper yang sama lintas sub-pertanyaan/penyedia via kunci `normalizeDoi ?? arxivId ??
    * locator` (baris berbeda dgn DOI/URL beda dapat NOMOR SAMA). Dipanggil step `assign-citations`
    * SEBELUM verify/synthesize → writer mengutip `[n]` global yang stabil. Mengembalikan item
-   * bernomor (urut createdAt) untuk menyusun inventory.
+   * (urut createdAt) untuk menyusun inventory — HANYA yang bernomor layak dikutip.
+   *
+   * `perSubQuestionCap` (ISSUE-5): tool search mem-persist SEMUA hasilnya, jadi run kaya-sumber
+   * menomori 3–4× kapasitas synthesize/analyze hilir. Cap membatasi baris bernomor per
+   * sub-pertanyaan (prioritas `evidenceStrength`, lalu urutan persist); baris tersisih di-set
+   * `citation_number = NULL` (overwrite — restart dengan cap berbeda tak meninggalkan nomor basi)
+   * tapi TETAP tersimpan di DB (panel Sources thread tak kehilangan data). Baris tanpa
+   * `subQuestionIndex` (bukti tandingan / untagged) selalu lolos.
    */
   async assignCitationNumbers(
     db: DbOrTx,
-    args: { threadId: string; turnId: string },
+    args: { threadId: string; turnId: string; perSubQuestionCap?: number },
   ): Promise<ResearchSourceItem[]> {
     const rows = await ResearchSourceRepo.listByThreadTurn(db, args.threadId, args.turnId);
     if (rows.length === 0) return [];
+    const selected = selectSourceIdsForNumbering(rows, args.perSubQuestionCap);
     const numberByKey = new Map<string, number>();
     let next = 1;
     const updates = rows.map((r) => {
-      const key = (r.doi && normalizeDoi(r.doi)) || r.arxivId || r.locator;
+      if (!selected.has(r.id)) return { id: r.id, citationNumber: null };
+      const key = citationDedupeKey(r);
       let n = numberByKey.get(key);
       if (n === undefined) {
         n = next++;
@@ -321,6 +332,81 @@ export const ResearchService = {
     return rows.map((r, i) => toResearchSourceItem({ ...r, citationNumber: updates[i]!.citationNumber }));
   },
 };
+
+/**
+ * Prioritas kekuatan bukti (kecil = kuat) — SATU sumber untuk seleksi penomoran di sini DAN
+ * prioritisasi unit klasifikasi step `analyze-sources` (agent deep-research). Nilai di luar
+ * vocab (kolom text bebas) diperingkat paling akhir via `evidenceStrengthRank`.
+ */
+export const EVIDENCE_STRENGTH_PRIORITY: Record<EvidenceStrength, number> = {
+  strong: 0,
+  medium: 1,
+  weak: 2,
+};
+
+/** Rank aman untuk nilai bebas kolom `evidence_strength` — tak dikenal = paling akhir. */
+export function evidenceStrengthRank(strength: string): number {
+  return (EVIDENCE_STRENGTH_PRIORITY as Record<string, number | undefined>)[strength] ?? 3;
+}
+
+/** Kunci dedupe sitasi — paper sama lintas baris/penyedia berbagi satu [n]. */
+function citationDedupeKey(r: { doi: string | null; arxivId: string | null; locator: string }): string {
+  return (r.doi && normalizeDoi(r.doi)) || r.arxivId || r.locator;
+}
+
+/**
+ * Pilih id baris yang layak dinomori: per sub-pertanyaan ambil ≤`cap` PAPER UNIK terkuat
+ * (`evidenceStrength` strong→medium→weak, seri dipecah urutan persist — baris lebih awal = hasil
+ * ronde search pertama yang paling relevan). Cap dihitung per kunci dedupe (BUKAN per baris):
+ * baris duplikat paper yang sudah terpilih (mis. baris arXiv + baris publisher ber-DOI sama)
+ * berbagi satu [n] di penomoran, jadi tak boleh memakan slot paper unik lain. Baris
+ * ber-`subQuestionIndex` null (bukti tandingan / read_url untagged) selalu lolos — jumlahnya
+ * kecil dan bernilai tinggi. Pure — diekspor untuk test.
+ */
+export function selectSourceIdsForNumbering(
+  rows: Array<{
+    id: string;
+    subQuestionIndex: number | null;
+    evidenceStrength: string;
+    doi: string | null;
+    arxivId: string | null;
+    locator: string;
+  }>,
+  perSubQuestionCap?: number,
+): Set<string> {
+  if (perSubQuestionCap === undefined || perSubQuestionCap <= 0) {
+    return new Set(rows.map((r) => r.id));
+  }
+  const selected = new Set<string>();
+  const bySubQ = new Map<number, Array<{ id: string; key: string; order: number; strength: number }>>();
+  rows.forEach((r, order) => {
+    if (r.subQuestionIndex === null) {
+      selected.add(r.id);
+      return;
+    }
+    const bucket = bySubQ.get(r.subQuestionIndex) ?? [];
+    bucket.push({
+      id: r.id,
+      key: citationDedupeKey(r),
+      order,
+      strength: evidenceStrengthRank(r.evidenceStrength),
+    });
+    bySubQ.set(r.subQuestionIndex, bucket);
+  });
+  for (const bucket of bySubQ.values()) {
+    const keys = new Set<string>();
+    for (const r of bucket.sort((a, b) => a.strength - b.strength || a.order - b.order)) {
+      if (keys.has(r.key)) {
+        selected.add(r.id);
+        continue;
+      }
+      if (keys.size >= perSubQuestionCap) continue;
+      keys.add(r.key);
+      selected.add(r.id);
+    }
+  }
+  return selected;
+}
 
 /** Row `research_sources` → read model `ResearchSourceItem`. */
 function toResearchSourceItem(r: ResearchSource): ResearchSourceItem {

--- a/packages/services/src/research/references.ts
+++ b/packages/services/src/research/references.ts
@@ -32,6 +32,32 @@ export type ReferenceSourceInput = {
 const AUTHOR_CAP = 3;
 
 /**
+ * Keluarkan baris deep yang tersisih cap penomoran (ISSUE-5): `citationNumber` null pada turn
+ * yang PUNYA baris bernomor = paper terkumpul yang tak pernah bisa dikutip laporan — jangan ikut
+ * daftar pustaka "semua sumber". Sumber chat biasa (turn tanpa penomoran sama sekali) tetap lolos.
+ * Dipakai tool `format_references` + route export `.bib/.ris` — SATU aturan untuk keduanya.
+ */
+export function filterCitableReferenceSources<
+  T extends { turnId: string | null; citationNumber: number | null },
+>(items: T[]): T[] {
+  const numberedTurns = new Set(
+    items.filter((s) => s.citationNumber !== null).map((s) => s.turnId),
+  );
+  return items.filter((s) => s.citationNumber !== null || !numberedTurns.has(s.turnId));
+}
+
+/**
+ * Aturan bersama "semua sumber yang layak masuk daftar pustaka" — komposisi filter citable lalu
+ * dedupe lintas turn, SATU tempat untuk tool `format_references` + route export `.bib/.ris`
+ * (urutan komposisi tak boleh drift antar konsumen).
+ */
+export function dedupeCitableReferenceSources<
+  T extends ReferenceSourceInput & { turnId: string | null; citationNumber: number | null },
+>(items: T[]): T[] {
+  return dedupeReferenceSources(filterCitableReferenceSources(items));
+}
+
+/**
  * Dedup lintas turn: `research_sources` unik per (thread, turn, locator) sehingga sumber yang
  * sama muncul lagi di turn lain. Kunci samadengan `assignCitationNumbers`: DOI ternormalisasi ??
  * arXiv id ?? locator. Pemenang = baris pertama; nomor sitasi & metadata terisi menang atas null.

--- a/packages/services/test/rag-extract.test.ts
+++ b/packages/services/test/rag-extract.test.ts
@@ -3,11 +3,18 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { extractStoredDocument } from "../src/artifacts/extract";
 
 let embeddingEnabled = true;
+// Spread modul asli supaya mock EXPORT-COMPLETE by construction: mock.module MENGGANTI seluruh
+// modul, export yang hilang = SyntaxError saat import (dan bocor ke file test lain) — export baru
+// di clients/embeddings otomatis ikut tanpa harus menambal daftar ini lagi.
+const actualEmbeddings = await import("../src/clients/embeddings");
 mock.module("../src/clients/embeddings", () => ({
+  ...actualEmbeddings,
   embedTexts: async (values: string[]) => values.map(() => [0.1, 0.2, 0.3]),
   isEmbeddingEnabled: () => embeddingEnabled,
-  EMBEDDING_MODEL: "text-embedding-3-small",
-  EMBEDDING_DIMENSION: 1536,
+  // Override tetap perlu: versi asli membaca kredensial env, test mengontrol via flag lokal.
+  assertEmbeddingEnabled: () => {
+    if (!embeddingEnabled) throw new Error("embedding disabled (mock)");
+  },
 }));
 
 const { RagService, ragEntryIdFor } = await import("../src/rag.service");

--- a/packages/services/test/research-citation-selection.test.ts
+++ b/packages/services/test/research-citation-selection.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { filterCitableReferenceSources, selectSourceIdsForNumbering } from "../src/research";
+
+type Row = {
+  id: string;
+  subQuestionIndex: number | null;
+  evidenceStrength: string;
+  doi: string | null;
+  arxivId: string | null;
+  locator: string;
+};
+
+function row(id: string, subQ: number | null, strength: string, doi: string | null = null): Row {
+  return { id, subQuestionIndex: subQ, evidenceStrength: strength, doi, arxivId: null, locator: id };
+}
+
+describe("selectSourceIdsForNumbering", () => {
+  test("tanpa cap → semua baris lolos", () => {
+    const rows = [row("a", 0, "weak"), row("b", 1, "strong"), row("c", null, "weak")];
+    expect(selectSourceIdsForNumbering(rows)).toEqual(new Set(["a", "b", "c"]));
+    expect(selectSourceIdsForNumbering(rows, 0)).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  test("cap per sub-Q memprioritaskan evidenceStrength (strong → medium → weak)", () => {
+    const rows = [
+      row("w1", 0, "weak"),
+      row("m1", 0, "medium"),
+      row("s1", 0, "strong"),
+      row("w2", 0, "weak"),
+    ];
+    expect(selectSourceIdsForNumbering(rows, 2)).toEqual(new Set(["s1", "m1"]));
+  });
+
+  test("seri kekuatan dipecah urutan persist (baris lebih awal menang)", () => {
+    const rows = [row("s1", 0, "strong"), row("s2", 0, "strong"), row("s3", 0, "strong")];
+    expect(selectSourceIdsForNumbering(rows, 2)).toEqual(new Set(["s1", "s2"]));
+  });
+
+  test("cap dihitung PER sub-pertanyaan, bukan global", () => {
+    const rows = [
+      row("a0", 0, "strong"),
+      row("b0", 0, "strong"),
+      row("a1", 1, "weak"),
+      row("b1", 1, "weak"),
+    ];
+    expect(selectSourceIdsForNumbering(rows, 1)).toEqual(new Set(["a0", "a1"]));
+  });
+
+  test("baris tanpa subQuestionIndex (bukti tandingan/untagged) selalu lolos", () => {
+    const rows = [
+      row("s1", 0, "strong"),
+      row("s2", 0, "strong"),
+      row("counter", null, "weak"),
+    ];
+    expect(selectSourceIdsForNumbering(rows, 1)).toEqual(new Set(["s1", "counter"]));
+  });
+
+  test("evidenceStrength tak dikenal diprioritaskan paling akhir", () => {
+    const rows = [row("x", 0, "unknown-value"), row("w", 0, "weak")];
+    expect(selectSourceIdsForNumbering(rows, 1)).toEqual(new Set(["w"]));
+  });
+
+  test("cap menghitung PAPER unik: baris duplikat (kunci dedupe sama) tak memakan slot", () => {
+    // Paper sama via arXiv + publisher (locator beda, DOI ternormalisasi sama) berbagi satu [n]
+    // di penomoran — baris duplikatnya ikut terpilih TANPA menggusur paper unik lain dari cap.
+    const rows = [
+      row("dupA", 0, "strong", "10.1/x"),
+      row("dupB", 0, "strong", "10.1/X"), // normalizeDoi lowercase → kunci sama dgn dupA
+      row("unik", 0, "medium"),
+    ];
+    expect(selectSourceIdsForNumbering(rows, 2)).toEqual(new Set(["dupA", "dupB", "unik"]));
+  });
+});
+
+describe("filterCitableReferenceSources", () => {
+  const item = (turnId: string | null, citationNumber: number | null) => ({
+    turnId,
+    citationNumber,
+  });
+
+  test("baris null pada turn BERNOMOR (tersisih cap) dikeluarkan", () => {
+    const items = [item("deep-run", 1), item("deep-run", null), item("deep-run", 2)];
+    expect(filterCitableReferenceSources(items)).toEqual([item("deep-run", 1), item("deep-run", 2)]);
+  });
+
+  test("sumber chat biasa (turn tanpa penomoran sama sekali) tetap lolos", () => {
+    const items = [item("chat-turn", null), item("deep-run", 1), item("deep-run", null)];
+    expect(filterCitableReferenceSources(items)).toEqual([item("chat-turn", null), item("deep-run", 1)]);
+  });
+
+  test("tanpa turn bernomor → semua lolos (perilaku lama utuh)", () => {
+    const items = [item("a", null), item(null, null)];
+    expect(filterCitableReferenceSources(items)).toEqual(items);
+  });
+});


### PR DESCRIPTION
Menindaklanjuti dua audit 2026-07-08 (`docs/audit-deep-stuck-stop-2026-07-08.md`): `/deep` "nyangkut" + Stop no-op, dan freeze navigasi antar-segmen.

## Perubahan

**`/deep` Stop & macet (ISSUE-1/2/4)**
- Teruskan `abortSignal` (executor `options.abortSignal`, di-abort saat `manager.cancel()`/timeout task) ke `agent.generate` — generasi LLM in-flight benar-benar berhenti, bukan sekadar tandai record `cancelled` lalu buang hasil (kredit `search_*` tak terlanjur habis).
- Stop fase RUNNING (handle client-js null pasca-refresh) kini bikin run lazily lalu `cancel()`; guard poll `getDeepRunId !== rid` berhenti re-seed progres (tombol Stop tak lagi terasa "rusak").
- Guard KEPEMILIKAN: terminal basi run lama tak meng-klobber kunci/handle run pengganti.
- Ambang macet per-fase — fase generate-berat (search/counter/analyze/synthesize) sah diam sampai 9 mnt + copy menenangkan; fase ringan beku = copy generik. `deepStalled: boolean → string | null` (identity string → poll bail-out `Object.is`, tak re-render seluruh surface).
- Fallback in-memory saat `localStorage.setItem` gagal — set senyap gagal tak lagi mematikan poll run yang hidup.
- `proSearchProviderOptions` (`AQSHA_PRO_SEARCH_REASONING_EFFORT`, default medium): `literature-searcher` tetap model Pro tapi effort diturunkan (fase fan-out terbanyak-panggilan).

**`/deep` kurasi sumber (ISSUE-5)**
- Tool search mem-persist SEMUA hasilnya (run nyata 257 baris utk 6 sub-Q → prompt sintesis ~400KB → run macet melewati timeout). `selectSourceIdsForNumbering`: per sub-Q ambil ≤20 paper unik terkuat; baris tersisih `citation_number = NULL` (overwrite, tetap tersimpan di DB).
- Snippet inventory adaptif (budget dibagi rata, lantai 80 char, fallback greedy backstop).
- `ANALYZE_UNIT_CAP` 60 → 100; `EVIDENCE_STRENGTH_PRIORITY`/`evidenceStrengthRank` satu sumber ranking; `dedupeCitableReferenceSources` satu aturan daftar pustaka utk tool + export `.bib/.ris`.

**Freeze navigasi (ISSUE-6)**
- 5 `loading.tsx` boundary di bawah `(product)` layout (`AppLoadingOverlay variant="absolute"`) — prefetch `<Link>` tak lagi di-skip; hapus `force-dynamic` vestigial.

**Lain-lain**
- Checkbox `ask_questions` pakai kotak-centang + role a11y benar.
- Mock embeddings di test di-spread export-complete.

## Test
- Test baru `research-citation-selection.test.ts` (seleksi penomoran + filter citable).
- ⚠️ Pre-commit `react-doctor` melaporkan warning non-blocking di `use-mastra-agent.ts`; commit tetap masuk. Belum ditindaklanjuti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)