### PR TITLE
fix(web): CI image build — standalone output hilang + sentry-cli TLS …

### DIFF
--- a/.github/actions/infisical-import/action.yml
+++ b/.github/actions/infisical-import/action.yml
@@ -1,0 +1,56 @@
+name: Import Infisical secrets
+description: >
+  Import secrets from Infisical (secrets.aqshara.com, env `prod`) into job env vars, with one
+  delayed retry. The upstream action has no built-in retry and the Infisical server lives on the
+  prod VPS, so a transient network blip (seen: `connect ETIMEDOUT`) would otherwise fail the job.
+  Composite actions can't read the `secrets`/`vars` contexts, so the caller passes them as inputs.
+
+inputs:
+  client-id:
+    description: Infisical machine-identity client id
+    required: true
+  client-secret:
+    description: Infisical machine-identity client secret
+    required: true
+  project-slug:
+    description: Infisical project slug
+    required: true
+  secret-path:
+    description: Infisical folder to import (e.g. /build, /deploy)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Pinned to an immutable commit SHA (see ci.yml). Trailing comment = version.
+    - name: Import secrets
+      id: attempt
+      continue-on-error: true
+      uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+      with:
+        method: universal
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+        domain: https://secrets.aqshara.com
+        project-slug: ${{ inputs.project-slug }}
+        env-slug: prod
+        secret-path: ${{ inputs.secret-path }}
+
+    # Brief pause so the retry doesn't land on the same transient blip; a fast failure (DNS,
+    # connection refused) would otherwise retry near-instantly.
+    - name: Wait before retry
+      if: steps.attempt.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Import secrets (retry)
+      if: steps.attempt.outcome == 'failure'
+      uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+      with:
+        method: universal
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+        domain: https://secrets.aqshara.com
+        project-slug: ${{ inputs.project-slug }}
+        env-slug: prod
+        secret-path: ${{ inputs.secret-path }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,23 @@ jobs:
       # Infisical /build and inject them as env vars (masked in logs) for the build step below. Only
       # the web image consumes them; api/agent ignore the extra build-args, so one step covers the
       # whole matrix. Bootstrap = the `gh-actions` machine identity (GH Secrets). env-slug `prod`.
+      # The action has no built-in retry and secrets.aqshara.com lives on the prod VPS, so a transient
+      # network blip (seen: `connect ETIMEDOUT`) would fail the whole build — hence the manual retry.
       - name: Import build secrets from Infisical
+        id: infisical_build
+        continue-on-error: true
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: universal
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          domain: https://secrets.aqshara.com
+          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          secret-path: /build
+
+      - name: Import build secrets from Infisical (retry)
+        if: steps.infisical_build.outcome == 'failure'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: universal
@@ -110,7 +126,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Pull the Dokploy API creds from Infisical /deploy (masked in logs), injected as env vars.
+      # Same transient-timeout retry rationale as the build job's Infisical step.
       - name: Import deploy secrets from Infisical
+        id: infisical_deploy
+        continue-on-error: true
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: universal
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          domain: https://secrets.aqshara.com
+          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          secret-path: /deploy
+
+      - name: Import deploy secrets from Infisical (retry)
+        if: steps.infisical_deploy.outcome == 'failure'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: universal

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,31 +57,13 @@ jobs:
       # Infisical /build and inject them as env vars (masked in logs) for the build step below. Only
       # the web image consumes them; api/agent ignore the extra build-args, so one step covers the
       # whole matrix. Bootstrap = the `gh-actions` machine identity (GH Secrets). env-slug `prod`.
-      # The action has no built-in retry and secrets.aqshara.com lives on the prod VPS, so a transient
-      # network blip (seen: `connect ETIMEDOUT`) would fail the whole build — hence the manual retry.
+      # The composite action wraps the import with a delayed retry against transient VPS blips.
       - name: Import build secrets from Infisical
-        id: infisical_build
-        continue-on-error: true
-        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        uses: ./.github/actions/infisical-import
         with:
-          method: universal
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-          domain: https://secrets.aqshara.com
           project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
-          env-slug: prod
-          secret-path: /build
-
-      - name: Import build secrets from Infisical (retry)
-        if: steps.infisical_build.outcome == 'failure'
-        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
-        with:
-          method: universal
-          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
-          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-          domain: https://secrets.aqshara.com
-          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
-          env-slug: prod
           secret-path: /build
 
       - name: Image tags + labels
@@ -125,31 +107,19 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      # Pull the Dokploy API creds from Infisical /deploy (masked in logs), injected as env vars.
-      # Same transient-timeout retry rationale as the build job's Infisical step.
-      - name: Import deploy secrets from Infisical
-        id: infisical_deploy
-        continue-on-error: true
-        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+      # Checkout is only needed to make the local composite action available.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          method: universal
-          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
-          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-          domain: https://secrets.aqshara.com
-          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
-          env-slug: prod
-          secret-path: /deploy
+          persist-credentials: false # don't retain the GITHUB_TOKEN in .git/config after checkout
 
-      - name: Import deploy secrets from Infisical (retry)
-        if: steps.infisical_deploy.outcome == 'failure'
-        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+      # Pull the Dokploy API creds from Infisical /deploy (masked in logs), injected as env vars.
+      # The composite action wraps the import with a delayed retry against transient VPS blips.
+      - name: Import deploy secrets from Infisical
+        uses: ./.github/actions/infisical-import
         with:
-          method: universal
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-          domain: https://secrets.aqshara.com
           project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
-          env-slug: prod
           secret-path: /deploy
 
       # compose.yaml references :latest (IMAGE_TAG default), which build just repushed → Dokploy pulls

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -4,6 +4,12 @@
 FROM oven/bun:1.3.10 AS build
 WORKDIR /app
 
+# oven/bun ships with an EMPTY system trust store (/etc/ssl/certs) — Bun itself bundles its own CA
+# list so `bun install` works, but sentry-cli (native binary, system trust store) fails every TLS
+# call with curl error 60. Install ca-certificates so the Sentry release + source-map upload works.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ARG NEXT_PUBLIC_SITE_URL=https://aqshara.com

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,11 +13,6 @@ const nextConfig: NextConfig = {
   },
 };
 
