### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,30 @@ Local infra (Postgres/Redis/MinIO): `docker compose -f infra/compose.dev.yaml up
 - `apps/web` consumes the API's `App` type for Eden Treaty (no codegen) and `@aqsha/ui`. It must not import `@aqsha/db` / `@aqsha/services`.
 - Business logic lives once in `packages/services`; routes, workers, and the agent are thin callers.
 - Test runners: `packages/db`, `packages/chat-core`, `packages/services`, `apps/api`.
+
+## Cursor Cloud specific instructions
+Standard commands live above and in `CLAUDE.md`; this section only captures non-obvious cloud caveats. The startup script runs `bun install` automatically.
+
+### Toolchain / PATH
+- **Bun 1.3.10** and **Node 24** are made default via `~/.bashrc` (Node 24 is required by `apps/web` + `apps/agent`; it shadows a `/exec-daemon/node` v22 shim that is otherwise first on PATH). New login shells (`bash -l`) pick this up. If a non-login shell resolves the wrong node/bun, prepend `export PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$HOME/.bun/bin:$PATH"`.
+
+### Local infra (Postgres/Redis/MinIO) — start each session
+Not started by the update script. The Docker daemon and infra containers must be (re)started per boot:
+```bash
+sudo dockerd >/tmp/dockerd.log 2>&1 &          # if `docker info` fails
+sudo docker compose -f infra/compose.dev.yaml up -d
+```
+- Docker uses the `fuse-overlayfs` storage driver with `containerd-snapshotter` disabled (see `/etc/docker/daemon.json`) — required for Docker-in-Docker here.
+- `infra/.env` (local dev creds; gitignored-by-intent but not in `.gitignore`, so never commit it) is already present. Postgres `5432`, Redis `6379`, MinIO S3 `9000` / console `9001`; the `aqsha` bucket is auto-created by `minio-init`.
+
+### Env files & missing secrets
+- Per-app `.env` (`apps/api/.env`, `apps/agent/.env`, `apps/web/.env.local`, `packages/db/.env`) already exist, point at `localhost` infra, and use **placeholder** Clerk/OpenAI keys so every process boots (boot validators only check presence, not validity).
+- **Real secrets are required for the full product**: `CLERK_SECRET_KEY` + a real `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (a placeholder key makes the browser Clerk handshake fail with `host_invalid`, even though the landing page still server-renders via `curl`), and `OPENAI_API_KEY` / `AQSHA_EMBEDDING_API_KEY` for Astra chat, `/deep`, and RAG artifact indexing.
+- Run `bun run db:migrate` before first boot (idempotent).
+
+### Run & ports
+- `bun dev` runs api (`:3001`), worker (no port), agent/Mastra (`:4111`), web (`:3000`) together (it builds `dist` first). Web proxies `/mastra-api/*` → agent.
+
+### Test caveats (`bun run test`)
+- **`@aqsha/services`**: 3 tests fail only in the full parallel run due to Bun `mock.module` leaking across files (e.g. `CHAT_QUEUES`/`ACCOUNT_QUEUES` "not found"); they pass when the file is run in isolation. Pre-existing, not an env issue.
+- **`apps/api`**: the artifact upload-pipeline test asserts `indexingStatus === "ready"`, which needs a real embedding key; with a placeholder it becomes `"failed"`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the full Aqsha dev environment on the Cloud Agent VM and documents non-obvious startup caveats. The only code/repo change is an appended `## Cursor Cloud specific instructions` section in `AGENTS.md`; no application code was modified.

## What was set up
- Toolchain: **Bun 1.3.10** + **Node 24** (default via `~/.bashrc`, shadowing a Node 22 shim), **Docker 29** (fuse-overlayfs + `containerd-snapshotter` disabled for Docker-in-Docker).
- `bun install` + `bun run build:dist`.
- Local infra via `infra/compose.dev.yaml`: Postgres (pgvector, `:5432`), Redis (`:6379`), MinIO (`:9000/:9001`, bucket auto-created).
- Per-app `.env` files pointing at localhost (placeholder Clerk/OpenAI keys so all processes boot).
- `bun run db:migrate`, then `bun dev` (api `:3001`, worker, agent/Mastra `:4111`, web `:3000`).

## Verification
- `/healthz` → `{ok, db, redis}` and `/health/ready` → `{ok, db, redis, storage}` all `true` (Postgres + Redis + MinIO round-trip).
- Core end-to-end write ("hello world"): a signed Clerk `user.created` webhook → HTTP 200 → new row in Postgres `users` (route → svix verify → Redis idempotency → `UserService` upsert → DB).
- `bun run lint` (0 errors), `bun run typecheck` (all 7 workspaces pass).
- `bun run test`: 360 pass; 3 `@aqsha/services` failures are a pre-existing Bun mock-isolation ordering issue (pass in isolation), 1 `apps/api` failure needs a real embedding key.

## Follow-up needed for full product
Real `CLERK_*` and `OPENAI_API_KEY` / `AQSHA_EMBEDDING_API_KEY` secrets are required for the browser frontend (Clerk handshake) and Astra AI chat / RAG indexing.

[aqsha_env_verification.log](https://cursor.com/agents/bc-10f3f65f-b412-4256-8aad-bfac501f728f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faqsha_env_verification.log)

Please merge the AGENTS.md updates so future agents remember these cloud setup caveats.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10f3f65f-b412-4256-8aad-bfac501f728f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10f3f65f-b412-4256-8aad-bfac501f728f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

