### PR TITLE
fix(infra): pull_policy always — deploy Dokploy tak pernah re-pull :latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,10 +55,12 @@ jobs:
 
       # Pull the web build-time secrets (NEXT_PUBLIC_* + Sentry org/project/DSN/auth-token) from
       # Infisical /build and inject them as env vars (masked in logs) for the build step below. Only
-      # the web image consumes them; api/agent ignore the extra build-args, so one step covers the
-      # whole matrix. Bootstrap = the `gh-actions` machine identity (GH Secrets). env-slug `prod`.
-      # The composite action wraps the import with a delayed retry against transient VPS blips.
+      # the web image consumes them, so ONLY the web matrix job runs the import — api/agent ignore
+      # the extra (then-empty) build-args, and skipping keeps a GH-runner→VPS connectivity blip from
+      # failing builds that never needed the secrets. Bootstrap = the `gh-actions` machine identity
+      # (GH Secrets). env-slug `prod`. The composite action wraps the import with a delayed retry.
       - name: Import build secrets from Infisical
+        if: matrix.name == 'web'
         uses: ./.github/actions/infisical-import
         with:
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,6 +38,9 @@ services:
   web:
     # Built in CI (NEXT_PUBLIC_* baked at build from Infisical /build). Local build: compose.build.yaml.
     image: ghcr.io/manikandareas/aqsha-web:${IMAGE_TAG:-latest}
+    # Dokploy deploys with `docker compose up -d` (no `pull`); a mutable tag like `latest` would
+    # otherwise keep running the stale local image forever. Applies to every GHCR app image below.
+    pull_policy: always
     restart: unless-stopped
     environment:
       <<: *infisical-bootstrap
@@ -51,6 +54,7 @@ services:
   api:
     # Built in CI, pushed to GHCR; the worker service reuses this exact image (same ref below).
     image: ghcr.io/manikandareas/aqsha-api:${IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     environment: &app-env
       <<: *infisical-bootstrap
@@ -70,6 +74,7 @@ services:
   # Sentry tags worker errors distinctly within the shared api project).
   worker:
     image: ghcr.io/manikandareas/aqsha-api:${IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     command: ["bun", "run", "start:worker"]
     environment:
@@ -83,6 +88,7 @@ services:
   agent:
     # Built in CI (mastra build), pushed to GHCR. Local build: compose.build.yaml.
     image: ghcr.io/manikandareas/aqsha-agent:${IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     environment:
       # PORT/HOST/NODE_ENV are baked in the image. Everything else — CLERK_PUBLISHABLE_KEY (Mastra
@@ -105,6 +111,7 @@ services:
   # so several app containers starting at once can't race the same migration.
   migrate:
     image: ghcr.io/manikandareas/aqsha-api:${IMAGE_TAG:-latest}
+    pull_policy: always
     profiles: ["migrate"]
     command: ["bun", "run", "db:migrate"]
     environment:


### PR DESCRIPTION
## Masalah
Semua container app di Dokploy crash-loop dengan:
```
error: failed to fetch secrets for path "/app": ... [GET https://secrets.aqshara.com/api/v4/secrets ...] [status-code=404]
```

## Akar masalah (dua lapis)
1. **CLI Infisical ≥ 0.43.99 pindah ke API v4** (`GET /api/v4/secrets`), sedangkan server self-hosted belum punya route v4 (v4 baru ada di server ≥ v0.150.0). Sudah di-fix dengan pin `infisical=0.43.98` (4cbbdfc, merged di #67) — image `:latest` di GHCR sudah benar (diverifikasi: berisi `infisical version 0.43.98`).
2. **Fix-nya tak pernah sampai ke container**: deploy Dokploy menjalankan `docker compose up -d --build --remove-orphans` **tanpa `docker compose pull`**. Tag `:latest` tidak berubah → Docker terus memakai image lokal basi → deploy #67 selesai 4–6 detik tanpa pull dan container lama tetap crash-loop.

## Fix
`pull_policy: always` pada kelima service ber-image GHCR (web/api/worker/agent/migrate) — compose selalu re-pull image saat `up`, berapa pun umur cache lokal.

## Follow-up (tidak di PR ini)
- Upgrade server Infisical self-hosted ke ≥ v0.150.0 (latest v0.162.x) supaya API v4 tersedia dan pin CLI bisa dilepas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by ensuring the latest container images are pulled during deployment and restarts.
  * Prevented unnecessary build-secret imports for services that do not require them, reducing deployment connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->