### PR TITLE
fix(infra): pin Infisical CLI 0.43.98 — CLI baru pakai API v4 yang ta…

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -30,11 +30,14 @@ ENV PORT=4317
 ENV HOST=0.0.0.0
 # Infisical CLI: the entrypoint `infisical run`s the app so runtime secrets come from Infisical /app.
 # Above the commit-changing ENV below so it stays cached. Debian base → official apt repo.
+# PINNED to 0.43.98 — the LAST CLI that fetches secrets via API v3; 0.43.99+ calls /api/v4/secrets,
+# which our self-hosted Infisical server doesn't serve (route 404 → every container crash-loops).
+# Bump only together with (or after) a server upgrade that adds the v4 routes.
 # pipefail: a failed setup-script download (curl -f) fails the build instead of being masked by bash.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
  && curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
- && apt-get install -y --no-install-recommends infisical \
+ && apt-get install -y --no-install-recommends infisical=0.43.98 \
  && rm -rf /var/lib/apt/lists/*
 # Release tag (commit SHA) baked in → Sentry `release` + Langfuse `GIT_COMMIT` (both read at runtime).
 ARG GIT_COMMIT=unknown

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,11 +7,14 @@ ENV NODE_ENV=production
 
 # Infisical CLI: baked in so the entrypoint can `infisical run` (inject /app secrets at start). Placed
 # above the dependency install so it caches across source/package edits. Debian base → official apt repo.
+# PINNED to 0.43.98 — the LAST CLI that fetches secrets via API v3; 0.43.99+ calls /api/v4/secrets,
+# which our self-hosted Infisical server doesn't serve (route 404 → every container crash-loops).
+# Bump only together with (or after) a server upgrade that adds the v4 routes.
 # pipefail: a failed setup-script download (curl -f) fails the build instead of being masked by bash.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
  && curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
- && apt-get install -y --no-install-recommends infisical \
+ && apt-get install -y --no-install-recommends infisical=0.43.98 \
  && rm -rf /var/lib/apt/lists/*
 
 # Manifests + lockfile FIRST so the (slow) `bun install` layer is cached until a package.json or

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -67,11 +67,14 @@ WORKDIR /app
 ENV NODE_ENV=production PORT=3000 HOSTNAME=0.0.0.0 NEXT_TELEMETRY_DISABLED=1
 # Infisical CLI: the entrypoint `infisical run`s the server so runtime secrets (CLERK_SECRET_KEY,
 # SENTRY_DSN_WEB, …) come from Infisical /app. NEXT_PUBLIC_* stay baked at build. Debian → apt repo.
+# PINNED to 0.43.98 — the LAST CLI that fetches secrets via API v3; 0.43.99+ calls /api/v4/secrets,
+# which our self-hosted Infisical server doesn't serve (route 404 → every container crash-loops).
+# Bump only together with (or after) a server upgrade that adds the v4 routes.
 # pipefail: a failed setup-script download (curl -f) fails the build instead of being masked by bash.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
  && curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
- && apt-get install -y --no-install-recommends infisical \
+ && apt-get install -y --no-install-recommends infisical=0.43.98 \
  && rm -rf /var/lib/apt/lists/*
 # Server-side release tag (must match the baked client release). SENTRY_DSN_WEB comes from Infisical.
 ARG GIT_COMMIT=unknown


### PR DESCRIPTION
…k ada di server

Semua container crash-loop pasca deploy: `infisical run` gagal dengan "Route GET:/api/v4/secrets ... not found" (404 pada ROUTE, bukan secret kosong). Image mem-bake CLI terbaru dari apt saat build; CLI 0.43.99+ (commit 327d3363, 2026-06-26) memindahkan fetch secrets ke /api/v4, sementara server Infisical self-hosted kita baru melayani /api/v3 (probe: /api/v3/secrets/raw → 401, /api/v4/secrets → 404).

Pin infisical=0.43.98 (versi terakhir ber-API v3) di ketiga Dockerfile. Terverifikasi E2E: container node:24-slim + CLI 0.43.98 login universal-auth ke secrets.aqshara.com dan `infisical run --path=/app` menginjeksi 40 secrets prod. Naikkan pin hanya bersamaan/berurutan dengan upgrade server yang menyediakan route v4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of container builds by enforcing stricter error handling during CLI setup.
  * Standardized the Infisical CLI version across application images to prevent compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->