-// withContentCollections menjalankan generate saat `next dev`/`next build`
-// (lapisan Next config, bukan webpack plugin → aman dgn Turbopack). Cast krn
-// return type-nya belum persis NextConfig di Next 16.
-const withCC = withContentCollections(nextConfig) as NextConfig;
-
 // Sentry build plugin: only wrap when Sentry is actually configured (client DSN or an upload token
 // present at build). Otherwise the build path is untouched — no plugin, no behaviour change — so the
 // default (Sentry-less) build stays exactly as before until the owner opts in via the CI build vars.
@@ -35,19 +30,27 @@ const sourcemapUploadEnabled = Boolean(
     process.env.SENTRY_PROJECT_WEB,
 );
 
-export default sentryConfigured
-  ? withSentryConfig(withCC, {
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT_WEB,
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      release: { name: process.env.SENTRY_RELEASE },
-      sourcemaps: { disable: !sourcemapUploadEnabled },
-      // Route browser → Sentry ingest through a same-origin Next route so ad/tracker blockers don't
-      // silently drop client error events. `/sentry-tunnel` is allow-listed in proxy.ts.
-      tunnelRoute: "/sentry-tunnel",
-      // Quiet locally, verbose in CI (CI=true is forwarded as a build arg in deploy.yml so it reaches
-      // this build). Lets the source-map upload output show up in the CI build log.
-      silent: !process.env.CI,
-      disableLogger: true,
-    })
-  : withCC;
+// withContentCollections menjalankan generate saat `next dev`/`next build` (lapisan Next config,
+// bukan webpack plugin → aman dgn Turbopack). Return-nya Promise<Partial<NextConfig>>, jadi WAJIB
+// di-await sebelum masuk withSentryConfig: withSentryConfig men-spread object config yang diterima,
+// dan spread atas Promise yang belum resolve = {} → seluruh config user (termasuk
+// `output: "standalone"` yang dibutuhkan image Docker) hilang diam-diam. Next sendiri men-support
+// default export berupa async function, jadi resolve di sini.
+export default async function buildConfig(): Promise<NextConfig> {
+  const withCC = (await withContentCollections(nextConfig)) as NextConfig;
+  if (!sentryConfigured) return withCC;
+  return withSentryConfig(withCC, {
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT_WEB,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    release: { name: process.env.SENTRY_RELEASE },
+    sourcemaps: { disable: !sourcemapUploadEnabled },
+    // Route browser → Sentry ingest through a same-origin Next route so ad/tracker blockers don't
+    // silently drop client error events. `/sentry-tunnel` is allow-listed in proxy.ts.
+    tunnelRoute: "/sentry-tunnel",
+    // Quiet locally, verbose in CI (CI=true is forwarded as a build arg in deploy.yml so it reaches
+    // this build). Lets the source-map upload output show up in the CI build log.
+    silent: !process.env.CI,
+    disableLogger: true,
+  });
+}


### PR DESCRIPTION
…+ retry Infisical

Deploy run pertama dari main gagal di job build web & api (actions/runs/29192245319). Tiga akar masalah:

1. next.config.ts: withContentCollections() mengembalikan Promise<NextConfig> yang di-cast paksa lalu diteruskan ke withSentryConfig, yang men-spread object config — spread atas Promise = {} sehingga seluruh config user (termasuk output: "standalone") hilang. Hanya terjadi saat Sentry aktif, yaitu di CI → COPY .next/standalone di stage runtime gagal "not found". Fix: default export jadi async function yang meng-await withContentCollections sebelum masuk withSentryConfig.

2. apps/web/Dockerfile: oven/bun:1.3.10 ber-trust-store kosong (/etc/ssl/certs), sentry-cli (binary native) gagal semua request TLS dengan curl error 60. Fix: install ca-certificates di build stage.

3. deploy.yml: job api mati karena Infisical/secrets-action timeout transient (connect ETIMEDOUT ke secrets.aqshara.com) — dua job lain sukses di waktu yang sama. Fix: step retry manual (continue-on-error
   + attempt kedua ber-guard outcome) untuk step Infisical di job build dan deploy.

Verifikasi: next build lokal dengan env Sentry ala CI menghasilkan .next/standalone/apps/web/server.js; resolve config dengan TURBOPACK=1 menunjukkan output standalone + hook compiler.runAfterProductionCompile terpasang; apt install ca-certificates di oven/bun mengisi bundle CA di path standar sentry-cli.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment reliability by retrying secret retrieval when the first attempt fails.
  - Resolved production build issues related to missing TLS certificate trust during image builds.
  - Ensured standalone build settings and error-monitoring configuration are preserved during Next.js builds.

- **Chores**
  - Updated build/deploy automation to use a local secrets-import step for more consistent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->