### PR TITLE
fix(web): prebuild content-collections (unblock deploy build)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "content-collections build && next build",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "content-collections build && tsc --noEmit",


### PR DESCRIPTION
Hotfix for the failed production deploy from PR #64.

## What failed
The `deploy.yml` build job failed building the **web** image: Turbopack could not resolve `content-collections` in `posts.ts` / `entries.ts`. Under Next 16 + Turbopack, the `withContentCollections` plugin runs a **watcher** during `next build` ("start watching"), racing module resolution — the `./.content-collections/generated` alias target isn't written when Turbopack looks for it. `ci.yml` only runs typecheck/lint/test, so a full `next build` never exercised this.

## Fix
`apps/web/package.json`: `"build": "content-collections build && next build"` — generate content **before** the framework build, as the content-collections docs require. One line.

## Verified
Local `next build` against a **clean** `.content-collections/generated`:
- prebuild generates the dir first (no "start watching")
- ✓ Compiled successfully, ✓ 32/32 static pages, exit 0 — no "Can't resolve".

## Note
Prod is unchanged — the failed build meant no images were pushed and the deploy step was skipped (no outage, Infisical cutover not yet applied). Merging this re-runs the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web application build process to generate content before compiling the application.
  * Improved build reliability by ensuring content is available during production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->